### PR TITLE
フロントエンドのアプリケーションのビルドをチェックする CI を追加

### DIFF
--- a/.github/workflows/client-admin-build.yml
+++ b/.github/workflows/client-admin-build.yml
@@ -1,0 +1,37 @@
+name: client-admin build
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'client-admin/**'
+      - '!client-admin/**/*.md'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'client-admin/**'
+      - '!client-admin/**/*.md'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./client-admin
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+          cache-dependency-path: './client-admin/package-lock.json'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run build
+        run: npm run build

--- a/.github/workflows/client-admin-build.yml
+++ b/.github/workflows/client-admin-build.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: './client-admin/package-lock.json'
 

--- a/.github/workflows/client-build.yml
+++ b/.github/workflows/client-build.yml
@@ -1,0 +1,37 @@
+name: client build
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'client/**'
+      - '!client/**/*.md'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'client/**'
+      - '!client/**/*.md'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./client
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+          cache-dependency-path: './client/package-lock.json'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run build
+        run: npm run build

--- a/.github/workflows/client-build.yml
+++ b/.github/workflows/client-build.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: './client/package-lock.json'
 


### PR DESCRIPTION
# 変更の概要
- フロントエンドのアプリケーション（client, client-admin）のビルドをチェックする CI を追加しました
  - client, client-admin の各ディレクトリのファイルを変更したら、それぞれのビルドが CI で実行されます

# 変更の背景
- fix: #73 

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/takahiroanno2024/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました