### PR TITLE
client の CI のエラーを修正

### DIFF
--- a/.github/workflows/client-build.yml
+++ b/.github/workflows/client-build.yml
@@ -35,3 +35,6 @@ jobs:
 
       - name: Run build
         run: npm run build
+        env:
+          NEXT_PUBLIC_API_BASEPATH: 'http://localhost:8000'
+          NEXT_PUBLIC_PUBLIC_API_KEY: 'xxxxxxxxxx'


### PR DESCRIPTION
# 変更の概要
- https://github.com/digitaldemocracy2030/kouchou-ai/pull/81 で導入した client のビルドの CI がエラーでこけていたので修正しました 🙏 
  - ref: https://github.com/digitaldemocracy2030/kouchou-ai/actions/runs/13916399265

# 変更の背景
- 原因: ビルド時に参照する環境変数が足りていませんでした
  - [client/.env-sample ](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/client/.env-sample)を元に環境変数の設定を追加しました
- 自分のリポジトリで GitHub Actions を起動して、ビルドが通ることを確認しました
  - https://github.com/shgtkshruch/kouchou-ai/actions/runs/13917048914
- client-admin は環境変数がなくてもビルドが通るので、一旦そのままにしています
  - https://github.com/shgtkshruch/kouchou-ai/actions/runs/13917035834/job/38941839876

# 関連Issue
特になし

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました