### PR TITLE
Docker 環境でサンプルファイルの DL が 404 になる不具合を修正

### DIFF
--- a/client-admin/Dockerfile
+++ b/client-admin/Dockerfile
@@ -39,6 +39,7 @@ COPY --from=builder /app/tsconfig.json ./tsconfig.json
 COPY --from=builder /app/type.d.ts ./type.d.ts
 COPY --from=builder /app/.next ./.next
 COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/public ./public
 
 EXPOSE 4000
 CMD ["npm", "start"]


### PR DESCRIPTION
# 変更の概要
- https://github.com/digitaldemocracy2030/kouchou-ai/pull/74 で追加したサンプルファイルが Docker 環境だとダウンロードできない不具合を修正しました

# 変更の背景
- client-admin の Dockerfile 内で、サンプルファイルが格納されている public ディレクトリが COPY されていなかった

# 関連Issue
Slack での報告スレッド: https://w1740803485-clv347541.slack.com/archives/C08F7JZPD63/p1742284927003429

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました