### PR TITLE
GitHub Actionsでself-assignを可能にする

### DIFF
--- a/.github/workflows/assign-bot.yml
+++ b/.github/workflows/assign-bot.yml
@@ -1,0 +1,41 @@
+name: Auto Assign and Unassign on /assign or /unassign
+
+permissions:
+  issues: write
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  manage-assignment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Process assignment comment only if command is used
+        if: startsWith(github.event.comment.body, '/assign') || startsWith(github.event.comment.body, '/unassign')
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const commentBody = context.payload.comment.body.trim();
+            const issueNumber = context.payload.issue.number;
+            const username = context.payload.comment.user.login;
+
+            if (commentBody === '/assign') {
+              await github.rest.issues.addAssignees({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                assignees: [username]
+              });
+              console.log(`Assigned ${username} to issue #${issueNumber}`);
+            } else if (commentBody === '/unassign') {
+              await github.rest.issues.removeAssignees({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                assignees: [username]
+              });
+              console.log(`Unassigned ${username} from issue #${issueNumber}`);
+            } else {
+              console.log("Comment does not exactly match '/assign' or '/unassign'");
+            }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,8 +10,11 @@
     - 同意する手順は、Pull Requestのテンプレートに記載があります
 
 # Issue/Pull Requestについて
-- 重複して同じIssueに取り組むのを避けるため、Issueに着手される際はasigneeとしてご自身のアカウントを指定してください
+- 重複して同じIssueに取り組むのを避けるため、Issueに着手される際はご自身のアカウントをasigneeに指定してください
+  - イシュー上で、 `/assign` というコメントを記載していただくと、Issueのasigneeとして登録されます
+    - 権限の関係で、一部のコントリビューターを除いてアサインの割当ができないためこのような運用にしています
+  - 割当を解除したい場合は、 `/unassign` というコメントを記載していただくと、Issueのasigneeから外れます
 - Issueはどなたでも起票いただいて構いません。ツールの利用時に感じた改善点やバグについてぜひIssueを起票してください。
 - 初めてのIssueとしてキャッチアップしやすいタスクについては、[good first issueラベル](https://github.com/digitaldemocracy2030/kouchou-ai/labels/good%20first%20issue)がついています。コミットに興味がある方は、ぜひそちらのIssueを御覧ください！
-- 現時点でのコードオーナーは@nasukaと@nanocloudxの2人で、どちらかがapproveした場合にmainへのマージを行います
+- 現時点でのコードオーナーは[@nasuka](https://github.com/nasuka)と[@nanocloudx](https://github.com/nanocloudx)の2人で、どちらかがapproveした場合にmainへのマージを行います
   - コードオーナーは将来的に増やしていきたいと考えていますが、当面はこの体制で運用していく予定です（2025/03/18時点）


### PR DESCRIPTION
# 変更の概要
- Issue上で、`/assign` というコメントをすると自身をasigneeにするworkflowを実装
- 同様に `/unassign` を実装
- どちらのコマンドも、別repoで動作について確認済み
  - （本来アサイン権限のない）repo owner以外のアカウントでコメントし、assign/unassignどちらも動作した

# 変更の背景
- ユーザーの権限によってIssueのアサインをできないケースがあるため、github actionsで同等の操作を実現した

# 関連Issue
https://github.com/digitaldemocracy2030/kouchou-ai/issues/95

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました