### PR TITLE
レポート画面に一覧へ戻るボタンを追加

### DIFF
--- a/client/app/[slug]/page.tsx
+++ b/client/app/[slug]/page.tsx
@@ -4,6 +4,7 @@ import {Header} from '@/components/Header'
 import {Overview} from '@/components/report/Overview'
 import {Footer} from '@/components/Footer'
 import {ClusterOverview} from '@/components/report/ClusterOverview'
+import {BackButton} from '@/components/report/BackButton'
 import {About} from '@/components/About'
 import {Separator} from '@chakra-ui/react'
 import {Metadata} from 'next'
@@ -89,6 +90,7 @@ export default async function Page({params}: PageProps) {
               <ClusterOverview key={c.id} cluster={c}/>
             ))}
           </ClientContainer>
+          <BackButton/>
           <Separator my={12} maxW={'750px'} mx={'auto'}/>
           <About meta={meta}/>
         </div>

--- a/client/components/report/BackButton.tsx
+++ b/client/components/report/BackButton.tsx
@@ -1,0 +1,17 @@
+import Link from 'next/link'
+
+import {Box, Button} from '@chakra-ui/react'
+import {ChevronLeft} from 'lucide-react'
+
+export function BackButton() {
+  return (
+    <Box w={'fit-content'} mx={'auto'}>
+      <Link href={'/'}>
+        <Button variant={'outline'} size={'md'}>
+          <ChevronLeft/>
+          一覧へ戻る
+        </Button>
+      </Link>
+    </Box>
+  )
+}


### PR DESCRIPTION
# 変更の概要
- レポート画面に一覧に戻るボタンを追加しました
- `/components/report` 以下に戻るボタンのコンポーネントを追加しました

![image](https://github.com/user-attachments/assets/0104ff6b-ba60-40f6-b29c-931d6c617115)

# 変更の背景
- 戻るボタンを表示する場所はページの内容を見てからが良さそう？と思ったので、ページの下部で共通コンポーネントの上部に配置しました
- 前の画面に戻るというよりも、一覧ページに戻る意味合いが強いかなと思ったので、固定でパスを指定しています
- 既存の実装を参考に実装してみたのですが、流儀がわかっていないので何かあればコメントお願いします 🙏 

# 関連Issue
- fix: https://github.com/digitaldemocracy2030/kouchou-ai/issues/57

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました