### PR TITLE
docker上でapiのlintを実行

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ dummy-server:
 # Docker環境でのlint/check, format
 lint/api-check:
 	docker compose run --rm api python -m ruff check .
+	docker compose run --rm api python -m ruff format . --check
 
 lint/api-format:
-	docker compose run --rm api python -m ruff check --fix .
+	docker compose run --rm api python -m ruff format .

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build up down client-setup client-dev client-dev-server client-admin-dev-server dummy-server
+.PHONY: build up down client-setup client-dev client-dev-server client-admin-dev-server dummy-server lint/server-check lint/server-format
 
 build:
 	docker compose build
@@ -24,3 +24,10 @@ client-admin-dev-server:
 
 dummy-server:
 	cd utils/dummy-server && npm run dev
+
+# Docker環境でのlint/check, format
+lint/api-check:
+	docker compose run --rm api python -m ruff check .
+
+lint/api-format:
+	docker compose run --rm api python -m ruff check --fix .

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -12,7 +12,15 @@ RUN apt-get update \
 RUN pip install uv
 
 COPY pyproject.toml requirements.lock requirements-dev.lock README.md ./
-RUN uv pip install --no-cache --system -r requirements.lock
+
+RUN if [ "$ENVIRONMENT" = "development" ]; then \
+        echo "Installing development dependencies from requirements-dev.lock" && \
+        uv pip install --no-cache --system -r requirements-dev.lock; \
+    else \
+        echo "Installing production dependencies from requirements.lock" && \
+        uv pip install --no-cache --system -r requirements.lock; \
+    fi
+
 
 COPY . .
 # アプリケーションの実行

--- a/server/broadlistening/pipeline/services/llm.py
+++ b/server/broadlistening/pipeline/services/llm.py
@@ -2,10 +2,10 @@ import os
 
 import openai
 from dotenv import load_dotenv
-from openai import AzureOpenAI
 
 # FIXME: Issue #58
 from langchain.embeddings import OpenAIEmbeddings
+from openai import AzureOpenAI
 
 # from langchain_openai import AzureOpenAIEmbeddings
 

--- a/server/broadlistening/pipeline/services/llm.py
+++ b/server/broadlistening/pipeline/services/llm.py
@@ -10,9 +10,7 @@ from openai import AzureOpenAI
 # from langchain_openai import AzureOpenAIEmbeddings
 
 
-DOTENV_PATH = os.path.abspath(
-    os.path.join(os.path.dirname(__file__), "../../../../.env")
-)
+DOTENV_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../.env"))
 load_dotenv(DOTENV_PATH)
 
 
@@ -89,9 +87,7 @@ EMBDDING_MODELS = [
 
 def _validate_model(model):
     if model not in EMBDDING_MODELS:
-        raise RuntimeError(
-            f"Invalid embedding model: {model}, available models: {EMBDDING_MODELS}"
-        )
+        raise RuntimeError(f"Invalid embedding model: {model}, available models: {EMBDDING_MODELS}")
 
 
 def request_to_embed(args, model):

--- a/server/broadlistening/pipeline/steps/embedding.py
+++ b/server/broadlistening/pipeline/steps/embedding.py
@@ -1,5 +1,6 @@
 import pandas as pd
 from tqdm import tqdm
+
 from services.llm import request_to_embed
 
 

--- a/server/broadlistening/pipeline/steps/embedding.py
+++ b/server/broadlistening/pipeline/steps/embedding.py
@@ -16,10 +16,5 @@ def embedding(config):
         args = arguments["argument"].tolist()[i : i + batch_size]
         embeds = request_to_embed(args, model)
         embeddings.extend(embeds)
-    df = pd.DataFrame(
-        [
-            {"arg-id": arguments.iloc[i]["arg-id"], "embedding": e}
-            for i, e in enumerate(embeddings)
-        ]
-    )
+    df = pd.DataFrame([{"arg-id": arguments.iloc[i]["arg-id"], "embedding": e} for i, e in enumerate(embeddings)])
     df.to_pickle(path)


### PR DESCRIPTION
# 変更の概要
- apiのlintについて、docker上で実行できるようにした
  - CIでlintエラーが出ていた箇所も修正
- Makefileにlint/format実行のコマンドを用意した

# 変更の背景
- docker環境を準備しているにもかかわらず、ruffの実行がホストマシンに依存していた

# 関連Issue
https://github.com/digitaldemocracy2030/kouchou-ai/issues/108

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました