### PR TITLE
ツリーマップで各クラスタの件数を表示する

### DIFF
--- a/client/components/charts/TreemapChart.tsx
+++ b/client/components/charts/TreemapChart.tsx
@@ -27,7 +27,7 @@ export function TreemapChart({clusterList, argumentList}: Props) {
     values: values,
     branchvalues: 'total',
     hovertemplate: '<b>%{label}</b><br>%{value:,}件<br>%{percentEntry:.2%}<extra></extra>',
-    texttemplate: '%{label}<br>%{percentEntry:.2%}',
+    texttemplate: '%{label}<br>%{value:,}件<br>%{percentEntry:.2%}',
     maxdepth: 2,
     pathbar: {
       thickness: 28,


### PR DESCRIPTION
# 変更の概要
- ツリーマップに各クラスタの件数を表示するテキストを追加しました

## Before
![image](https://github.com/user-attachments/assets/4acc9f97-4305-47f9-93f7-708183d0a8af)

## After
![image](https://github.com/user-attachments/assets/b23bdaab-d9bc-424b-b6f8-7ceb7dcad7bb)

# 変更の背景
- クラスタ毎に何件あるのかを把握したい要望があるため

# 関連Issue
- fix: https://github.com/digitaldemocracy2030/kouchou-ai/issues/17

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました