### PR TITLE
ロゴの掛け算の右側を削除

### DIFF
--- a/client-admin/components/Header.tsx
+++ b/client-admin/components/Header.tsx
@@ -1,5 +1,4 @@
-import {Alert, Box, HStack, Image, Text} from '@chakra-ui/react'
-import {XIcon} from 'lucide-react'
+import {Alert, HStack, Image} from '@chakra-ui/react'
 
 
 export function Header() {
@@ -14,19 +13,6 @@ export function Header() {
           maxW={{base: '120px', md: '200px'}}
           alt={'レポート発行者'}
         />
-        <XIcon color={'gray'}/>
-        <Box
-          fontWeight={'bold'}
-          className={'gradientColor'}
-        >
-          <Text
-            fontSize={{base: 'md', md: 'lg'}}
-          >広聴AI</Text>
-          <Text
-            fontSize={{base: 'xs', md: 'sm'}}
-            lineHeight={1.1}
-          >デジタル民主主義2030<br/>ブロードリスニング</Text>
-        </Box>
       </HStack>
       <HStack>
         <Alert.Root status="warning">

--- a/client/components/Header.tsx
+++ b/client/components/Header.tsx
@@ -1,7 +1,6 @@
 'use client'
 
-import {Box, HStack, Image, Text} from '@chakra-ui/react'
-import {XIcon} from 'lucide-react'
+import {HStack, Image} from '@chakra-ui/react'
 import {BroadlisteningGuide} from '@/components/report/BroadlisteningGuide'
 import {Meta} from '@/type'
 import {getApiBaseUrl} from '@/app/utils/api'
@@ -24,21 +23,8 @@ export function Header({meta}: Props) {
               maxW={{base: '120px', md: '200px'}}
               alt={meta.reporter}
             />
-            <XIcon color={'gray'}/>
           </>
         )}
-        <Box
-          fontWeight={'bold'}
-          className={'gradientColor'}
-        >
-          <Text
-            fontSize={{base: 'md', md: 'lg'}}
-          >広聴AI</Text>
-          <Text
-            fontSize={{base: 'xs', md: 'sm'}}
-            lineHeight={1.1}
-          >デジタル民主主義2030<br/>ブロードリスニング</Text>
-        </Box>
       </HStack>
       <BroadlisteningGuide/>
     </HStack>


### PR DESCRIPTION
close #106 

# 変更の概要

- client
  - ヘッダーの掛け算から右側を削除
- client-admin
  - ヘッダーの掛け算から右側を削除

# 変更の背景

> - 上記ロゴの掛け算の右側はないほうがよいかと思います
>    - 自治体、政党などがより使いやすくなる
>    - ユーザーにとっても初見で情報が多すぎなくて済む

# 関連Issue
#106 

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました