### PR TITLE
レポート作成画面でOpenAI APIの並列実行数をパラメータとして追加

### DIFF
--- a/client-admin/app/create/page.tsx
+++ b/client-admin/app/create/page.tsx
@@ -39,6 +39,7 @@ export default function Page() {
   const [model, setModel] = useState<string>('gpt-4o-mini')
   const [clusterLv1, setClusterLv1] = useState<number>(5)
   const [clusterLv2, setClusterLv2] = useState<number>(50)
+  const [workers, setWorkers] = useState<number>(30)
   const [extraction, setExtraction] = useState<string>(extractionPrompt)
   const [initialLabelling, setInitialLabelling] = useState<string>(initialLabellingPrompt)
   const [mergeLabelling, setMergeLabelling] = useState<string>(mergeLabellingPrompt)
@@ -92,6 +93,7 @@ export default function Page() {
           comments,
           cluster: [clusterLv1, clusterLv2],
           model,
+          workers,
           prompt: {
             extraction,
             initialLabelling,
@@ -223,6 +225,22 @@ export default function Page() {
                 </HStack>
                 <Field.HelperText>
                   階層ごとのクラスタ生成数です
+                </Field.HelperText>
+              </Field.Root>
+              <Field.Root>
+                <Field.Label>並列実行数</Field.Label>
+                <StepperInput
+                  w={'40%'}
+                  value={workers.toString()}
+                  min={1}
+                  max={100}
+                  onValueChange={(e) => {
+                    const v = Number(e.value)
+                    setWorkers(v)
+                  }}
+                />
+                <Field.HelperText>
+                  OpenAI APIの並列実行数です。値を大きくすることでレポート出力が速くなりますが、OpenAIアカウントのTierによってはレートリミットの上限に到達し、レポート出力が失敗する可能性があります。
                 </Field.HelperText>
               </Field.Root>
               <Field.Root>

--- a/server/src/schemas/admin_report.py
+++ b/server/src/schemas/admin_report.py
@@ -24,5 +24,6 @@ class ReportInput(SchemaBaseModel):
     intro: str  # レポートの調査概要
     cluster: list[int]  # 層ごとのクラスタ数定義
     model: str  # 利用するLLMの名称
+    workers: int  # LLM APIの並列実行数
     prompt: Prompt  # プロンプト
     comments: list[Comment]  # コメントのリスト

--- a/server/src/services/report_launcher.py
+++ b/server/src/services/report_launcher.py
@@ -18,15 +18,27 @@ def _build_config(report_input: ReportInput) -> dict:
         "question": report_input.question,
         "intro": report_input.intro,
         "model": report_input.model,
-        "extraction": {"prompt": report_input.prompt.extraction, "workers": 30, "limit": comment_num},
+        "extraction": {
+            "prompt": report_input.prompt.extraction,
+            "workers": report_input.workers,
+            "limit": comment_num,
+        },
         "hierarchical_clustering": {
             "cluster_nums": report_input.cluster,
         },
-        "hierarchical_initial_labelling": {"prompt": report_input.prompt.initial_labelling, "sampling_num": 30},
-        "hierarchical_merge_labelling": {"prompt": report_input.prompt.merge_labelling, "sampling_num": 30},
+        "hierarchical_initial_labelling": {
+            "prompt": report_input.prompt.initial_labelling,
+            "sampling_num": 30,
+            "workers": report_input.workers,
+        },
+        "hierarchical_merge_labelling": {
+            "prompt": report_input.prompt.merge_labelling,
+            "sampling_num": 30,
+            "workers": report_input.workers,
+        },
         "hierarchical_overview": {"prompt": report_input.prompt.overview},
         "hierarchical_aggregation": {
-            "sampling_num": 30,
+            "sampling_num": report_input.workers,
         },
     }
     return config


### PR DESCRIPTION
# 変更の概要
* client-admin側で、OpenAI APIの並列実行数を設定可能にした
* api側で、extraction, initial labelling, merge labellingの各プロセスで設定された並列実行数でAPIを実行するようにした

client-admin上での設定画面
<img width="1081" alt="image" src="https://github.com/user-attachments/assets/23a23448-a39a-4250-99e5-62479d8fa49b" />


# 変更の背景
- OpenAI APIの並列実行数が固定化されていた
  - [APIのレートリミットはアカウントのtierによって異なる](https://platform.openai.com/docs/guides/rate-limits#free-tier-rate-limits)ため、固定化されていると以下の問題が起きうる
    - tierの低いアカウントではレポート出力が失敗する
    - tierの高いアカウントではレポート出力まで不要に待たなければならない

# 関連Issue
https://github.com/digitaldemocracy2030/kouchou-ai/issues/92
https://github.com/digitaldemocracy2030/kouchou-ai/issues/93


# 挙動の確認結果
- [x] client-admin設定した並列実行数が、configファイルに保存されている
- [x] 正常にレポートが出力できている

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました