### PR TITLE
UIの「クラスタ」を「意見グループ」に修正

### DIFF
--- a/client-admin/app/create/page.tsx
+++ b/client-admin/app/create/page.tsx
@@ -205,7 +205,7 @@ export default function Page() {
                 <Field.HelperText>英字小文字と数字とハイフンのみ(URLで利用されます)</Field.HelperText>
               </Field.Root>
               <Field.Root>
-                <Field.Label>クラスター数</Field.Label>
+                <Field.Label>意見グループ数</Field.Label>
                 <HStack>
                   <StepperInput
                     value={clusterLv1.toString()}
@@ -228,7 +228,7 @@ export default function Page() {
                   />
                 </HStack>
                 <Field.HelperText>
-                  階層ごとのクラスタ生成数です
+                  階層ごとの意見グループ生成数です
                 </Field.HelperText>
               </Field.Root>
               <Field.Root>

--- a/client/components/charts/SelectChartButton.tsx
+++ b/client/components/charts/SelectChartButton.tsx
@@ -43,7 +43,7 @@ export function SelectChartButton({selected, onChange, onClickDensitySetting, on
           />
           <RadioCardItem
             value={'scatterDensity'}
-            label={useBreakpointValue({base: '', md: '濃いクラスタ'})}
+            label={useBreakpointValue({base: '', md: '濃い意見グループ'})}
             indicator={false}
             icon={<Icon><MessageCircleWarningIcon/></Icon>}
             cursor={'pointer'}
@@ -58,7 +58,7 @@ export function SelectChartButton({selected, onChange, onClickDensitySetting, on
         </HStack>
       </RadioCardRoot>
       <HStack>
-        <Tooltip content={'濃いクラスタ設定'} openDelay={0} closeDelay={0}>
+        <Tooltip content={'濃い意見グループ設定'} openDelay={0} closeDelay={0}>
           <Button
             onClick={onClickDensitySetting}
             variant={'outline'}

--- a/client/components/report/Analysis.tsx
+++ b/client/components/report/Analysis.tsx
@@ -75,7 +75,7 @@ export function Analysis({result}: ReportProps) {
         </Tooltip>
         <ChevronRightIcon/>
         <Tooltip
-          content={'抽出した議論をAIで分析し、近しい議論を一つのクラスターに分類します。クラスターごとの議論を要約し、大量の意見を見える化します。'}
+          content={'抽出した議論をAIで分析し、近しい議論を一つの意見グループに分類します。意見グループごとの議論を要約し、大量の意見を見える化します。'}
           openDelay={0} closeDelay={0}>
           <VStack gap={0} w={'200px'}>
             <Icon mb={2}><ClipboardCheckIcon size={'30px'}/></Icon>
@@ -100,7 +100,7 @@ export function Analysis({result}: ReportProps) {
                 {clusterNum['2'].toLocaleString()}
               </Text>
             </HStack>
-            <Text fontSize={'xs'}>集約したクラスター数</Text>
+            <Text fontSize={'xs'}>集約した意見グループ数</Text>
           </VStack>
         </Tooltip>
       </HStack>
@@ -245,7 +245,7 @@ export function Analysis({result}: ReportProps) {
                     <TimelineTitle fontWeight={'bold'}>表示</TimelineTitle>
                     <TimelineDescription>
                       出力されたJSONファイルをグラフィカルに表示するステップです。<br/>
-                      クラスタの概要、議論の内容などを可視化します。あなたが見ているこの画面が出来上がります。
+                      意見グループの概要、議論の内容などを可視化します。あなたが見ているこの画面が出来上がります。
                     </TimelineDescription>
                     <HStack>
                       <Button variant={'outline'} size={'xs'} onClick={() => setSelectedData({

--- a/client/components/report/ClusterBreadcrumb.tsx
+++ b/client/components/report/ClusterBreadcrumb.tsx
@@ -38,7 +38,7 @@ export function ClusterBreadcrumb({selectedClusters, onChangeFilter}: Props) {
   if (!selectedClusters.length) return <></>
   return (
     <Box mx={'auto'} maxW={'870px'} mb={6} display={{base: 'none', md: 'block'}}>
-      <Text fontSize={'sm'} fontWeight={'bold'}>表示中のクラスター</Text>
+      <Text fontSize={'sm'} fontWeight={'bold'}>表示中の意見グループ</Text>
       <BreadcrumbRoot
         size="lg"
       >

--- a/client/components/report/DensityFilterSettingDialog.tsx
+++ b/client/components/report/DensityFilterSettingDialog.tsx
@@ -31,13 +31,13 @@ export function DensityFilterSettingDialog({onClose, onChangeFilter, currentMaxD
     <DialogRoot lazyMount open={true} onOpenChange={onClose}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>濃いクラスタ設定</DialogTitle>
-          <Text>濃いクラスタ設定を設定すると、表示件数を絞って詳細を確認できます<br/>（全体図には適用されません）</Text>
+          <DialogTitle>濃い意見グループ設定</DialogTitle>
+          <Text>濃い意見グループ設定を設定すると、表示件数を絞って詳細を確認できます<br/>（全体図には適用されません）</Text>
         </DialogHeader>
         <DialogBody>
           <Box mb={4}>
             <Slider
-              label={`上位何％のクラスタを表示するか: ${maxDensity * 100}%`}
+              label={`上位何％の意見グループを表示するか: ${maxDensity * 100}%`}
               step={0.1}
               min={0.1}
               max={1}
@@ -51,7 +51,7 @@ export function DensityFilterSettingDialog({onClose, onChangeFilter, currentMaxD
           </Box>
           <Box>
             <Slider
-              label={`クラスタのサンプル数の最小数: ${minValue}`}
+              label={`意見グループのサンプル数の最小数: ${minValue}`}
               step={1}
               min={0}
               max={10}


### PR DESCRIPTION
# 変更の概要
- UIに関連する部分のみ「クラスタ」を「意見グループ」に修正

# 変更の背景
レポートを見るユーザーに対して分かりやすくするという意図だと思うので、一括置換せず、以下の箇所は一旦「クラスタ」のままにしました。

- 内部処理に影響しそうな部分（プロンプトなど）
- Analysis パート（分析する/分析内容を確認したい人は、クラスタというキーワードのほうが適切？）

# 関連Issue
#110 

- レポート生成ページ
![Screenshot from 2025-03-25 12-56-19](https://github.com/user-attachments/assets/c9c6b042-0354-4389-b66b-a076ffe00194)

- レポート表示のUI部分（ボタン）
![Screenshot from 2025-03-25 12-56-42](https://github.com/user-attachments/assets/090c86ac-a989-4d1e-8d4b-823a9457a6d6)

- レポート表示部分（濃い意見グループ設定の中）
![Screenshot from 2025-03-25 12-56-59](https://github.com/user-attachments/assets/9f8e8489-4c94-4c77-8f7e-f4cf1b7d0cbd)

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました