### PR TITLE
CSVファイル送信時にコメント数とクラスタ数設定を比較して警告を出す

### DIFF
--- a/client-admin/app/create/page.tsx
+++ b/client-admin/app/create/page.tsx
@@ -72,9 +72,9 @@ export default function Page() {
       comments = await parseCsv(csv!)
       if (comments.length < clusterLv2) {
         const confirmProceed = window.confirm(
-          `csvファイル内のコメント数 (${comments.length}) が設定されたクラスタ数 (${clusterLv2}) を下回っています。このまま続けますか？
-          \nコメントから抽出される意見の数がクラスタ数に満たない場合、適切にクラスタリングが行えない可能性があります。（一つのコメントから複数の意見が抽出されることもあるため、問題ない場合もあります）
-          \nクラスタ数を変更する場合は、AI詳細設定を開いてください。`
+          `csvファイルの行数 (${comments.length}) が設定された意見グループ数 (${clusterLv2}) を下回っています。このまま続けますか？
+          \n※コメントから抽出される意見が設定された意見グループ数に満たない場合、処理中にエラーになる可能性があります（一つのコメントから複数の意見が抽出されることもあるため、問題ない場合もあります）。
+          \n意見グループ数を変更する場合は、「AI詳細設定」を開いてください。`
         )
         if (!confirmProceed) {
           setLoading(false)

--- a/client-admin/app/create/page.tsx
+++ b/client-admin/app/create/page.tsx
@@ -71,13 +71,15 @@ export default function Page() {
     try {
       comments = await parseCsv(csv!)
       if (comments.length < clusterLv2) {
-        toaster.create({
-          type: 'error',
-          title: 'コメント数が不足しています',
-          description: `指定されたクラスタ数（${clusterLv2}）よりコメント数（${comments.length}）が少ないため、分析できません。クラスタ数を減らしてください。`,
-        })
-        setLoading(false)
-        return
+        const confirmProceed = window.confirm(
+          `csvファイル内のコメント数 (${comments.length}) が設定されたクラスタ数 (${clusterLv2}) を下回っています。このまま続けますか？
+          \nコメントから抽出される意見の数がクラスタ数に満たない場合、適切にクラスタリングが行えない可能性があります。（一つのコメントから複数の意見が抽出されることもあるため、問題ない場合もあります）
+          \nクラスタ数を変更する場合は、AI詳細設定を開いてください。`
+        )
+        if (!confirmProceed) {
+          setLoading(false)
+          return
+        }
       }
     } catch (e) {
       toaster.create({

--- a/client-admin/app/create/page.tsx
+++ b/client-admin/app/create/page.tsx
@@ -70,6 +70,15 @@ export default function Page() {
     let comments = []
     try {
       comments = await parseCsv(csv!)
+      if (comments.length < clusterLv2) {
+        toaster.create({
+          type: 'error',
+          title: 'コメント数が不足しています',
+          description: `指定されたクラスタ数（${clusterLv2}）よりコメント数（${comments.length}）が少ないため、分析できません。クラスタ数を減らしてください。`,
+        })
+        setLoading(false)
+        return
+      }
     } catch (e) {
       toaster.create({
         type: 'error',


### PR DESCRIPTION
# 変更の概要

- レポート作成ボタンクリック時にCSVファイルの行数とクラスタ数の設定を比較し、ファイルの行数が少ない場合に警告を出す。

![image](https://github.com/user-attachments/assets/8d0ff772-d758-4575-826a-4aebe8ea3b01)

# 変更の背景

- デフォルトのクラスタ数設定は[5, 50]。
- 登録されたCSVファイルの意見数が設定されたクラスタ数に満たない場合、クラスタリングの過程でエラーになる。
- これを防ぐため、APIを呼び出す前にCSVファイル内のコメント数（ファイルの行数）を確認する。
- コメント数＝意見数ではなく、一つのコメントから複数の意見が抽出される可能性もあるため、エラーではなく警告にとどめる。

# 関連Issue
Closes #147 

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました