### PR TITLE
dependabotを導入

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,49 @@
+version: 2
+updates:
+  # ルートディレクトリの docker-compose.yml 等（Docker 関連）
+  - package-ecosystem: "docker"
+    directory: "/" 
+    schedule:
+      interval: "daily"
+
+  # server 内の Dockerfile 更新チェック
+  - package-ecosystem: "docker"
+    directory: "/server"
+    schedule:
+      interval: "daily"
+
+  # client サービスの Dockerfile 更新チェック
+  - package-ecosystem: "docker"
+    directory: "/client"
+    schedule:
+      interval: "daily"
+
+  # client-admin サービスの Dockerfile 更新チェック
+  - package-ecosystem: "docker"
+    directory: "/client-admin"
+    schedule:
+      interval: "daily"
+
+  # GitHub Actions の依存関係更新
+  - package-ecosystem: "github-actions"
+    directory: "/" 
+    schedule:
+      interval: "daily"
+
+  # client サービスの package.json 更新チェック（npm）
+  - package-ecosystem: "npm"
+    directory: "/client"
+    schedule:
+      interval: "daily"
+
+  # client-admin サービスの package.json 更新チェック（npm）
+  - package-ecosystem: "npm"
+    directory: "/client-admin"
+    schedule:
+      interval: "daily"
+
+  # server の pyproject.toml 更新チェック（pip）
+  - package-ecosystem: "pip"
+    directory: "/server"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
# 変更の概要
* dependabotの設定ファイルを設置し、パッケージアップデートのPR作成が自動で行われるようにした

# 変更の背景
* セキュリティの脆弱性に伴うパッケージのアップデートを行いたいが、現状でもgithub上の Security でアラートはくるが、パッケージアップデートをする際は手作業が入る
  * -> dependabotで自動化する

# 関連Issue
https://github.com/digitaldemocracy2030/kouchou-ai/issues/151

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました