### PR TITLE
階層図ホバー時にクラスタの概要説明を表示

### DIFF
--- a/client/components/charts/TreemapChart.tsx
+++ b/client/components/charts/TreemapChart.tsx
@@ -19,14 +19,19 @@ export function TreemapChart({clusterList, argumentList}: Props) {
   const labels = list.map(node => node.label.replace(/(.{15})/g, '$1<br />'))
   const parents = list.map(node => node.parent)
   const values = list.map(node => node.value)
+  const customdata = list.map(node => node.takeaway.replace(/(.{15})/g, '$1<br />'))
   const data: Partial<PlotData & { maxdepth: number, pathbar: { thickness: number } }> = {
     type: 'treemap',
     ids: ids,
     labels: labels,
     parents: parents,
     values: values,
+    customdata: customdata,
     branchvalues: 'total',
-    hovertemplate: '<b>%{label}</b><br>%{value:,}件<br>%{percentEntry:.2%}<extra></extra>',
+    hovertemplate: '%{customdata}<extra></extra>',
+    hoverlabel: {
+      align: 'left',
+    },
     texttemplate: '%{label}<br>%{value:,}件<br>%{percentEntry:.2%}',
     maxdepth: 2,
     pathbar: {


### PR DESCRIPTION
# 変更の概要
- 階層図にホバー時に表示される Tooltip にクラスタの概要（takeaway）を表示するようにしました
![image](https://github.com/user-attachments/assets/19d49dd4-3b7c-4f13-8e5f-db9960712f3f)

# 変更の背景
- issue 上では元々表示していた件数や割合は削除した方が見やすいという意見があったので、その方向で実装しました
> ツールチップには件数/割合があるとごちゃごちゃしている印象を抱いたので、個人的に件数/割合は省いた方が見やすいと感じました
> ref: https://github.com/digitaldemocracy2030/kouchou-ai/issues/14#issuecomment-2745205016
# 関連Issue
- fix: https://github.com/digitaldemocracy2030/kouchou-ai/issues/14
# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました