### PR TITLE
fix assertion position

### DIFF
--- a/server/broadlistening/pipeline/services/llm.py
+++ b/server/broadlistening/pipeline/services/llm.py
@@ -13,6 +13,18 @@ from openai import AzureOpenAI
 DOTENV_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../.env"))
 load_dotenv(DOTENV_PATH)
 
+# check env
+use_azure = os.getenv("USE_AZURE", "false").lower()
+if use_azure == "true":
+    assert os.getenv("AZURE_CHATCOMPLETION_ENDPOINT")
+    assert os.getenv("AZURE_CHATCOMPLETION_DEPLOYMENT_NAME")
+    assert os.getenv("AZURE_CHATCOMPLETION_API_KEY")
+    assert os.getenv("AZURE_CHATCOMPLETION_VERSION")
+    assert os.getenv("AZURE_EMBEDDING_ENDPOINT")
+    assert os.getenv("AZURE_EMBEDDING_API_KEY")
+    assert os.getenv("AZURE_EMBEDDING_VERSION")
+    assert os.getenv("AZURE_EMBEDDING_DEPLOYMENT_NAME")
+
 
 def request_to_openai(
     messages: list[dict],
@@ -41,7 +53,6 @@ def request_to_azure_chatcompletion(
     deployment = os.getenv("AZURE_CHATCOMPLETION_DEPLOYMENT_NAME")
     api_key = os.getenv("AZURE_CHATCOMPLETION_API_KEY")
     api_version = os.getenv("AZURE_CHATCOMPLETION_VERSION")
-    assert azure_endpoint and deployment and api_key and api_version
 
     client = AzureOpenAI(
         api_version=api_version,
@@ -106,7 +117,6 @@ def request_to_azure_embed(args, model):
     api_key = os.getenv("AZURE_EMBEDDING_API_KEY")
     api_version = os.getenv("AZURE_EMBEDDING_VERSION")
     deployment = os.getenv("AZURE_EMBEDDING_DEPLOYMENT_NAME")
-    assert azure_endpoint and deployment and api_key and api_version
 
     client = AzureOpenAI(
         api_version=api_version,

--- a/server/broadlistening/pipeline/services/llm.py
+++ b/server/broadlistening/pipeline/services/llm.py
@@ -33,6 +33,7 @@ if use_azure == "true":
     if not os.getenv("AZURE_EMBEDDING_DEPLOYMENT_NAME"):
         raise RuntimeError("AZURE_EMBEDDING_DEPLOYMENT_NAME environment variable is not set")
 
+
 def request_to_openai(
     messages: list[dict],
     model: str = "gpt-4",

--- a/server/broadlistening/pipeline/services/llm.py
+++ b/server/broadlistening/pipeline/services/llm.py
@@ -16,15 +16,22 @@ load_dotenv(DOTENV_PATH)
 # check env
 use_azure = os.getenv("USE_AZURE", "false").lower()
 if use_azure == "true":
-    assert os.getenv("AZURE_CHATCOMPLETION_ENDPOINT")
-    assert os.getenv("AZURE_CHATCOMPLETION_DEPLOYMENT_NAME")
-    assert os.getenv("AZURE_CHATCOMPLETION_API_KEY")
-    assert os.getenv("AZURE_CHATCOMPLETION_VERSION")
-    assert os.getenv("AZURE_EMBEDDING_ENDPOINT")
-    assert os.getenv("AZURE_EMBEDDING_API_KEY")
-    assert os.getenv("AZURE_EMBEDDING_VERSION")
-    assert os.getenv("AZURE_EMBEDDING_DEPLOYMENT_NAME")
-
+    if not os.getenv("AZURE_CHATCOMPLETION_ENDPOINT"):
+        raise RuntimeError("AZURE_CHATCOMPLETION_ENDPOINT environment variable is not set")
+    if not os.getenv("AZURE_CHATCOMPLETION_DEPLOYMENT_NAME"):
+        raise RuntimeError("AZURE_CHATCOMPLETION_DEPLOYMENT_NAME environment variable is not set")
+    if not os.getenv("AZURE_CHATCOMPLETION_API_KEY"):
+        raise RuntimeError("AZURE_CHATCOMPLETION_API_KEY environment variable is not set")
+    if not os.getenv("AZURE_CHATCOMPLETION_VERSION"):
+        raise RuntimeError("AZURE_CHATCOMPLETION_VERSION environment variable is not set")
+    if not os.getenv("AZURE_EMBEDDING_ENDPOINT"):
+        raise RuntimeError("AZURE_EMBEDDING_ENDPOINT environment variable is not set")
+    if not os.getenv("AZURE_EMBEDDING_API_KEY"):
+        raise RuntimeError("AZURE_EMBEDDING_API_KEY environment variable is not set")
+    if not os.getenv("AZURE_EMBEDDING_VERSION"):
+        raise RuntimeError("AZURE_EMBEDDING_VERSION environment variable is not set")
+    if not os.getenv("AZURE_EMBEDDING_DEPLOYMENT_NAME"):
+        raise RuntimeError("AZURE_EMBEDDING_DEPLOYMENT_NAME environment variable is not set")
 
 def request_to_openai(
     messages: list[dict],


### PR DESCRIPTION
# 変更の背景
Azureのchat extractionの中でenvが不完全であるときに、チェックしてAssertionErrorを投げていたが、上流でcatchしてAPI呼び出しのエラーとして扱っていた

# 変更の概要
そもそも環境変数の正しさを毎回のAPI呼び出し時にチェックする必要はない、もっと早い段階でチェックすべき

何が間違っているのかも分かりやすくなった
```
kouchou-ai-dev-api-1           |     assert os.getenv("AZURE_EMBEDDING_API_KEY")
kouchou-ai-dev-api-1           |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました