### PR TITLE
不要なターゲット(azure-acr-login)を削除

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,13 +80,6 @@ azure-setup:
 	    echo '>>> 設定されたACR名を.env.azureに保存しています...' && \
 	    echo 'AZURE_ACR_NAME=$(AZURE_ACR_NAME)' > /workspace/.env.azure.generated"
 
-# ACRにログイン（トークンを表示）
-azure-acr-login:
-	docker run -it --rm -v $(shell pwd):/workspace -v $(HOME)/.azure:/root/.azure -w /workspace mcr.microsoft.com/azure-cli /bin/bash -c "\
-	    echo '以下のトークンでDockerログインしてください:' && \
-	    token=\$$(az acr login --name kouchouairegistry --expose-token --query accessToken -o tsv) && \
-	    echo \"docker login kouchouairegistry.azurecr.io --username 00000000-0000-0000-0000-000000000000 --password \$$token\""
-
 # ACRに自動ログイン
 azure-acr-login-auto:
 	$(call read-env)


### PR DESCRIPTION
# 変更の概要
- Makaefile中の不要なターゲットが残っていたので削除しました

# 変更の背景
> Makefileのazure-acr-loginターゲットってACR名を置き換えてないから一般的には動かないし、どこからも呼ばれてないように思いますが盲腸ですかね？
https://w1740803485-clv347541.slack.com/archives/C08F7JZPD63/p1743423114579229

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました