### PR TITLE
クラスタ見出しをanchorにする

### DIFF
--- a/client/components/report/ClusterOverview.tsx
+++ b/client/components/report/ClusterOverview.tsx
@@ -1,5 +1,5 @@
 import {Cluster} from '@/type'
-import {Box, Heading, Text} from '@chakra-ui/react'
+import {Box, Heading, Link, Text} from '@chakra-ui/react'
 import {MessagesSquareIcon} from 'lucide-react'
 
 type Props = {
@@ -10,8 +10,25 @@ export function ClusterOverview({cluster}: Props) {
   return (
     <Box mx={'auto'} maxW={'750px'} mb={12}>
       <Box mb={2}>
-        <Heading fontSize={'2xl'} className={'headingColor'} mb={1}>{cluster.label}</Heading>
-        <Text fontWeight={'bold'} display='flex' gap={1}>
+        <Link
+          id={cluster.label}
+          href={`#${cluster.label}`}
+          className={'headingColor'}
+          position={'relative'}
+          _hover={{
+            '&:before': {
+              content: '"#"',
+              fontSize: '2xl',
+              position: 'absolute',
+              left: '-1.4rem',
+            },
+          }}
+        >
+          <Heading fontSize={'2xl'} mb={0}>
+            {cluster.label}
+          </Heading>
+        </Link>
+        <Text fontWeight={'bold'} display={'flex'} gap={1} mt={2}>
           <MessagesSquareIcon size={20}/>
           {cluster.value.toLocaleString()}件
         </Text>


### PR DESCRIPTION
# 変更の概要
-  レポートの詳細ページのクラスターの見出しにリンクをつけました

https://github.com/user-attachments/assets/a885796d-6fd5-44f5-b70e-49efdce7ff99

# 変更の背景
- リンクの href, id 属性は、URL から意味が把握しやすいと思ったので見出しの日本語の文字列を設定しています
  - レポートの個別ページに同じ見出しのクラスターは出てこないことを前提にしているので、認識違いがあればコメントいただけると :pray:
- クリックできるとわかりやすいように hover 時にアイコンを表示しました

# 関連Issue
- fix: #112

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました