### PR TITLE
意見グループ（クラスタ）数の値の変更を直接入力でも可能にする

### DIFF
--- a/client-admin/app/create/page.tsx
+++ b/client-admin/app/create/page.tsx
@@ -20,7 +20,6 @@ import {
 import { FileUploadDropzone, FileUploadList, FileUploadRoot } from '@/components/ui/file-upload'
 import { useState } from 'react'
 import { Checkbox } from '@/components/ui/checkbox'
-import { StepperInput } from '@/components/ui/stepper-input'
 import { parseCsv, CsvData } from '@/app/create/parseCsv'
 import { useRouter } from 'next/navigation'
 import { toaster } from '@/components/ui/toaster'
@@ -682,16 +681,36 @@ export default function Page() {
               </Field.Root>
               <Field.Root>
                 <Field.Label>並列実行数</Field.Label>
-                <StepperInput
-                  w={'40%'}
-                  value={workers.toString()}
-                  min={1}
-                  max={100}
-                  onValueChange={(e) => {
-                    const v = Number(e.value)
-                    setWorkers(v)
-                  }}
-                />
+                <HStack>
+                  <Button
+                    onClick={() => {
+                      setWorkers(Math.max(1, workers - 1))
+                    }}
+                    variant="outline"
+                  >
+                    -
+                  </Button>
+                  <Input
+                    type="number"
+                    value={workers.toString()}
+                    min={1}
+                    max={100}
+                    onChange={(e) => {
+                      const v = Number(e.target.value)
+                      if (!isNaN(v)) {
+                        setWorkers(Math.max(1, Math.min(100, v)))
+                      }
+                    }}
+                  />
+                  <Button
+                    onClick={() => {
+                      setWorkers(Math.min(100, workers + 1))
+                    }}
+                    variant="outline"
+                  >
+                    +
+                  </Button>
+                </HStack>
                 <Field.HelperText>
                   OpenAI APIの並列実行数です。値を大きくすることでレポート出力が速くなりますが、OpenAIアカウントのTierによってはレートリミットの上限に到達し、レポート出力が失敗する可能性があります。
                 </Field.HelperText>

--- a/client-admin/app/create/page.tsx
+++ b/client-admin/app/create/page.tsx
@@ -616,7 +616,7 @@ export default function Page() {
               </Field.Root>
               <Field.Root>
                 <Field.Label>意見グループ数</Field.Label>
-                <HStack>
+                <HStack w={'100%'}>
                   <Button
                     onClick={() => {
                       setClusterLv1(Math.max(2, clusterLv1 - 1))

--- a/client-admin/app/create/page.tsx
+++ b/client-admin/app/create/page.tsx
@@ -618,25 +618,63 @@ export default function Page() {
               <Field.Root>
                 <Field.Label>意見グループ数</Field.Label>
                 <HStack>
-                  <StepperInput
+                  <Button
+                    onClick={() => {
+                      setClusterLv1(Math.max(2, clusterLv1 - 1))
+                    }}
+                    variant="outline"
+                  >
+                    -
+                  </Button>
+                  <Input
+                    type="number"
                     value={clusterLv1.toString()}
                     min={2}
                     max={10}
-                    onValueChange={(e) => {
-                      const v = Number(e.value)
-                      setClusterLv1(v)
+                    onChange={(e) => {
+                      const v = Number(e.target.value)
+                      if (!isNaN(v)) {
+                        setClusterLv1(Math.max(2, Math.min(10, v)))
+                      }
                     }}
                   />
-                  <ChevronRightIcon />
-                  <StepperInput
+                  <Button
+                    onClick={() => {
+                      setClusterLv1(Math.min(10, clusterLv1 + 1))
+                    }}
+                    variant="outline"
+                  >
+                    +
+                  </Button>
+                  <ChevronRightIcon width="100px"/>
+                  <Button
+                    onClick={() => {
+                      setClusterLv2(Math.max(2, clusterLv2 - 1))
+                    }}
+                    variant="outline"
+                  >
+                    -
+                  </Button>
+                  <Input
+                    type="number"
                     value={clusterLv2.toString()}
                     min={2}
                     max={1000}
-                    onValueChange={(e) => {
-                      const v = Number(e.value)
-                      setClusterLv2(v)
+                    onChange={(e) => {
+                      const v = Number(e.target.value)
+                      if (!isNaN(v)) {
+                        setClusterLv2(Math.max(2, Math.min(1000, v)))
+                      }
                     }}
                   />
+                  <Button
+                    onClick={() => {
+                      setClusterLv2(Math.min(1000, clusterLv2 + 1))
+                    }}
+                    variant="outline"
+                  >
+                    +
+                  </Button>
                 </HStack>
                 <Field.HelperText>
                   階層ごとの意見グループ生成数です


### PR DESCRIPTION
# 変更の概要
- タイトルの通り
- 並列実行数についても見た目を揃えるために同様に修正

# スクリーンショット
![Screenshot from 2025-04-05 12-06-44](https://github.com/user-attachments/assets/7ea283c1-f25d-405a-a30e-ba8a298ecd97)

# 変更の背景
現状では大きく値を変更しようとするとボタンをたくさん押す必要があってユーザーに負担がかかるため

# 関連Issue
#222 

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました