### PR TITLE
「意見が含まれるコメント数」 -> 「コメント数」に文言を修正

### DIFF
--- a/client/components/report/Analysis.tsx
+++ b/client/components/report/Analysis.tsx
@@ -52,7 +52,7 @@ export function Analysis({result}: ReportProps) {
             <Icon mb={2}><MessageCircleWarningIcon size={'30px'}/></Icon>
             <Text className={'headingColor'} fontSize={'3xl'} fontWeight={'bold'} lineHeight={1}
               mb={1}>{result.comment_num.toLocaleString()}</Text>
-            <Text fontSize={'xs'}>意見が含まれるコメント数</Text>
+            <Text fontSize={'xs'}>コメント数</Text>
           </VStack>
         </Tooltip>
         <ChevronRightIcon/>


### PR DESCRIPTION
# 変更の概要
Analysis上で、「意見が含まれるコメント数」 -> 「コメント数」に文言を修正

# 変更の背景
* 実装の実態として、「意見が含まれるコメント数」ではなく元データ内の単純な「コメント数」を計算しており、文言と実態が合っていない
* また、件数を表示するうえでも、入力データ全体の件数が表示されている方が自然
  * 「コメント数」と「抽出された意見数」の間に「意見が含まれるコメント数」を入れる

# 関連Issue
Close https://github.com/digitaldemocracy2030/kouchou-ai/issues/238

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました