### PR TITLE
Fix: 静的ビルド時のパーミッションエラー修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ down:
 client-build-static:
 	rm -rf out
 	docker compose up -d api
-	docker compose run --rm -v $(shell pwd)/server:/server -v $(shell pwd)/out:/app/dist client sh -c "npm run build:static && cp -r out/* dist"
+	docker compose run --user $(shell id -u):$(shell id -g) --rm -v $(shell pwd)/server:/server -v $(shell pwd)/out:/app/dist client sh -c "npm run build:static && cp -r out/* dist"
 	docker compose down
 
 client-setup:


### PR DESCRIPTION
# 静的ビルド時のパーミッションエラー修正

## 問題
静的ファイル出力（static build）を行う際、2回目以降にパーミッションエラーが発生する問題を修正しました。
Dockerコンテナ内でrootユーザーとしてファイルが生成されるため、ホスト側の通常ユーザーが`rm -rf out`でファイルを削除できなくなっていました。

## 解決策
Dockerコンテナ起動時にホストと同じユーザーIDを指定する方法（ユーザー指定アプローチ）を実装しました。
`docker compose run`コマンドに`--user $(shell id -u):$(shell id -g)`オプションを追加することで、
生成されるファイルの所有者がホストユーザーになり、パーミッションエラーが発生しなくなります。

## メリット
- 根本的な解決策（原因を解決）
- 生成されるファイルの所有者が最初からホストユーザーになる
- セキュリティ的に優れている（最小権限の原則に従う）

Fixes #225

Link to Devin run: https://app.devin.ai/sessions/b996b4b929424c5788a064bcafebf242
Requested by: NISHIO Hirokazu (nishio.hirokazu@gmail.com)

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました