### PR TITLE
Azure Blob Storageにローカルのレポートをuploadするscript

### DIFF
--- a/docs/azure-blob-storage-guide.md
+++ b/docs/azure-blob-storage-guide.md
@@ -1,0 +1,143 @@
+# Azure Blob Storage 連携ガイド
+
+このガイドでは、広聴AIアプリケーションでAzure Blob Storageを使用してレポートデータを永続化する方法について説明します。
+
+## 目次
+
+1. [概要](#概要)
+2. [環境設定](#環境設定)
+3. [既存レポートの永続化](#既存レポートの永続化)
+4. [トラブルシューティング](#トラブルシューティング)
+5. [運用コマンド](#運用コマンド)
+
+## 概要
+
+Azure Container Apps環境では、コンテナが再起動されるとコンテナ内のファイルが失われます。Azure Blob Storageを使用することで、レポートデータを永続的に保存し、コンテナが再起動されても利用可能な状態を維持できます。
+
+## 環境設定
+
+### 1. 環境変数の設定
+
+`.env`ファイルに以下の設定を追加します：
+
+```
+# Storage settings
+# ローカル環境では"local"、Azure環境では"azure_blob"を設定
+STORAGE_TYPE=azure_blob
+# Azure Blob Storageのアカウント名
+AZURE_BLOB_STORAGE_ACCOUNT_NAME=your_storage_account_name
+# Azure Blob Storageのコンテナ名
+AZURE_BLOB_STORAGE_CONTAINER_NAME=your_container_name
+```
+
+**注意事項：**
+- ストレージアカウント名は3〜24文字の小文字英数字で、全体で一意である必要があります
+- コンテナ名は3〜63文字の小文字英数字とハイフンで構成する必要があります
+
+### 2. Azure Blob Storageの作成
+
+既存のAzure環境がある場合は、以下のコマンドでストレージを作成します：
+
+```bash
+make azure-create-storage
+```
+
+### 3. ストレージへのアクセス権限の設定
+
+ストレージへのアクセス権限を設定するには、以下のスクリプトを実行します：
+
+```bash
+./scripts/assign_storage_role.sh
+```
+
+このスクリプトは、現在ログインしているユーザーに「Storage Blob Data Contributor」ロールを付与します。
+
+## 既存レポートの永続化
+
+### 1. レポートのアップロード
+
+既存のレポートをAzure Blob Storageにアップロードするには、以下のスクリプトを使用します：
+
+```bash
+python scripts/upload_reports_to_azure.py
+```
+
+テストモードでスクリプトを実行して、アップロードされるファイルを確認することもできます：
+
+```bash
+python scripts/upload_reports_to_azure.py --test
+```
+
+### 2. APIコンテナの再起動
+
+レポートをアップロードした後、変更を反映させるにはAPIコンテナの再起動が必要です：
+
+```bash
+make azure-restart-api
+```
+
+再起動後、ブラウザをリロードすると、アップロードしたレポートが表示されます。
+
+## トラブルシューティング
+
+### 権限エラー（AuthorizationPermissionMismatch）
+
+アップロード時に以下のようなエラーが表示される場合：
+
+```
+ErrorCode:AuthorizationPermissionMismatch
+```
+
+これは、ストレージアカウントへのアクセス権限が不足していることを示しています。以下の手順で解決できます：
+
+1. Azure CLIでログインしていることを確認：
+   ```bash
+   az login
+   ```
+
+2. ストレージへのアクセス権限を付与：
+   ```bash
+   ./scripts/assign_storage_role.sh
+   ```
+
+### コンテナ再起動後もレポートが表示されない
+
+1. ログを確認して問題を特定：
+   ```bash
+   make azure-logs-api
+   ```
+
+2. 環境変数が正しく設定されているか確認：
+   ```bash
+   make azure-config-update
+   ```
+
+3. APIコンテナを再起動：
+   ```bash
+   make azure-restart-api
+   ```
+
+## 運用コマンド
+
+### ステータス確認
+
+```bash
+make azure-status
+```
+
+### ログの確認
+
+```bash
+# APIログ
+make azure-logs-api
+```
+
+### コンテナの停止/起動
+
+```bash
+# コンテナをスケールダウン
+make azure-stop
+
+# 再度使う時に起動
+make azure-start
+```

--- a/docs/azure-blob-storage-guide.md
+++ b/docs/azure-blob-storage-guide.md
@@ -1,4 +1,4 @@
-# Azure Blob Storage 連携ガイド
+# Azure Blob Storage 移行ガイド
 
 このガイドでは、広聴AIアプリケーションでAzure Blob Storageを使用してレポートデータを永続化する方法について説明します。
 
@@ -11,10 +11,19 @@
 5. [運用コマンド](#運用コマンド)
 
 ## 概要
-
-Azure Container Apps環境では、コンテナが再起動されるとコンテナ内のファイルが失われます。Azure Blob Storageを使用することで、レポートデータを永続的に保存し、コンテナが再起動されても利用可能な状態を維持できます。
+2025-04-08以前に作成されたAzure Container Apps環境では、コンテナが再起動されるとコンテナ内のファイルが失われます。Azure Blob Storageを使用することで、レポートデータを永続的に保存し、コンテナが再起動されても利用可能な状態を維持できます。
 
 ## 環境設定
+
+### 0. 既存レポートのバックアップ
+
+```bash
+python scripts/fetch_reports.py --api-url https://your-api-url
+```
+
+このスクリプトは全てのレポートをローカル環境にダウンロードします。
+
+注: 完了した分析の最終結果データのみを保存します。
 
 ### 1. 環境変数の設定
 
@@ -60,12 +69,6 @@ make azure-create-storage
 
 ```bash
 python scripts/upload_reports_to_azure.py
-```
-
-テストモードでスクリプトを実行して、アップロードされるファイルを確認することもできます：
-
-```bash
-python scripts/upload_reports_to_azure.py --test
 ```
 
 ### 2. APIコンテナの再起動

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,43 @@
+# スクリプト集
+
+このディレクトリには、kouchou-aiプロジェクトの運用と管理に役立つスクリプトが含まれています。
+
+## スクリプト一覧
+
+### fetch_reports.py
+既存のAPIサーバーからレポートデータを取得し、ローカル環境に保存するスクリプト。
+新しい環境へのデータ移行に使用します。
+
+### upload_reports_to_azure.py
+ローカル環境のレポートデータをAzure Blob Storageにアップロードするスクリプト。
+Azure環境への移行時に使用します。
+
+### assign_storage_role.sh
+Azure Blob Storageへのアクセス権限（Storage Blob Data Contributor）を
+現在ログインしているユーザーに付与するスクリプト。
+
+## 使用方法
+
+各スクリプトの詳細な使用方法は、スクリプトファイル内のコメントを参照してください。
+一般的な実行手順：
+
+```bash
+# レポートデータの取得
+python scripts/fetch_reports.py --api-url https://your-api-url
+
+# Azure Blob Storageへのアクセス権限付与
+./scripts/assign_storage_role.sh
+
+# レポートデータのAzure Blob Storageへのアップロード
+python scripts/upload_reports_to_azure.py
+```
+
+## アップロード後のコンテナ再起動
+
+レポートをアップロードした後、変更を反映させるにはAPIコンテナの再起動が必要です：
+
+```bash
+make azure-restart-api
+```
+
+再起動後、ブラウザをリロードすると、アップロードしたレポートが表示されます。

--- a/scripts/assign_storage_role.sh
+++ b/scripts/assign_storage_role.sh
@@ -1,0 +1,72 @@
+
+echo "Azure Blob Storageへのアクセス権限を付与するスクリプト"
+echo "このスクリプトは現在ログインしているユーザーにStorage Blob Data Contributorロールを付与します"
+echo "-------------------------------------------------------------------"
+
+if [ -f .env ]; then
+  echo "環境変数を.envファイルから読み込みます..."
+  export $(grep -v '^#' .env | xargs)
+fi
+
+if [ -f .env.azure ]; then
+  echo "環境変数を.env.azureファイルから読み込みます..."
+  export $(grep -v '^#' .env.azure | xargs)
+fi
+
+if [ -z "$AZURE_RESOURCE_GROUP" ]; then
+  echo "エラー: AZURE_RESOURCE_GROUP が設定されていません。"
+  echo ".env または .env.azure ファイルで設定してください。"
+  exit 1
+fi
+
+if [ -z "$AZURE_BLOB_STORAGE_ACCOUNT_NAME" ]; then
+  echo "エラー: AZURE_BLOB_STORAGE_ACCOUNT_NAME が設定されていません。"
+  echo ".env または .env.azure ファイルで設定してください。"
+  exit 1
+fi
+
+echo "現在のサブスクリプションIDを取得しています..."
+SUBSCRIPTION_ID=$(az account show --query id -o tsv)
+if [ -z "$SUBSCRIPTION_ID" ]; then
+  echo "エラー: サブスクリプションIDの取得に失敗しました。"
+  echo "Azure CLIでログインしているか確認してください: az login"
+  exit 1
+fi
+
+echo "現在ログインしているユーザーのIDを取得しています..."
+USER_ID=$(az ad signed-in-user show --query id -o tsv)
+if [ -z "$USER_ID" ]; then
+  echo "エラー: ユーザーIDの取得に失敗しました。"
+  echo "Azure CLIでログインしているか確認してください: az login"
+  exit 1
+fi
+
+echo "-------------------------------------------------------------------"
+echo "使用する設定:"
+echo "サブスクリプションID: $SUBSCRIPTION_ID"
+echo "リソースグループ: $AZURE_RESOURCE_GROUP"
+echo "ストレージアカウント: $AZURE_BLOB_STORAGE_ACCOUNT_NAME"
+echo "ユーザーID: $USER_ID"
+echo "-------------------------------------------------------------------"
+
+read -p "上記の設定でロールを割り当てますか？ (y/n): " confirm
+if [ "$confirm" != "y" ]; then
+  echo "キャンセルしました。"
+  exit 0
+fi
+
+echo "ストレージアカウントへのアクセス権を付与しています..."
+az role assignment create \
+  --role "Storage Blob Data Contributor" \
+  --assignee "$USER_ID" \
+  --scope "/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$AZURE_RESOURCE_GROUP/providers/Microsoft.Storage/storageAccounts/$AZURE_BLOB_STORAGE_ACCOUNT_NAME"
+
+if [ $? -eq 0 ]; then
+  echo "-------------------------------------------------------------------"
+  echo "ロールの割り当てが完了しました。"
+  echo "これでAzure Blob Storageへのアップロードが可能になります。"
+else
+  echo "-------------------------------------------------------------------"
+  echo "エラー: ロールの割り当てに失敗しました。"
+  echo "Azure CLIの出力を確認してください。"
+fi

--- a/scripts/assign_storage_role.sh
+++ b/scripts/assign_storage_role.sh
@@ -1,8 +1,11 @@
+#!/bin/bash
 
+# スクリプトの説明
 echo "Azure Blob Storageへのアクセス権限を付与するスクリプト"
 echo "このスクリプトは現在ログインしているユーザーにStorage Blob Data Contributorロールを付与します"
 echo "-------------------------------------------------------------------"
 
+# 環境変数の読み込み
 if [ -f .env ]; then
   echo "環境変数を.envファイルから読み込みます..."
   export $(grep -v '^#' .env | xargs)
@@ -13,6 +16,7 @@ if [ -f .env.azure ]; then
   export $(grep -v '^#' .env.azure | xargs)
 fi
 
+# 必要な変数の確認
 if [ -z "$AZURE_RESOURCE_GROUP" ]; then
   echo "エラー: AZURE_RESOURCE_GROUP が設定されていません。"
   echo ".env または .env.azure ファイルで設定してください。"
@@ -25,6 +29,7 @@ if [ -z "$AZURE_BLOB_STORAGE_ACCOUNT_NAME" ]; then
   exit 1
 fi
 
+# サブスクリプションIDの取得
 echo "現在のサブスクリプションIDを取得しています..."
 SUBSCRIPTION_ID=$(az account show --query id -o tsv)
 if [ -z "$SUBSCRIPTION_ID" ]; then
@@ -33,6 +38,7 @@ if [ -z "$SUBSCRIPTION_ID" ]; then
   exit 1
 fi
 
+# ユーザーIDの取得
 echo "現在ログインしているユーザーのIDを取得しています..."
 USER_ID=$(az ad signed-in-user show --query id -o tsv)
 if [ -z "$USER_ID" ]; then
@@ -41,6 +47,7 @@ if [ -z "$USER_ID" ]; then
   exit 1
 fi
 
+# 変数の表示
 echo "-------------------------------------------------------------------"
 echo "使用する設定:"
 echo "サブスクリプションID: $SUBSCRIPTION_ID"
@@ -49,19 +56,22 @@ echo "ストレージアカウント: $AZURE_BLOB_STORAGE_ACCOUNT_NAME"
 echo "ユーザーID: $USER_ID"
 echo "-------------------------------------------------------------------"
 
+# 確認
 read -p "上記の設定でロールを割り当てますか？ (y/n): " confirm
 if [ "$confirm" != "y" ]; then
   echo "キャンセルしました。"
   exit 0
 fi
 
+# ロールの割り当て
 echo "ストレージアカウントへのアクセス権を付与しています..."
 az role assignment create \
   --role "Storage Blob Data Contributor" \
   --assignee "$USER_ID" \
   --scope "/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$AZURE_RESOURCE_GROUP/providers/Microsoft.Storage/storageAccounts/$AZURE_BLOB_STORAGE_ACCOUNT_NAME"
 
-if [ $? -eq 0 ]; then
+RESULT=$?
+if [ $RESULT -eq 0 ]; then
   echo "-------------------------------------------------------------------"
   echo "ロールの割り当てが完了しました。"
   echo "これでAzure Blob Storageへのアップロードが可能になります。"
@@ -69,4 +79,5 @@ else
   echo "-------------------------------------------------------------------"
   echo "エラー: ロールの割り当てに失敗しました。"
   echo "Azure CLIの出力を確認してください。"
+  exit $RESULT
 fi

--- a/scripts/upload_reports_to_azure.py
+++ b/scripts/upload_reports_to_azure.py
@@ -1,0 +1,269 @@
+"""
+Script to upload existing reports from local filesystem to Azure Blob Storage.
+
+This script:
+1. Reads local report files from the server/broadlistening/pipeline/outputs directory
+2. Reads the report_status.json file from server/data
+3. Uploads these files to Azure Blob Storage with the appropriate structure
+
+Usage:
+    python upload_reports_to_azure.py [--test]
+
+Options:
+    --test       Run in test mode (doesn't actually upload files)
+"""
+
+import json
+import os
+import sys
+import argparse
+from pathlib import Path
+import logging
+from dotenv import load_dotenv
+
+load_dotenv()
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    handlers=[logging.StreamHandler()],
+)
+logger = logging.getLogger(__name__)
+
+SCRIPT_DIR = Path(__file__).parent
+REPO_ROOT = SCRIPT_DIR.parent
+SERVER_DIR = REPO_ROOT / "server"
+OUTPUT_DIR = SERVER_DIR / "broadlistening" / "pipeline" / "outputs"
+STATUS_FILE = SERVER_DIR / "data" / "report_status.json"
+
+try:
+    from azure.identity import DefaultAzureCredential
+    from azure.storage.blob import BlobServiceClient
+except ImportError as e:
+    logger.error(f"Error importing Azure libraries: {e}")
+    logger.error("Please install required packages: pip install azure-storage-blob azure-identity")
+    sys.exit(1)
+
+
+class AzureBlobUploader:
+    """Azure Blob Storage uploader for reports."""
+
+    def __init__(self):
+        """Initialize the Azure Blob Storage uploader."""
+        self.storage_type = os.environ.get("STORAGE_TYPE", "local")
+        self.account_name = os.environ.get("AZURE_BLOB_STORAGE_ACCOUNT_NAME", "")
+        self.container_name = os.environ.get("AZURE_BLOB_STORAGE_CONTAINER_NAME", "")
+        
+        self.account_url = f"https://{self.account_name}.blob.core.windows.net"
+        
+        self.blob_service_client = None
+        self.container_client = None
+
+    def check_environment(self):
+        """Check if the environment is properly configured for Azure Blob Storage."""
+        if self.storage_type != "azure_blob":
+            logger.error("STORAGE_TYPE is not set to 'azure_blob'. Please update your .env file.")
+            return False
+
+        if not self.account_name:
+            logger.error("AZURE_BLOB_STORAGE_ACCOUNT_NAME is not set. Please update your .env file.")
+            return False
+
+        if not self.container_name:
+            logger.error("AZURE_BLOB_STORAGE_CONTAINER_NAME is not set. Please update your .env file.")
+            return False
+
+        return True
+
+    def connect(self):
+        """Connect to Azure Blob Storage."""
+        try:
+            self.blob_service_client = BlobServiceClient(
+                account_url=self.account_url,
+                credential=DefaultAzureCredential(),
+            )
+            self.container_client = self.blob_service_client.get_container_client(
+                self.container_name
+            )
+            return True
+        except Exception as e:
+            logger.error(f"Failed to connect to Azure Blob Storage: {e}")
+            return False
+
+    def upload_file(self, local_file_path, remote_blob_path, skip_if_same=True):
+        """Upload a file to Azure Blob Storage."""
+        try:
+            if remote_blob_path.endswith("/"):
+                remote_blob_path = remote_blob_path + os.path.basename(local_file_path)
+            elif remote_blob_path == "" or remote_blob_path == ".":
+                remote_blob_path = os.path.basename(local_file_path)
+
+            blob_client = self.container_client.get_blob_client(remote_blob_path)
+
+            if skip_if_same and blob_client.exists():
+                local_file_size = os.path.getsize(local_file_path)
+
+                blob_properties = blob_client.get_blob_properties()
+                remote_file_size = blob_properties.size
+
+                if local_file_size == remote_file_size:
+                    logger.info(
+                        f"同一ファイルが存在します。アップロードをスキップします。パス: '{local_file_path}' -> '{remote_blob_path}'"
+                    )
+                    return True
+
+            with open(local_file_path, "rb") as data:
+                blob_client.upload_blob(data, overwrite=True)
+            logger.info(f"ファイルをアップロードしました。パス: '{local_file_path}' -> '{remote_blob_path}'")
+            return True
+        except Exception as e:
+            logger.error(
+                f"ファイルのアップロードに失敗しました。パス: '{local_file_path}' -> '{remote_blob_path}' エラー: {str(e)}"
+            )
+            return False
+
+    def upload_directory(self, local_dir_path, remote_dir_prefix, target_suffixes=(), skip_if_same=True):
+        """Upload a directory to Azure Blob Storage."""
+        try:
+            prefix = remote_dir_prefix
+            if prefix and not prefix.endswith("/"):
+                prefix += "/"
+
+            files_processed = 0
+            upload_results = []
+
+            for root, _, files in os.walk(local_dir_path):
+                for filename in files:
+                    file_path = os.path.join(root, filename)
+                    relative_path = os.path.relpath(file_path, local_dir_path)
+                    remote_blob_path = (
+                        prefix + relative_path.replace(os.sep, "/") if prefix else relative_path.replace(os.sep, "/")
+                    )
+                    
+                    if target_suffixes and not any(remote_blob_path.endswith(suffix) for suffix in target_suffixes):
+                        continue
+
+                    files_processed += 1
+                    success = self.upload_file(file_path, remote_blob_path, skip_if_same=skip_if_same)
+                    upload_results.append(success)
+
+            if files_processed == 0:
+                logger.warning(f"アップロード対象のファイルが見つかりませんでした。パス: '{local_dir_path}'")
+                return False
+
+            if not all(upload_results):
+                logger.error(
+                    f"ディレクトリのアップロードに失敗しました。パス: '{local_dir_path}' プレフィックス: '{remote_dir_prefix}'"
+                )
+                return False
+
+            return True
+        except Exception as e:
+            logger.error(
+                f"ディレクトリのアップロードに失敗しました。パス: '{local_dir_path}' プレフィックス: '{remote_dir_prefix}' エラー: {str(e)}"
+            )
+            return False
+
+
+def check_environment():
+    """Check if the environment is properly configured for Azure Blob Storage."""
+    uploader = AzureBlobUploader()
+    return uploader.check_environment()
+
+
+def upload_reports(test_mode=False):
+    """Upload all local reports to Azure Blob Storage."""
+    uploader = AzureBlobUploader()
+    
+    if not uploader.check_environment():
+        return False
+    
+    if not test_mode and not uploader.connect():
+        return False
+
+    if not OUTPUT_DIR.exists():
+        logger.error(f"Output directory not found: {OUTPUT_DIR}")
+        return False
+
+    if not STATUS_FILE.exists():
+        logger.error(f"Status file not found: {STATUS_FILE}")
+        return False
+
+    try:
+        with open(STATUS_FILE, "r", encoding="utf-8") as f:
+            status_data = json.load(f)
+    except json.JSONDecodeError as e:
+        logger.error(f"Error parsing status file: {e}")
+        return False
+    except Exception as e:
+        logger.error(f"Error reading status file: {e}")
+        return False
+
+    if test_mode:
+        logger.info("Running in test mode. No files will be uploaded.")
+        logger.info(f"Would upload status file: {STATUS_FILE}")
+        logger.info(f"Would upload reports from: {OUTPUT_DIR}")
+        for slug in status_data:
+            logger.info(f"Would upload report: {slug}")
+        return True
+
+    logger.info("Uploading status file...")
+    status_upload_success = uploader.upload_file(
+        str(STATUS_FILE), "status/report_status.json"
+    )
+    
+    if not status_upload_success:
+        logger.error("Failed to upload status file.")
+        return False
+    
+    logger.info("Status file uploaded successfully.")
+
+    success_count = 0
+    total_count = 0
+    
+    for slug in status_data:
+        total_count += 1
+        report_dir = OUTPUT_DIR / slug
+        
+        if not report_dir.exists():
+            logger.warning(f"Report directory not found for slug: {slug}")
+            continue
+        
+        logger.info(f"Uploading report: {slug}")
+        
+        upload_success = uploader.upload_directory(
+            str(report_dir), f"outputs/{slug}"
+        )
+        
+        if upload_success:
+            success_count += 1
+            logger.info(f"Successfully uploaded report: {slug}")
+        else:
+            logger.error(f"Failed to upload report: {slug}")
+    
+    logger.info(f"Uploaded {success_count} out of {total_count} reports.")
+    return success_count > 0
+
+
+def main():
+    """Main function to upload reports to Azure Blob Storage."""
+    parser = argparse.ArgumentParser(
+        description="Upload local reports to Azure Blob Storage"
+    )
+    parser.add_argument(
+        "--test", action="store_true", help="Run in test mode (don't actually upload files)"
+    )
+    args = parser.parse_args()
+
+    logger.info("Starting upload of reports to Azure Blob Storage...")
+    
+    if upload_reports(args.test):
+        logger.info("Upload completed successfully.")
+        return 0
+    else:
+        logger.error("Upload failed.")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
# 変更の概要
- Azure Blob Storageにローカルのレポートをuploadするscriptを追加した
- 実環境で動作確認済み

# 変更の背景
- Azure Blob Storage導入後に生成されたレポートは永続化されるが、それ以前のものは別途Azure Blob Storageに入れる必要があるため

# 関連Issue
- https://github.com/digitaldemocracy2030/kouchou-ai/issues/260

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました