### PR TITLE
第一階層のクラスタ数の上限を緩和

### DIFF
--- a/client/components/charts/ScatterChart.tsx
+++ b/client/components/charts/ScatterChart.tsx
@@ -1,6 +1,5 @@
-import React from 'react'
-import {ChartCore} from './ChartCore'
-import {Argument, Cluster} from '@/type'
+import { Argument, Cluster } from '@/type'
+import { ChartCore } from './ChartCore'
 
 type Props = {
   clusterList: Cluster[]
@@ -10,7 +9,11 @@ type Props = {
 
 export function ScatterChart({clusterList, argumentList, targetLevel}: Props) {
   const targetClusters = clusterList.filter((cluster) => cluster.level === targetLevel)
-  const softColors = ['#7ac943', '#3fa9f5', '#ff7997', '#e0dd02', '#d6410f', '#b39647', '#7cccc3', '#a147e6']
+  const softColors = [
+    '#7ac943', '#3fa9f5', '#ff7997', '#e0dd02', '#d6410f', '#b39647', '#7cccc3', '#a147e6',
+    '#ff6b6b', '#4ecdc4', '#ffbe0b', '#fb5607', '#8338ec', '#3a86ff', '#ff006e', '#8ac926',
+    '#1982c4', '#6a4c93', '#f72585', '#7209b7', 
+  ]
   const clusterColorMap = targetClusters.reduce((acc, cluster, index) => {
     acc[cluster.id] = softColors[index % softColors.length]
     return acc


### PR DESCRIPTION
# 変更の概要
- (admin) 第一階層のクラスタ数上限を10 -> 20に緩和
  - これに合わせて、第二階層のクラスタ数下限を、`第一階層のクラスタ数 * 2` に変更
  - 条件に合致しない（下回る）場合は第二階層のクラスタ数が自動で下限に調整される & メッセージが表示される（gif参照）
- (client) 散布図のカラーバリエーションを8種類 -> 20種類まで追加

![acd132c150b21a9a813d7fe7f92e81e9](https://github.com/user-attachments/assets/71d995c8-e179-43b7-ba74-06a531a153b3)

20件のクラスタを可視化した例
![image](https://github.com/user-attachments/assets/d3d5467a-51c0-436e-87ee-50a4cbdf15ef)



# 変更の背景
* 第一階層のクラスタ数上限が10になっていたが、これだと少なすぎるケースがある
  * TTTCの過去事例だとクラスタ数を30に出力しているケースもある
    * 参考: https://broadlistening.seisakukikaku.metro.tokyo.lg.jp/20250131/index.html
  * 上限クラスタ数は出来ればもう少し緩和したかったが、クラスタ数が増えすぎると散布図が見にくくなる問題があるため、一旦今回のPRでは20に設定している

# 関連Issue
https://github.com/digitaldemocracy2030/kouchou-ai/issues/257

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました