### PR TITLE
frontend のコードを push する際に Biome の Lint を実行できるようにする

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 node_modules
 docker-compose.override.y*ml
 out
+lefthook-local.yml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,11 @@
   * `api` については、以下のコマンドでフォーマットのチェックと自動整形を実施できます
     * チェック: `make lint/api-check`
     * 整形: `make lint/api-format`
-  * `client` / `client-admin` については現在フォーマット環境を整備中です
+  * `client` / `client-admin` については Biome で lint, format のチェックを実施できます
+    * チェック: `npm run lint`
+    * 整形: `npm run format`
+    * [Lefthook](https://lefthook.dev/intro.html) で git push 時に Biome のチェックをかける設定をしています
+    * プロジェクトルートの [lefthook-local.sample.yml](./lefthook-local.sample.yml) を参考に、`lefthook-local.yml` を用意してください
 
 #### Pull Requestのプロセス
 

--- a/client-admin/app/create/page.tsx
+++ b/client-admin/app/create/page.tsx
@@ -73,7 +73,10 @@ export default function Page() {
   const [csvColumns, setCsvColumns] = useState<string[]>([]);
   const [selectedCommentColumn, setSelectedCommentColumn] =
     useState<string>("");
-  const [recommendedClusters, setRecommendedClusters] = useState<{ lv1: number, lv2: number } | null>(null);
+  const [recommendedClusters, setRecommendedClusters] = useState<{
+    lv1: number;
+    lv2: number;
+  } | null>(null);
   const [autoAdjusted, setAutoAdjusted] = useState<boolean>(false);
 
   // IDのバリデーション関数
@@ -94,7 +97,7 @@ export default function Page() {
   const calculateRecommendedClusters = (commentCount: number) => {
     const lv1 = Math.max(2, Math.min(20, Math.round(Math.cbrt(commentCount))));
     const lv2 = Math.max(2, Math.min(1000, Math.round(lv1 * lv1)));
-    
+
     return { lv1, lv2 };
   };
 
@@ -166,8 +169,10 @@ export default function Page() {
       if (commentData.comments.length > 0) {
         setCsvColumns(Object.keys(commentData.comments[0]));
       }
-      
-      setRecommendedClusters(calculateRecommendedClusters(commentData.comments.length));
+
+      setRecommendedClusters(
+        calculateRecommendedClusters(commentData.comments.length),
+      );
 
       toaster.create({
         type: "success",
@@ -384,7 +389,7 @@ export default function Page() {
           if (columns.includes("comment")) {
             setSelectedCommentColumn("comment");
           }
-          setRecommendedClusters(calculateRecommendedClusters(parsed.length))
+          setRecommendedClusters(calculateRecommendedClusters(parsed.length));
         }
       });
     } else if (newType === "spreadsheet" && spreadsheetData.length > 0) {
@@ -394,7 +399,9 @@ export default function Page() {
       if (columns.includes("comment")) {
         setSelectedCommentColumn("comment");
       }
-      setRecommendedClusters(calculateRecommendedClusters(spreadsheetData.length));
+      setRecommendedClusters(
+        calculateRecommendedClusters(spreadsheetData.length),
+      );
     } else {
       // データがない場合はカラムリセット
       setCsvColumns([]);
@@ -482,7 +489,9 @@ export default function Page() {
                             if (columns.includes("comment")) {
                               setSelectedCommentColumn("comment");
                             }
-                            setRecommendedClusters(calculateRecommendedClusters(parsed.length))
+                            setRecommendedClusters(
+                              calculateRecommendedClusters(parsed.length),
+                            );
                           }
                         }
                       }}
@@ -499,10 +508,10 @@ export default function Page() {
                       <FileUploadList
                         clearable={true}
                         onRemove={() => {
-                          setCsv(null)
-                          setCsvColumns([])
-                          setSelectedCommentColumn('')
-                          setRecommendedClusters(null)
+                          setCsv(null);
+                          setCsvColumns([]);
+                          setSelectedCommentColumn("");
+                          setRecommendedClusters(null);
                         }}
                       />
                     </FileUploadRoot>
@@ -530,7 +539,7 @@ export default function Page() {
                         </Field.HelperText>
                       </Field.Root>
                     )}
-                    
+
                     {recommendedClusters && (
                       <Field.Root mt={4}>
                         <Field.Label>おすすめクラスタ数設定</Field.Label>
@@ -538,10 +547,10 @@ export default function Page() {
                           <Text>
                             {recommendedClusters.lv1}→{recommendedClusters.lv2}
                           </Text>
-                          <Button 
+                          <Button
                             onClick={() => {
-                              setClusterLv1(recommendedClusters.lv1)
-                              setClusterLv2(recommendedClusters.lv2)
+                              setClusterLv1(recommendedClusters.lv1);
+                              setClusterLv2(recommendedClusters.lv2);
                             }}
                             size="sm"
                             colorScheme="blue"
@@ -612,18 +621,19 @@ export default function Page() {
                           </Field.HelperText>
                         </Field.Root>
                       )}
-                      
+
                       {recommendedClusters && (
                         <Field.Root mt={4}>
                           <Field.Label>おすすめクラスタ数設定</Field.Label>
                           <HStack>
                             <Text>
-                              {recommendedClusters.lv1}→{recommendedClusters.lv2}
+                              {recommendedClusters.lv1}→
+                              {recommendedClusters.lv2}
                             </Text>
-                            <Button 
+                            <Button
                               onClick={() => {
-                                setClusterLv1(recommendedClusters.lv1)
-                                setClusterLv2(recommendedClusters.lv2)
+                                setClusterLv1(recommendedClusters.lv1);
+                                setClusterLv2(recommendedClusters.lv2);
                               }}
                               size="sm"
                               colorScheme="blue"
@@ -636,7 +646,6 @@ export default function Page() {
                           </Field.HelperText>
                         </Field.Root>
                       )}
-
                     </Field.Root>
                     {spreadsheetImported && (
                       <Text color="green.500" fontSize="sm">

--- a/client-admin/app/layout.tsx
+++ b/client-admin/app/layout.tsx
@@ -1,8 +1,8 @@
 import ClientProvider from "./ClientProvider";
 import "./global.css";
 import { Toaster } from "@/components/ui/toaster";
-import type { Metadata } from "next";
 import { GoogleAnalytics } from "@next/third-parties/google";
+import type { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "デジタル民主主義2030ブロードリスニング",
@@ -12,8 +12,10 @@ export const metadata: Metadata = {
   },
 };
 
-const enableGA = !!process.env.NEXT_PUBLIC_ADMIN_GA_MEASUREMENT_ID && 
-  (process.env.ENVIRONMENT === "production" || process.env.NODE_ENV === "production");
+const enableGA =
+  !!process.env.NEXT_PUBLIC_ADMIN_GA_MEASUREMENT_ID &&
+  (process.env.ENVIRONMENT === "production" ||
+    process.env.NODE_ENV === "production");
 
 export default function RootLayout({
   children,
@@ -27,7 +29,9 @@ export default function RootLayout({
           sizes={"any"}
         />
         {enableGA && (
-          <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_ADMIN_GA_MEASUREMENT_ID || ""} />
+          <GoogleAnalytics
+            gaId={process.env.NEXT_PUBLIC_ADMIN_GA_MEASUREMENT_ID || ""}
+          />
         )}
       </head>
       <body>

--- a/client/app/layout.tsx
+++ b/client/app/layout.tsx
@@ -3,8 +3,10 @@ import "./global.css";
 import { getImageFromServerSrc } from "@/app/utils/image-src";
 import { GoogleAnalytics } from "@next/third-parties/google";
 
-const enableGA = !!process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID && 
-  (process.env.ENVIRONMENT === "production" || process.env.NODE_ENV === "production");
+const enableGA =
+  !!process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID &&
+  (process.env.ENVIRONMENT === "production" ||
+    process.env.NODE_ENV === "production");
 
 export default function RootLayout({
   children,
@@ -18,7 +20,9 @@ export default function RootLayout({
           sizes={"any"}
         />
         {enableGA && (
-          <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID || ""} />
+          <GoogleAnalytics
+            gaId={process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID || ""}
+          />
         )}
       </head>
       <body>

--- a/client/app/page.tsx
+++ b/client/app/page.tsx
@@ -73,7 +73,11 @@ export default async function Page() {
                           </Card.Title>
                           {report.createdAt && (
                             <Text fontSize={"xs"} color={"gray.500"} mb={1}>
-                              作成日時: {new Date(report.createdAt).toLocaleString("ja-JP", { timeZone: "Asia/Tokyo" })}
+                              作成日時:{" "}
+                              {new Date(report.createdAt).toLocaleString(
+                                "ja-JP",
+                                { timeZone: "Asia/Tokyo" },
+                              )}
                             </Text>
                           )}
                           <Card.Description>

--- a/client/components/charts/ScatterChart.tsx
+++ b/client/components/charts/ScatterChart.tsx
@@ -1,6 +1,5 @@
-import { Argument, Cluster } from '@/type';
-import { ChartCore } from './ChartCore';
-
+import type { Argument, Cluster } from "@/type";
+import { ChartCore } from "./ChartCore";
 
 type Props = {
   clusterList: Cluster[];
@@ -8,17 +7,43 @@ type Props = {
   targetLevel: number;
 };
 
-export function ScatterChart({clusterList, argumentList, targetLevel}: Props) {
-  const targetClusters = clusterList.filter((cluster) => cluster.level === targetLevel)
+export function ScatterChart({
+  clusterList,
+  argumentList,
+  targetLevel,
+}: Props) {
+  const targetClusters = clusterList.filter(
+    (cluster) => cluster.level === targetLevel,
+  );
   const softColors = [
-    '#7ac943', '#3fa9f5', '#ff7997', '#e0dd02', '#d6410f', '#b39647', '#7cccc3', '#a147e6',
-    '#ff6b6b', '#4ecdc4', '#ffbe0b', '#fb5607', '#8338ec', '#3a86ff', '#ff006e', '#8ac926',
-    '#1982c4', '#6a4c93', '#f72585', '#7209b7', 
-  ]
-  const clusterColorMap = targetClusters.reduce((acc, cluster, index) => {
-    acc[cluster.id] = softColors[index % softColors.length]
-    return acc
-  }, {} as Record<string, string>)
+    "#7ac943",
+    "#3fa9f5",
+    "#ff7997",
+    "#e0dd02",
+    "#d6410f",
+    "#b39647",
+    "#7cccc3",
+    "#a147e6",
+    "#ff6b6b",
+    "#4ecdc4",
+    "#ffbe0b",
+    "#fb5607",
+    "#8338ec",
+    "#3a86ff",
+    "#ff006e",
+    "#8ac926",
+    "#1982c4",
+    "#6a4c93",
+    "#f72585",
+    "#7209b7",
+  ];
+  const clusterColorMap = targetClusters.reduce(
+    (acc, cluster, index) => {
+      acc[cluster.id] = softColors[index % softColors.length];
+      return acc;
+    },
+    {} as Record<string, string>,
+  );
 
   // クラスタごとのデータを構築
   const clusterData = targetClusters.map((cluster) => {

--- a/client/type.d.ts
+++ b/client/type.d.ts
@@ -13,7 +13,7 @@ export type Report = {
   title: string;
   description: string;
   isPublic?: boolean;
-  createdAt?: string;  // 作成日時（ISO形式の文字列）
+  createdAt?: string; // 作成日時（ISO形式の文字列）
 };
 
 export type Result = {

--- a/lefthook-local.sample.yml
+++ b/lefthook-local.sample.yml
@@ -1,0 +1,17 @@
+# デフォルトでは skip: true で無効にしています。
+# 有効にしたい hook は、コメントアウトを外してしてください
+
+# pre-push:
+#   commands:
+#     client-lint:
+#       skip:
+#         - merge
+#         - rebase
+#     client-admin-lint:
+#       skip:
+#         - merge
+#         - rebase
+#     dummy-server-lint:
+#       skip:
+#         - merge
+#         - rebase

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,19 @@
+pre-push:
+  parallel: true
+  commands:
+    client-lint:
+      root: "client/"
+      glob: "client/**/*.{js,mjs,jsx,ts,tsx,json}"
+      run: "npx biome check {push_files}"
+      skip: true
+    client-admin-lint:
+      root: "client-admin/"
+      glob: "client-admin/**/*.{js,mjs,jsx,ts,tsx,json}"
+      run: "npx biome check {push_files}"
+      skip: true
+    dummy-server-lint:
+      root: "utils/dummy-server/"
+      glob: "utils/dummy-server/**/*.{js,mjs,jsx,ts,tsx,json}"
+      exclude: "hierarchical_result.json"
+      run: "npx biome check {push_files}"
+      skip: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "@next/third-parties": "^15.2.4"
       },
       "devDependencies": {
-        "@biomejs/biome": "1.9.4"
+        "@biomejs/biome": "1.9.4",
+        "lefthook": "^1.11.8"
       }
     },
     "node_modules/@biomejs/biome": {
@@ -726,6 +727,169 @@
       "license": "MIT",
       "optional": true,
       "peer": true
+    },
+    "node_modules/lefthook": {
+      "version": "1.11.8",
+      "resolved": "https://registry.npmjs.org/lefthook/-/lefthook-1.11.8.tgz",
+      "integrity": "sha512-U+x49i83GWjRigejsiEnGMsH34SjUFtSGd4VuEUWDFzDc2uerzTx5oqFv0GMwCIXTxsecoPqop+e+1gop8DDXA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "lefthook": "bin/index.js"
+      },
+      "optionalDependencies": {
+        "lefthook-darwin-arm64": "1.11.8",
+        "lefthook-darwin-x64": "1.11.8",
+        "lefthook-freebsd-arm64": "1.11.8",
+        "lefthook-freebsd-x64": "1.11.8",
+        "lefthook-linux-arm64": "1.11.8",
+        "lefthook-linux-x64": "1.11.8",
+        "lefthook-openbsd-arm64": "1.11.8",
+        "lefthook-openbsd-x64": "1.11.8",
+        "lefthook-windows-arm64": "1.11.8",
+        "lefthook-windows-x64": "1.11.8"
+      }
+    },
+    "node_modules/lefthook-darwin-arm64": {
+      "version": "1.11.8",
+      "resolved": "https://registry.npmjs.org/lefthook-darwin-arm64/-/lefthook-darwin-arm64-1.11.8.tgz",
+      "integrity": "sha512-myew7k1hz00Uyrdh4a7gQkzlRDKALb4pHmh1GDH0ZMBoy3348qlN3HegAnvwcx2tlWSxqfwkBj+xmBS2c7ujAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/lefthook-darwin-x64": {
+      "version": "1.11.8",
+      "resolved": "https://registry.npmjs.org/lefthook-darwin-x64/-/lefthook-darwin-x64-1.11.8.tgz",
+      "integrity": "sha512-hwwnY0jDMVDlEXDNCQIxx+sgYjSKJ2tx1LEbf7JsBv8icPMppY9UTKleRKzNv0qSaA5MKLciSWVAhi98/QzFJA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/lefthook-freebsd-arm64": {
+      "version": "1.11.8",
+      "resolved": "https://registry.npmjs.org/lefthook-freebsd-arm64/-/lefthook-freebsd-arm64-1.11.8.tgz",
+      "integrity": "sha512-cllq5oqik463TwhR/3kU19gZv/MHzEl7bYIlmeXJGyS4VBZ2zbrcy5dYj0u58DkxOYjM3Jpi+0xS7FQwSOkRMg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/lefthook-freebsd-x64": {
+      "version": "1.11.8",
+      "resolved": "https://registry.npmjs.org/lefthook-freebsd-x64/-/lefthook-freebsd-x64-1.11.8.tgz",
+      "integrity": "sha512-qGPo95rvzarOl7RUWcnVtkqKTYGpyFnJNnU47bvspeancENQcjzF2QLQnvfVfuTR6oR2rhHE/2z9aq//gxQJ+w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/lefthook-linux-arm64": {
+      "version": "1.11.8",
+      "resolved": "https://registry.npmjs.org/lefthook-linux-arm64/-/lefthook-linux-arm64-1.11.8.tgz",
+      "integrity": "sha512-i5B5BQntVNg/7Glei36U2uCsVdUiJVmxna2eJalMW06t2cb84fsNKPUqQCiUb/mmbs8YaNgZTG/AKezsGP3RgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/lefthook-linux-x64": {
+      "version": "1.11.8",
+      "resolved": "https://registry.npmjs.org/lefthook-linux-x64/-/lefthook-linux-x64-1.11.8.tgz",
+      "integrity": "sha512-B7zqxVc+9bQ6Bkdfu2TreJNoY6J2AFXIcm/JTD1NQMBHTkIbFysSQUKqiaCs9BHUCGuNOCTpuk7YHa9nlszRiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/lefthook-openbsd-arm64": {
+      "version": "1.11.8",
+      "resolved": "https://registry.npmjs.org/lefthook-openbsd-arm64/-/lefthook-openbsd-arm64-1.11.8.tgz",
+      "integrity": "sha512-08kdSBxtcdTFRMIQwaziXGdG3RxrzH2QkRWeNAoUG7PpV5itIb5j+xnZqOeYM6eTLgf7QUle1xKcNwcWACuefw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/lefthook-openbsd-x64": {
+      "version": "1.11.8",
+      "resolved": "https://registry.npmjs.org/lefthook-openbsd-x64/-/lefthook-openbsd-x64-1.11.8.tgz",
+      "integrity": "sha512-HlGr9t33BAnKZz9I11qRMijJpGg6/iMtb8ODIcStdM72FGgadqSLBHbNAJbD4dnN2wwR1PPu2POut/OYQfpGtg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/lefthook-windows-arm64": {
+      "version": "1.11.8",
+      "resolved": "https://registry.npmjs.org/lefthook-windows-arm64/-/lefthook-windows-arm64-1.11.8.tgz",
+      "integrity": "sha512-iBgsUdLL3d6Ty5N3s4gCgxjIDviP7flBeVb6BUy5BbNzjW+OzljKx8DlzTAUmMnUJuo+a+svYYCjqwcNs1/nvA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/lefthook-windows-x64": {
+      "version": "1.11.8",
+      "resolved": "https://registry.npmjs.org/lefthook-windows-x64/-/lefthook-windows-x64-1.11.8.tgz",
+      "integrity": "sha512-nFFS6jB7PxHXJ7nIg59+507j1myFeX1Kq3ssqGI5uxK42nCcSKXBGnnEjUnq3WpbWM8b9Ly005jDb4LN0yIvVw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/nanoid": {
       "version": "3.3.11",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "format": "biome check --write ."
   },
   "devDependencies": {
-    "@biomejs/biome": "1.9.4"
+    "@biomejs/biome": "1.9.4",
+    "lefthook": "^1.11.8"
   },
   "dependencies": {
     "@next/third-parties": "^15.2.4"


### PR DESCRIPTION
# 変更の概要
- [Lefthook](https://github.com/evilmartians/lefthook) を使って、Git Hooks の pre-push で Biome の Lint を実行できるようにしました
- CONTRIBUTING.md に client, client-admin のコードチェックに関する記載を追加しました
- 動作確認をしている際にフォーマット漏れのコードがあったので、Biome のフォーマットを適用しました

# 変更の背景
-  Lefthook はデフォルトでは off にしていて、設定ファイルを作成することで on になる設計にしています
    - 理由: 現状の Lefthook の設定は frontend のコードのみで、server 側の開発をする人にも有効にした場合に弊害が出る可能性を避けたかった
    - 最初は安全側に倒して、導入してみて良さそうであればデフォルトで on に変えても良いかもしれません
- pre-commit で毎回チェックすると少し煩雑かなと思ったので、pre-push でチェックするようにしました

# 関連Issue
- fix: #84 

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました