### PR TITLE
fix issue #278 : 要約文が「全画面終了」ボタンの後ろに隠れないようにする

### DIFF
--- a/client/components/charts/ScatterChart.tsx
+++ b/client/components/charts/ScatterChart.tsx
@@ -1,19 +1,18 @@
 import type { Argument, Cluster } from "@/type";
-import { PlotHoverEvent } from "plotly.js";
 import { ChartCore } from "./ChartCore";
 
 type Props = {
   clusterList: Cluster[];
   argumentList: Argument[];
   targetLevel: number;
-  onHover?: (event: Readonly<PlotHoverEvent>) => void;
+  onHover?: () => void;
 };
 
 export function ScatterChart({
   clusterList,
   argumentList,
   targetLevel,
-  onHover
+  onHover,
 }: Props) {
   const targetClusters = clusterList.filter(
     (cluster) => cluster.level === targetLevel,

--- a/client/components/charts/ScatterChart.tsx
+++ b/client/components/charts/ScatterChart.tsx
@@ -6,7 +6,7 @@ type Props = {
   clusterList: Cluster[];
   argumentList: Argument[];
   targetLevel: number;
-  onHover: (event: Readonly<PlotHoverEvent>) => void;
+  onHover?: (event: Readonly<PlotHoverEvent>) => void;
 };
 
 export function ScatterChart({

--- a/client/components/charts/ScatterChart.tsx
+++ b/client/components/charts/ScatterChart.tsx
@@ -1,16 +1,19 @@
 import type { Argument, Cluster } from "@/type";
+import { PlotHoverEvent } from "plotly.js";
 import { ChartCore } from "./ChartCore";
 
 type Props = {
   clusterList: Cluster[];
   argumentList: Argument[];
   targetLevel: number;
+  onHover: (event: Readonly<PlotHoverEvent>) => void;
 };
 
 export function ScatterChart({
   clusterList,
   argumentList,
   targetLevel,
+  onHover
 }: Props) {
   const targetClusters = clusterList.filter(
     (cluster) => cluster.level === targetLevel,
@@ -130,6 +133,7 @@ export function ScatterChart({
         displayModeBar: false,
         locale: "ja",
       }}
+      onHover={onHover}
     />
   );
 }

--- a/client/components/charts/TreemapChart.tsx
+++ b/client/components/charts/TreemapChart.tsx
@@ -1,14 +1,14 @@
 import type { Argument, Cluster } from "@/type";
-import type { PlotData } from "plotly.js";
-import React from "react";
+import type { PlotData, PlotHoverEvent } from "plotly.js";
 import { ChartCore } from "./ChartCore";
 
 type Props = {
   clusterList: Cluster[];
   argumentList: Argument[];
+  onHover: (event: Readonly<PlotHoverEvent>) => void;
 };
 
-export function TreemapChart({ clusterList, argumentList }: Props) {
+export function TreemapChart({ clusterList, argumentList, onHover }: Props) {
   const convertedArgumentList = argumentList.map(convertArgumentToCluster);
   const list = [
     { ...clusterList[0], parent: "" },
@@ -70,6 +70,7 @@ export function TreemapChart({ clusterList, argumentList }: Props) {
         displayModeBar: false,
         locale: "ja",
       }}
+      onHover={onHover}
     />
   );
 }

--- a/client/components/charts/TreemapChart.tsx
+++ b/client/components/charts/TreemapChart.tsx
@@ -5,7 +5,7 @@ import { ChartCore } from "./ChartCore";
 type Props = {
   clusterList: Cluster[];
   argumentList: Argument[];
-  onHover: (event: Readonly<PlotHoverEvent>) => void;
+  onHover?: (event: Readonly<PlotHoverEvent>) => void;
 };
 
 export function TreemapChart({ clusterList, argumentList, onHover }: Props) {

--- a/client/components/charts/TreemapChart.tsx
+++ b/client/components/charts/TreemapChart.tsx
@@ -1,11 +1,11 @@
 import type { Argument, Cluster } from "@/type";
-import type { PlotData, PlotHoverEvent } from "plotly.js";
+import type { PlotData } from "plotly.js";
 import { ChartCore } from "./ChartCore";
 
 type Props = {
   clusterList: Cluster[];
   argumentList: Argument[];
-  onHover?: (event: Readonly<PlotHoverEvent>) => void;
+  onHover?: () => void;
 };
 
 export function TreemapChart({ clusterList, argumentList, onHover }: Props) {

--- a/client/components/report/Chart.tsx
+++ b/client/components/report/Chart.tsx
@@ -99,10 +99,22 @@ export function Chart({
 }
 
 export function avoidHoverTextCoveringShrinkButton(): void {
-  alert('avoidHoverTextCoveringShrinkButton');
   const hoverlayer = document.querySelector(".hoverlayer");
-  const shrinkButton = document.getElementById("tooltip:«rg»:trigger");
-  if (!hoverlayer || !shrinkButton) return;
+  if (!hoverlayer) return;
+  const tooltipButtons =document.querySelectorAll('[type="button"][id^="tooltip:«"][id$="»:trigger"]');
+  let shrinkButton = null;
+  for (let tooltipButton of tooltipButtons) {
+    if (tooltipButton?.computedStyleMap()?.get("z-index") == 1) {
+      // 候補となるボタンが以下の3つ。
+      //  - SelectChartButton >「濃い意見グループ設定」「全画面表示」
+      //  - Chart >「全画面終了」
+      // そのうち目当ての「全画面終了」ボタンのみプロットの全面に表示されるようにz-indexが1と指定されている。他は未指定につき"auto"となる。
+      // もう少しちゃんとした判定方法があるはずだが、思いつかないので暫定的にこうする。
+      shrinkButton = tooltipButton;
+      break;
+    }
+  }
+  if (!shrinkButton) return;
   const hoverPos = hoverlayer.getBoundingClientRect();
   const btnPos = shrinkButton.getBoundingClientRect();
   const isCovered = !(btnPos.top > hoverPos.bottom || btnPos.bottom < hoverPos.top || btnPos.left > hoverPos.right || btnPos.right < hoverPos.left);
@@ -124,10 +136,11 @@ export function avoidHoverTextCoveringShrinkButton(): void {
   if (!hoverpath) return;
   const originalPath = hoverpath.getAttribute("d"); // 例：M0,-65 L-6,40 v89 h-201 v-190 H-6 V28 Z
   if (!originalPath) return;
+  const leftOrRight = originalPath.includes("L") ? "L" : "R"; // 吹き出しが起点から左右どちらに出るか
   const newPath = originalPath.split(",")[0]
     + ","
-    + (Number(originalPath.split(",")[1].split("L")[0]) - diff).toString()
-    + "L"
-    + originalPath.split("L")[1];
+    + (Number(originalPath.split(",")[1].split(leftOrRight)[0]) - diff).toString()
+    + leftOrRight
+    + originalPath.split(leftOrRight)[1];
   hoverpath.setAttribute("d", newPath);
 }

--- a/client/components/report/Chart.tsx
+++ b/client/components/report/Chart.tsx
@@ -33,6 +33,7 @@ export function Chart({
       >
         <Tooltip content={"全画面終了"} openDelay={0} closeDelay={0}>
           <Button
+            id={"shrinkButton"}
             onClick={onExitFullscreen}
             h={"50px"}
             position={"fixed"}
@@ -100,21 +101,8 @@ export function Chart({
 
 export function avoidHoverTextCoveringShrinkButton(): void {
   const hoverlayer = document.querySelector(".hoverlayer");
-  if (!hoverlayer) return;
-  const tooltipButtons =document.querySelectorAll('[type="button"][id^="tooltip:«"][id$="»:trigger"]');
-  let shrinkButton = null;
-  for (let tooltipButton of tooltipButtons) {
-    if (tooltipButton?.computedStyleMap()?.get("z-index") == 1) {
-      // 候補となるボタンが以下の3つ。
-      //  - SelectChartButton >「濃い意見グループ設定」「全画面表示」
-      //  - Chart >「全画面終了」
-      // そのうち目当ての「全画面終了」ボタンのみプロットの全面に表示されるようにz-indexが1と指定されている。他は未指定につき"auto"となる。
-      // もう少しちゃんとした判定方法があるはずだが、思いつかないので暫定的にこうする。
-      shrinkButton = tooltipButton;
-      break;
-    }
-  }
-  if (!shrinkButton) return;
+  const shrinkButton = document.getElementById("shrinkButton");
+  if (!hoverlayer || !shrinkButton) return;
   const hoverPos = hoverlayer.getBoundingClientRect();
   const btnPos = shrinkButton.getBoundingClientRect();
   const isCovered = !(btnPos.top > hoverPos.bottom || btnPos.bottom < hoverPos.top || btnPos.left > hoverPos.right || btnPos.right < hoverPos.left);

--- a/client/components/report/Chart.tsx
+++ b/client/components/report/Chart.tsx
@@ -57,7 +57,7 @@ export function Chart({
                 ? 1
                 : Math.max(...result.clusters.map((c) => c.level))
             }
-            onHover={avoidHoverTextCoveringShrinkButton}
+            onHover={() => setTimeout(avoidHoverTextCoveringShrinkButton, 500)}
           />
         )}
         {selectedChart === "treemap" && (
@@ -106,7 +106,12 @@ function avoidHoverTextCoveringShrinkButton(): void {
   if (!hoverlayer || !shrinkButton) return;
   const hoverPos = hoverlayer.getBoundingClientRect();
   const btnPos = shrinkButton.getBoundingClientRect();
-  const isCovered = !(btnPos.top > hoverPos.bottom || btnPos.bottom < hoverPos.top || btnPos.left > hoverPos.right || btnPos.right < hoverPos.left);
+  const isCovered = !(
+    btnPos.top > hoverPos.bottom ||
+    btnPos.bottom < hoverPos.top ||
+    btnPos.left > hoverPos.right ||
+    btnPos.right < hoverPos.left
+  );
   if (!isCovered) return;
 
   const diff = btnPos.bottom - hoverPos.top;
@@ -116,10 +121,7 @@ function avoidHoverTextCoveringShrinkButton(): void {
   if (!hovertext) return;
   const originalTransform = hovertext.getAttribute("transform"); // example：translate(1643,66)
   if (!originalTransform) return;
-  const newTransform = originalTransform.split(",")[0]
-    + ","
-    + (Number(originalTransform.split(",")[1].slice(0, -1)) + diff).toString()
-    + ")";
+  const newTransform = `${originalTransform.split(",")[0]},${(Number(originalTransform.split(",")[1].slice(0, -1)) + diff).toString()})`;
   hovertext.setAttribute("transform", newTransform);
 
   // hoverpath SVGs follow either of the following patterns:
@@ -133,10 +135,6 @@ function avoidHoverTextCoveringShrinkButton(): void {
   const bubblePointers = originalPath.match(/[Ll]/g);
   if (!bubblePointers) return; // rectangle pattern
   const bubblePointer = bubblePointers[0];
-  const newPath = originalPath.split(",")[0]
-    + ","
-    + (Number(originalPath.split(",")[1].split(bubblePointer)[0]) - diff).toString()
-    + bubblePointer
-    + originalPath.split(bubblePointer)[1];
+  const newPath = `${originalPath.split(",")[0]},${(Number(originalPath.split(",")[1].split(bubblePointer)[0]) - diff).toString()}${bubblePointer}${originalPath.split(bubblePointer)[1]}`;
   hoverpath.setAttribute("d", newPath);
 }

--- a/client/components/report/Chart.tsx
+++ b/client/components/report/Chart.tsx
@@ -4,7 +4,6 @@ import { Tooltip } from "@/components/ui/tooltip";
 import type { Result } from "@/type";
 import { Box, Button, Icon } from "@chakra-ui/react";
 import { Undo2Icon } from "lucide-react";
-import React from "react";
 
 type ReportProps = {
   result: Result;
@@ -57,12 +56,14 @@ export function Chart({
                 ? 1
                 : Math.max(...result.clusters.map((c) => c.level))
             }
+            onHover={avoidHoverTextCoveringShrinkButton}
           />
         )}
         {selectedChart === "treemap" && (
           <TreemapChart
             clusterList={result.clusters}
             argumentList={result.arguments}
+            onHover={avoidHoverTextCoveringShrinkButton}
           />
         )}
       </Box>
@@ -76,6 +77,7 @@ export function Chart({
           <TreemapChart
             clusterList={result.clusters}
             argumentList={result.arguments}
+            onHover={avoidHoverTextCoveringShrinkButton}
           />
         )}
         {(selectedChart === "scatterAll" ||
@@ -88,9 +90,44 @@ export function Chart({
                 ? 1
                 : Math.max(...result.clusters.map((c) => c.level))
             }
+            onHover={avoidHoverTextCoveringShrinkButton}
           />
         )}
       </Box>
     </Box>
   );
+}
+
+export function avoidHoverTextCoveringShrinkButton(): void {
+  alert('avoidHoverTextCoveringShrinkButton');
+  const hoverlayer = document.querySelector(".hoverlayer");
+  const shrinkButton = document.getElementById("tooltip:«rg»:trigger");
+  if (!hoverlayer || !shrinkButton) return;
+  const hoverPos = hoverlayer.getBoundingClientRect();
+  const btnPos = shrinkButton.getBoundingClientRect();
+  const isCovered = !(btnPos.top > hoverPos.bottom || btnPos.bottom < hoverPos.top || btnPos.left > hoverPos.right || btnPos.right < hoverPos.left);
+  if (!isCovered) return;
+
+  const diff = btnPos.bottom - hoverPos.top;
+
+  const hovertext = hoverlayer.querySelector(".hovertext");
+  if (!hovertext) return;
+  const originalTransform = hovertext.getAttribute("transform"); // 例：translate(1643,66)
+  if (!originalTransform) return;
+  const newTransform = originalTransform.split(",")[0]
+    + ","
+    + (Number(originalTransform.split(",")[1].slice(0, -1)) + diff).toString()
+    + ")";
+  hovertext.setAttribute("transform", newTransform);
+
+  const hoverpath = hovertext.querySelector("path");
+  if (!hoverpath) return;
+  const originalPath = hoverpath.getAttribute("d"); // 例：M0,-65 L-6,40 v89 h-201 v-190 H-6 V28 Z
+  if (!originalPath) return;
+  const newPath = originalPath.split(",")[0]
+    + ","
+    + (Number(originalPath.split(",")[1].split("L")[0]) - diff).toString()
+    + "L"
+    + originalPath.split("L")[1];
+  hoverpath.setAttribute("d", newPath);
 }


### PR DESCRIPTION
# 変更の背景
全画面表示の「全画面終了」ボタンの後ろに要素の要約文が一部隠れてしまい、読めないことがある。

# 関連Issue
https://github.com/digitaldemocracy2030/kouchou-ai/issues/278

# 変更の概要
- `client/components/charts/ScatterChart.tsx` と`client/components/charts/TreemapChart.tsx` の props に `onHover` 用のfunctionを追加。 `onHover` が有効であることは以下で確認： https://github.com/plotly/react-plotly.js/blob/master/src/factory.js
- `client/components/report/Chart.tsx` に `onHover` 用のfunctionを実装。内容は「全画面終了ボタンと要約文の吹き出しが重なる場合に重ならなくなる位置まで吹き出しを下方向にずらす」。

# 動作確認結果
○
- 全画面表示でない場合は挙動が変わらない
- 要約文がボタンに隠れない場合は挙動が変わらない
- 要約文がボタンに隠れる場合は、一番右上の要素でなくとも被らなくなるまで要約文が下方向にずれる
- 下方向にずれた場合、要約文の背景が吹き出し型であれば吹き出しの先端だけ元の位置に紐づく

△
- `ScatterChart` の場合、マウス移動のたびに `onHover` と `onUnhover` が交互に発火されるのだが、 `onHover` のたびに要約文が再描画され、本修正の位置ずらしがリセットされてしまう。そのため、 `ScatterChart` ではsetTimeoutで位置ずらしを実行するタイミングを遅らせている。これにより概ね意図通り動作するようになったが、マウスの動かし具合によっては戻ってしまうこともある。ReactのイベントとしてはonMouseMoveなどほしいものが発火されていないので、これ以上精度を上げるには独自にmousemoveイベントなどを作成する必要があるが、効果の割に影響範囲調査含めて実装コストが高そうなので、Issue [#283](https://github.com/digitaldemocracy2030/kouchou-ai/issues/283) に分離する。

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました