### PR TITLE
濃いクラスタ抽出で対象となるクラスタがない時にはボタンをdisabledにする

### DIFF
--- a/client/components/charts/SelectChartButton.tsx
+++ b/client/components/charts/SelectChartButton.tsx
@@ -8,13 +8,14 @@ import {
   MessageCircleWarningIcon,
   SquareSquareIcon,
 } from "lucide-react";
-import type React from "react";
+import React from "react";
 
 type Props = {
   selected: string;
   onChange: (value: string) => void;
   onClickDensitySetting: () => void;
   onClickFullscreen: () => void;
+  isDenseGroupEnabled: boolean;
 };
 
 export function SelectChartButton({
@@ -22,6 +23,7 @@ export function SelectChartButton({
   onChange,
   onClickDensitySetting,
   onClickFullscreen,
+  isDenseGroupEnabled,
 }: Props) {
   return (
     <HStack
@@ -68,6 +70,8 @@ export function SelectChartButton({
               </Icon>
             }
             cursor={"pointer"}
+            disabled={!isDenseGroupEnabled}
+            disabledReason={"この設定条件では抽出できませんでした"}
           />
           <RadioCardItem
             value={"treemap"}
@@ -84,11 +88,7 @@ export function SelectChartButton({
       </RadioCardRoot>
       <HStack>
         <Tooltip content={"濃い意見グループ設定"} openDelay={0} closeDelay={0}>
-          <Button
-            onClick={onClickDensitySetting}
-            variant={"outline"}
-            h={"50px"}
-          >
+          <Button onClick={onClickDensitySetting} variant={"outline"} h={"50px"}>
             <Icon>
               <CogIcon />
             </Icon>

--- a/client/components/charts/SelectChartButton.tsx
+++ b/client/components/charts/SelectChartButton.tsx
@@ -8,7 +8,7 @@ import {
   MessageCircleWarningIcon,
   SquareSquareIcon,
 } from "lucide-react";
-import React from "react";
+import type React from "react";
 
 type Props = {
   selected: string;
@@ -88,7 +88,11 @@ export function SelectChartButton({
       </RadioCardRoot>
       <HStack>
         <Tooltip content={"濃い意見グループ設定"} openDelay={0} closeDelay={0}>
-          <Button onClick={onClickDensitySetting} variant={"outline"} h={"50px"}>
+          <Button
+            onClick={onClickDensitySetting}
+            variant={"outline"}
+            h={"50px"}
+          >
             <Icon>
               <CogIcon />
             </Icon>

--- a/client/components/report/ClientContainer.tsx
+++ b/client/components/report/ClientContainer.tsx
@@ -3,7 +3,7 @@
 import { SelectChartButton } from "@/components/charts/SelectChartButton";
 import { Chart } from "@/components/report/Chart";
 import { DensityFilterSettingDialog } from "@/components/report/DensityFilterSettingDialog";
-import { Cluster, Result } from "@/type";
+import type { Cluster, Result } from "@/type";
 import { useEffect, useState } from "react";
 
 type Props = {
@@ -12,7 +12,8 @@ type Props = {
 
 export function ClientContainer({ result }: Props) {
   const [filteredResult, setFilteredResult] = useState<Result>(result);
-  const [openDensityFilterSetting, setOpenDensityFilterSetting] = useState(false);
+  const [openDensityFilterSetting, setOpenDensityFilterSetting] =
+    useState(false);
   const [selectedChart, setSelectedChart] = useState("scatterAll");
   const [maxDensity, setMaxDensity] = useState(0.2);
   const [minValue, setMinValue] = useState(5);
@@ -21,13 +22,21 @@ export function ClientContainer({ result }: Props) {
 
   // maxDensityやminValueが変化するたびに密度フィルターの結果をチェック
   useEffect(() => {
-    const { filtered, isEmpty } = getDenseClusters(result.clusters || [], maxDensity, minValue);
+    const { filtered, isEmpty } = getDenseClusters(
+      result.clusters || [],
+      maxDensity,
+      minValue,
+    );
     setIsDenseGroupEnabled(!isEmpty);
   }, [maxDensity, minValue, result.clusters]);
 
   function updateFilteredResult(maxDensity: number, minValue: number) {
     if (!result) return;
-    const { filtered } = getDenseClusters(result.clusters || [], maxDensity, minValue);
+    const { filtered } = getDenseClusters(
+      result.clusters || [],
+      maxDensity,
+      minValue,
+    );
     setFilteredResult({
       ...result,
       clusters: filtered,
@@ -88,23 +97,27 @@ export function ClientContainer({ result }: Props) {
 function getDenseClusters(
   clusters: Cluster[],
   maxDensity: number,
-  minValue: number
+  minValue: number,
 ): { filtered: Cluster[]; isEmpty: boolean } {
   // 全クラスターの中で一番大きい level を deepestLevel として取得します。
   const deepestLevel = clusters.reduce(
     (maxLevel, cluster) => Math.max(maxLevel, cluster.level),
-    0
+    0,
   );
 
   console.log("=== Dense Cluster Extraction ===");
-  console.log(`Filter settings: maxDensity=${maxDensity}, minValue=${minValue}`);
+  console.log(
+    `Filter settings: maxDensity=${maxDensity}, minValue=${minValue}`,
+  );
 
   const deepestLevelClusters = clusters.filter((c) => c.level === deepestLevel);
-  console.log(`Total clusters at deepest level (${deepestLevel}): ${deepestLevelClusters.length}`);
+  console.log(
+    `Total clusters at deepest level (${deepestLevel}): ${deepestLevelClusters.length}`,
+  );
 
   deepestLevelClusters.forEach((cluster) => {
     console.log(
-      `Cluster ID: ${cluster.id}, Label: ${cluster.label}, Density: ${cluster.density_rank_percentile}, Elements: ${cluster.value}`
+      `Cluster ID: ${cluster.id}, Label: ${cluster.label}, Density: ${cluster.density_rank_percentile}, Elements: ${cluster.value}`,
     );
   });
 
@@ -112,7 +125,9 @@ function getDenseClusters(
     .filter((c) => c.density_rank_percentile <= maxDensity)
     .filter((c) => c.value >= minValue);
 
-  console.log(`Clusters after filtering: ${filteredDeepestLevelClusters.length}`);
+  console.log(
+    `Clusters after filtering: ${filteredDeepestLevelClusters.length}`,
+  );
   console.log(filteredDeepestLevelClusters);
   console.log("=== End of Dense Cluster Extraction ===");
 

--- a/client/components/report/ClientContainer.tsx
+++ b/client/components/report/ClientContainer.tsx
@@ -3,8 +3,8 @@
 import { SelectChartButton } from "@/components/charts/SelectChartButton";
 import { Chart } from "@/components/report/Chart";
 import { DensityFilterSettingDialog } from "@/components/report/DensityFilterSettingDialog";
-import type { Cluster, Result } from "@/type";
-import React, { useState } from "react";
+import { Cluster, Result } from "@/type";
+import { useEffect, useState } from "react";
 
 type Props = {
   result: Result;
@@ -12,18 +12,25 @@ type Props = {
 
 export function ClientContainer({ result }: Props) {
   const [filteredResult, setFilteredResult] = useState<Result>(result);
-  const [openDensityFilterSetting, setOpenDensityFilterSetting] =
-    useState(false);
+  const [openDensityFilterSetting, setOpenDensityFilterSetting] = useState(false);
   const [selectedChart, setSelectedChart] = useState("scatterAll");
   const [maxDensity, setMaxDensity] = useState(0.2);
   const [minValue, setMinValue] = useState(5);
   const [isFullscreen, setIsFullscreen] = useState(false);
+  const [isDenseGroupEnabled, setIsDenseGroupEnabled] = useState(true);
+
+  // maxDensityやminValueが変化するたびに密度フィルターの結果をチェック
+  useEffect(() => {
+    const { filtered, isEmpty } = getDenseClusters(result.clusters || [], maxDensity, minValue);
+    setIsDenseGroupEnabled(!isEmpty);
+  }, [maxDensity, minValue, result.clusters]);
 
   function updateFilteredResult(maxDensity: number, minValue: number) {
     if (!result) return;
+    const { filtered } = getDenseClusters(result.clusters || [], maxDensity, minValue);
     setFilteredResult({
       ...result,
-      clusters: getDenseClusters(result.clusters || [], maxDensity, minValue),
+      clusters: filtered,
     });
   }
 
@@ -64,6 +71,7 @@ export function ClientContainer({ result }: Props) {
         onClickFullscreen={() => {
           setIsFullscreen(true);
         }}
+        isDenseGroupEnabled={isDenseGroupEnabled}
       />
       <Chart
         result={filteredResult}
@@ -80,17 +88,39 @@ export function ClientContainer({ result }: Props) {
 function getDenseClusters(
   clusters: Cluster[],
   maxDensity: number,
-  minValue: number,
-): Cluster[] {
+  minValue: number
+): { filtered: Cluster[]; isEmpty: boolean } {
+  // 全クラスターの中で一番大きい level を deepestLevel として取得します。
   const deepestLevel = clusters.reduce(
     (maxLevel, cluster) => Math.max(maxLevel, cluster.level),
-    0,
+    0
   );
-  return [
-    ...clusters.filter((c) => c.level !== deepestLevel),
-    ...clusters
-      .filter((c) => c.level === deepestLevel)
-      .filter((c) => c.density_rank_percentile <= maxDensity)
-      .filter((c) => c.value >= minValue),
-  ];
+
+  console.log("=== Dense Cluster Extraction ===");
+  console.log(`Filter settings: maxDensity=${maxDensity}, minValue=${minValue}`);
+
+  const deepestLevelClusters = clusters.filter((c) => c.level === deepestLevel);
+  console.log(`Total clusters at deepest level (${deepestLevel}): ${deepestLevelClusters.length}`);
+
+  deepestLevelClusters.forEach((cluster) => {
+    console.log(
+      `Cluster ID: ${cluster.id}, Label: ${cluster.label}, Density: ${cluster.density_rank_percentile}, Elements: ${cluster.value}`
+    );
+  });
+
+  const filteredDeepestLevelClusters = deepestLevelClusters
+    .filter((c) => c.density_rank_percentile <= maxDensity)
+    .filter((c) => c.value >= minValue);
+
+  console.log(`Clusters after filtering: ${filteredDeepestLevelClusters.length}`);
+  console.log(filteredDeepestLevelClusters);
+  console.log("=== End of Dense Cluster Extraction ===");
+
+  return {
+    filtered: [
+      ...clusters.filter((c) => c.level !== deepestLevel),
+      ...filteredDeepestLevelClusters,
+    ],
+    isEmpty: filteredDeepestLevelClusters.length === 0,
+  };
 }

--- a/client/components/ui/radio-card.tsx
+++ b/client/components/ui/radio-card.tsx
@@ -1,14 +1,17 @@
-import { RadioCard } from "@chakra-ui/react";
-import * as React from "react";
+import { RadioCard } from '@chakra-ui/react'
+import * as React from 'react'
+import { Tooltip } from './tooltip'
 
 interface RadioCardItemProps extends RadioCard.ItemProps {
-  icon?: React.ReactElement;
-  label?: React.ReactNode;
-  description?: React.ReactNode;
-  addon?: React.ReactNode;
-  indicator?: React.ReactNode | null;
-  indicatorPlacement?: "start" | "end" | "inside";
-  inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
+  icon?: React.ReactElement
+  label?: React.ReactNode
+  description?: React.ReactNode
+  addon?: React.ReactNode
+  indicator?: React.ReactNode | null
+  indicatorPlacement?: 'start' | 'end' | 'inside'
+  inputProps?: React.InputHTMLAttributes<HTMLInputElement>
+  disabled?: boolean
+  disabledReason?: React.ReactNode
 }
 
 export const RadioCardItem = React.forwardRef<
@@ -22,18 +25,32 @@ export const RadioCardItem = React.forwardRef<
     addon,
     icon,
     indicator = <RadioCard.ItemIndicator />,
-    indicatorPlacement = "end",
+    indicatorPlacement = 'end',
+    disabled,
+    disabledReason,
     ...rest
   } = props;
 
   const hasContent = label || description || icon;
   const ContentWrapper = indicator ? RadioCard.ItemContent : React.Fragment;
 
-  return (
-    <RadioCard.Item {...rest}>
+  const cardItem = (
+    <RadioCard.Item
+      {...rest}
+      data-disabled={disabled}
+      cursor={disabled ? 'not-allowed' : rest.cursor}
+      css={
+        disabled
+          ? {
+            opacity: 0.3,
+            // pointerEvents: 'none',
+          }
+          : undefined
+      }
+    >
       <RadioCard.ItemHiddenInput ref={ref} {...inputProps} />
       <RadioCard.ItemControl>
-        {indicatorPlacement === "start" && indicator}
+        {indicatorPlacement === 'start' && indicator}
         {hasContent && (
           <ContentWrapper>
             {icon}
@@ -43,15 +60,26 @@ export const RadioCardItem = React.forwardRef<
                 {description}
               </RadioCard.ItemDescription>
             )}
-            {indicatorPlacement === "inside" && indicator}
+            {indicatorPlacement === 'inside' && indicator}
           </ContentWrapper>
         )}
-        {indicatorPlacement === "end" && indicator}
+        {indicatorPlacement === 'end' && indicator}
       </RadioCard.ItemControl>
       {addon && <RadioCard.ItemAddon>{addon}</RadioCard.ItemAddon>}
     </RadioCard.Item>
   );
-});
+
+  // disabledがtrueかつdisabledReasonが存在する場合はTooltipでラップする
+  if (disabled && disabledReason) {
+    return (
+      <Tooltip content={disabledReason} showArrow>
+        {cardItem}
+      </Tooltip>
+    )
+  }
+
+  return cardItem
+})
 
 export const RadioCardRoot = RadioCard.Root;
 export const RadioCardLabel = RadioCard.Label;


### PR DESCRIPTION
# 変更の背景+概要

https://w1740803485-clv347541.slack.com/archives/C08F7JZPD63/p1743685246693499
>少ないデータに「濃い意見グループ」分析をかけた時に何が起こるか
>- getDenseClusters関数が末端グループを対象に濃度でのフィルタリングをする。この時「最小クラスタサイズ」の制約があるのでみんな小さすぎる時はフィルター結果が空になる。このフィルターは末端グループだけフィルターし、親グループはそのまま残す仕組みになっている。
>- フィルターされた結果を受け取ったChartコンポーネントは、チャートの種類選択が「濃い意見グループ」の時、データから一番深いグループを計算してそのレベルのグループを表示する。このとき「本来の末端グループがすべてフィルターされてる」ことで、上位のグループが表示されてしまう
>- 修正案: getDenseClustersが「フィルター結果がemptyか」のbooleanをセットで返すようにし、emptyな時には「濃い意見グループ」のボタンをdisabledにする

# 関連Issue
- #96

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました