### PR TITLE
レポート一覧のクリック可能範囲を広げる(#207)

### DIFF
--- a/client-admin/app/page.tsx
+++ b/client-admin/app/page.tsx
@@ -245,6 +245,18 @@ function ReportCard({
       mb={4}
       borderLeftWidth={10}
       borderLeftColor={isErrorState ? "red.600" : statusDisplay.borderColor}
+      position="relative"
+      transition="all 0.2s"
+      role="group"
+      _hover={report.status === "ready" ? {
+        backgroundColor: "gray.50",
+        cursor: "pointer",
+      } : {}}
+      onClick={() => {
+        if (report.status === "ready") {
+          window.open(`${process.env.NEXT_PUBLIC_CLIENT_BASEPATH}/${report.slug}`, "_blank");
+        }
+      }}
     >
       <Card.Body>
         <HStack justify="space-between">
@@ -327,6 +339,38 @@ function ReportCard({
               )}
             </Box>
           </HStack>
+          {report.status === "ready" && (
+            <Box
+              position="absolute"
+              top="0"
+              left="0"
+              right="0"
+              bottom="0"
+              display="flex"
+              alignItems="center"
+              justifyContent="center"
+              backgroundColor="rgba(0, 0, 0, 0.05)"
+              opacity="0"
+              transition="opacity 0.2s"
+              _hover={{ opacity: 1 }}
+              pointerEvents="auto"
+              zIndex="10"
+            >
+              <Button
+                variant="solid"
+                size="sm"
+                bg="white"
+                color="black"
+                zIndex="50"
+                pointerEvents="auto"
+              >
+                <Flex align="center" gap={2}>
+                  <ExternalLinkIcon size={16} />
+                  <Text>レポートを見る</Text>
+                </Flex>
+              </Button>
+            </Box>
+          )}
           <HStack>
             {report.status === "ready" && report.isPubcom && (
               <Tooltip
@@ -336,7 +380,8 @@ function ReportCard({
               >
                 <Button
                   variant="ghost"
-                  onClick={async () => {
+                  onClick={async (e) => {
+                    e.stopPropagation(); // カード全体のクリックイベントを停止
                     try {
                       const response = await fetch(
                         `${getApiBaseUrl()}/admin/comments/${report.slug}/csv`,
@@ -381,7 +426,8 @@ function ReportCard({
                     <Button
                       variant={report.isPublic ? "solid" : "outline"}
                       size="sm"
-                      onClick={async () => {
+                      onClick={async (e) => {
+                        e.stopPropagation(); // カード全体のクリックイベントを停止
                         try {
                           const response = await fetch(
                             `${getApiBaseUrl()}/admin/reports/${report.slug}/visibility`,
@@ -416,19 +462,15 @@ function ReportCard({
                     </Button>
                   </Box>
                 </Tooltip>
-                <Link
-                  href={`${process.env.NEXT_PUBLIC_CLIENT_BASEPATH}/${report.slug}`}
-                  target="_blank"
-                >
-                  <Button variant="ghost">
-                    <ExternalLinkIcon />
-                  </Button>
-                </Link>
               </>
             )}
             <MenuRoot>
               <MenuTrigger asChild>
-                <Button variant="ghost" size="lg">
+                <Button
+                  variant="ghost"
+                  size="lg"
+                  onClick={(e) => e.stopPropagation()} // カード全体のクリックイベントを停止
+                >
                   <EllipsisIcon />
                 </Button>
               </MenuTrigger>
@@ -439,7 +481,8 @@ function ReportCard({
                 <MenuItem
                   value="delete"
                   color="fg.error"
-                  onClick={async () => {
+                  onClick={async (e) => {
+                    e.stopPropagation(); // カード全体のクリックイベントを停止
                     if (
                       confirm(
                         `レポート「${report.title}」を削除してもよろしいですか？`,

--- a/client-admin/app/page.tsx
+++ b/client-admin/app/page.tsx
@@ -371,7 +371,7 @@ function ReportCard({
               </Button>
             </Box>
           )}
-          <HStack>
+          <HStack position="relative" zIndex="20">
             {report.status === "ready" && report.isPubcom && (
               <Tooltip
                 content="CSVファイルをダウンロード"
@@ -381,7 +381,7 @@ function ReportCard({
                 <Button
                   variant="ghost"
                   onClick={async (e) => {
-                    e.stopPropagation(); // カード全体のクリックイベントを停止
+                    e.stopPropagation();
                     try {
                       const response = await fetch(
                         `${getApiBaseUrl()}/admin/comments/${report.slug}/csv`,
@@ -427,7 +427,7 @@ function ReportCard({
                       variant={report.isPublic ? "solid" : "outline"}
                       size="sm"
                       onClick={async (e) => {
-                        e.stopPropagation(); // カード全体のクリックイベントを停止
+                        e.stopPropagation();
                         try {
                           const response = await fetch(
                             `${getApiBaseUrl()}/admin/reports/${report.slug}/visibility`,
@@ -469,7 +469,7 @@ function ReportCard({
                 <Button
                   variant="ghost"
                   size="lg"
-                  onClick={(e) => e.stopPropagation()} // カード全体のクリックイベントを停止
+                  onClick={(e) => e.stopPropagation()}
                 >
                   <EllipsisIcon />
                 </Button>
@@ -482,7 +482,7 @@ function ReportCard({
                   value="delete"
                   color="fg.error"
                   onClick={async (e) => {
-                    e.stopPropagation(); // カード全体のクリックイベントを停止
+                    e.stopPropagation();
                     if (
                       confirm(
                         `レポート「${report.title}」を削除してもよろしいですか？`,


### PR DESCRIPTION
# 変更の概要
- レポート一覧画面で各カードにマウスオーバーするとカードがグレーになり、中央に「レポートを表示」というボックスが表示される
- カード全体(既存のボタンを除く)をクリックするとレポートが開く
- 既存のレポートページへ飛ぶアイコンは削除

![](https://i.gyazo.com/f4b591f63332a0d3bc21741c95e6b581.jpg)

# 変更の背景
- 初見のユーザーがどこをクリックしていいか分からない問題があった
- マウスオーバー効果でクリッカブルであることが分からない層にも伝わるように「レポートを表示」を出すようにした
- 既存のレポート表示ボタンは重複するので削除した

# 関連Issue
#207 

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました