### PR TITLE
CSVダウンロードにBOM付きオプションを追加する

### DIFF
--- a/client-admin/app/page.tsx
+++ b/client-admin/app/page.tsx
@@ -374,7 +374,7 @@ function ReportCard({
           )}
           <HStack position="relative" zIndex="20">
             {report.status === "ready" && report.isPubcom && (
-              <Popover.Root>
+              <Popover.Root portalled={true}>
                 <Tooltip
                   content="CSVファイルをダウンロード"
                   openDelay={0}
@@ -393,7 +393,12 @@ function ReportCard({
                     </Button>
                   </Popover.Trigger>
                 </Tooltip>
-                <Popover.Content width="200px">
+                <Popover.Content
+                  width="200px"
+                  position="absolute"
+                  zIndex={1000}
+                  style={{ margin: "8px" }}
+                  >
                   <Popover.Arrow />
                   <Popover.Body p={0}>
                     <VStack align="stretch" gap={0}>

--- a/client-admin/app/page.tsx
+++ b/client-admin/app/page.tsx
@@ -381,7 +381,12 @@ function ReportCard({
                   closeDelay={0}
                 >
                   <Popover.Trigger asChild>
-                    <Button variant="ghost">
+                    <Button
+                      variant="ghost"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                      }}
+                    >
                       <Icon>
                         <DownloadIcon />
                       </Icon>

--- a/client-admin/app/page.tsx
+++ b/client-admin/app/page.tsx
@@ -19,6 +19,7 @@ import {
   Heading,
   Icon,
   Popover,
+  Portal,
   Spinner,
   Steps,
   Text,
@@ -374,12 +375,7 @@ function ReportCard({
           )}
           <HStack position="relative" zIndex="20">
             {report.status === "ready" && report.isPubcom && (
-              <Popover.Root portalled={true}>
-                <Tooltip
-                  content="CSVファイルをダウンロード"
-                  openDelay={0}
-                  closeDelay={0}
-                >
+              <Popover.Root>
                   <Popover.Trigger asChild>
                     <Button
                       variant="ghost"
@@ -387,100 +383,104 @@ function ReportCard({
                         e.stopPropagation();
                       }}
                     >
-                      <Icon>
-                        <DownloadIcon />
-                      </Icon>
+                      <Tooltip
+                        content="CSVファイルをダウンロード"
+                        openDelay={0}
+                        closeDelay={0}
+                      >
+                        <Icon>
+                          <DownloadIcon />
+                        </Icon>
+                      </Tooltip>
                     </Button>
                   </Popover.Trigger>
-                </Tooltip>
-                <Popover.Content
-                  width="200px"
-                  position="absolute"
-                  zIndex={1000}
-                  style={{ margin: "8px" }}
-                  >
-                  <Popover.Arrow />
-                  <Popover.Body p={0}>
-                    <VStack align="stretch" gap={0}>
-                      <Button
-                        variant="ghost"
-                        justifyContent="flex-start"
-                        borderRadius={0}
-                        py={2}
-                        onClick={async (e) => {
-                          e.stopPropagation();
-                          try {
-                            const response = await fetch(
-                              `${getApiBaseUrl()}/admin/comments/${report.slug}/csv`,
-                              {
-                                headers: {
-                                  "x-api-key":
-                                    process.env.NEXT_PUBLIC_ADMIN_API_KEY || "",
-                                  "Content-Type": "application/json",
-                                },
-                              },
-                            );
-                            if (!response.ok) {
-                              const errorData = await response.json();
-                              throw new Error(errorData.detail || "CSV ダウンロードに失敗しました");
-                            }
-                            const blob = await response.blob();
-                            const url = window.URL.createObjectURL(blob);
-                            const link = document.createElement("a");
-                            link.href = url;
-                            link.download = `kouchou_${report.slug}.csv`;
-                            link.click();
-                            window.URL.revokeObjectURL(url);
-                          } catch (error) {
-                            console.error(error);
-                          }
-                        }}
-                      >
-                        CSV
-                      </Button>
-                      <Button
-                        variant="ghost"
-                        justifyContent="flex-start"
-                        borderRadius={0}
-                        py={2}
-                        onClick={async (e) => {
-                          e.stopPropagation();
-                          try {
-                            const response = await fetch(
-                              `${getApiBaseUrl()}/admin/comments/${report.slug}/csv`,
-                              {
-                                headers: {
-                                  "x-api-key":
-                                    process.env.NEXT_PUBLIC_ADMIN_API_KEY || "",
-                                  "Content-Type": "application/json",
-                                },
-                              },
-                            );
-                            if (!response.ok) {
-                              const errorData = await response.json();
-                              throw new Error(errorData.detail || "CSV ダウンロードに失敗しました");
-                            }
-                            const blob = await response.blob();
-                            const text = await blob.text();
-                            // UTF-8 BOMを追加
-                            const bom = "\uFEFF";
-                            const bomBlob = new Blob([bom + text], { type: "text/csv;charset=utf-8" });
-                            const url = window.URL.createObjectURL(bomBlob);
-                            const link = document.createElement("a");
-                            link.href = url;
-                            link.download = `kouchou_${report.slug}_excel.csv`;
-                            link.click();
-                            window.URL.revokeObjectURL(url);
-                          } catch (error) {
-                            console.error(error);
-                          }
-                        }}
-                      >
-                        CSV for Excel(Windows)
-                      </Button>
-                    </VStack>
-                  </Popover.Body>
-                </Popover.Content>
+                <Portal>
+                  <Popover.Positioner>
+                    <Popover.Content>
+                      <Popover.Arrow />
+                      <Popover.Body p={0}>
+                        <VStack align="stretch" gap={0}>
+                          <Button
+                            variant="ghost"
+                            justifyContent="flex-start"
+                            borderRadius={0}
+                            py={2}
+                            onClick={async (e) => {
+                              e.stopPropagation();
+                              try {
+                                const response = await fetch(
+                                  `${getApiBaseUrl()}/admin/comments/${report.slug}/csv`,
+                                  {
+                                    headers: {
+                                      "x-api-key":
+                                        process.env.NEXT_PUBLIC_ADMIN_API_KEY || "",
+                                      "Content-Type": "application/json",
+                                    },
+                                  },
+                                );
+                                if (!response.ok) {
+                                  const errorData = await response.json();
+                                  throw new Error(errorData.detail || "CSV ダウンロードに失敗しました");
+                                }
+                                const blob = await response.blob();
+                                const url = window.URL.createObjectURL(blob);
+                                const link = document.createElement("a");
+                                link.href = url;
+                                link.download = `kouchou_${report.slug}.csv`;
+                                link.click();
+                                window.URL.revokeObjectURL(url);
+                              } catch (error) {
+                                console.error(error);
+                              }
+                            }}
+                          >
+                            CSV
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            justifyContent="flex-start"
+                            borderRadius={0}
+                            py={2}
+                            onClick={async (e) => {
+                              e.stopPropagation();
+                              try {
+                                const response = await fetch(
+                                  `${getApiBaseUrl()}/admin/comments/${report.slug}/csv`,
+                                  {
+                                    headers: {
+                                      "x-api-key":
+                                        process.env.NEXT_PUBLIC_ADMIN_API_KEY || "",
+                                      "Content-Type": "application/json",
+                                    },
+                                  },
+                                );
+                                if (!response.ok) {
+                                  const errorData = await response.json();
+                                  throw new Error(errorData.detail || "CSV ダウンロードに失敗しました");
+                                }
+                                const blob = await response.blob();
+                                const text = await blob.text();
+                                // UTF-8 BOMを追加
+                                const bom = "\uFEFF";
+                                const bomBlob = new Blob([bom + text], { type: "text/csv;charset=utf-8" });
+                                const url = window.URL.createObjectURL(bomBlob);
+                                const link = document.createElement("a");
+                                link.href = url;
+                                link.download = `kouchou_${report.slug}_excel.csv`;
+                                link.click();
+                                window.URL.revokeObjectURL(url);
+                              } catch (error) {
+                                console.error(error);
+                              }
+                            }}
+                          >
+                            CSV for Excel(Windows)
+                          </Button>
+                        </VStack>
+                      </Popover.Body>
+                    </Popover.Content>
+                  </Popover.Positioner>
+                </Portal>
               </Popover.Root>
             )}
             {report.status === "ready" && (

--- a/client-admin/app/page.tsx
+++ b/client-admin/app/page.tsx
@@ -18,10 +18,11 @@ import {
   HStack,
   Heading,
   Icon,
+  Popover,
   Spinner,
   Steps,
   Text,
-  VStack,
+  VStack
 } from "@chakra-ui/react";
 import {
   CircleAlertIcon,
@@ -373,47 +374,104 @@ function ReportCard({
           )}
           <HStack position="relative" zIndex="20">
             {report.status === "ready" && report.isPubcom && (
-              <Tooltip
-                content="CSVファイルをダウンロード"
-                openDelay={0}
-                closeDelay={0}
-              >
-                <Button
-                  variant="ghost"
-                  onClick={async (e) => {
-                    e.stopPropagation();
-                    try {
-                      const response = await fetch(
-                        `${getApiBaseUrl()}/admin/comments/${report.slug}/csv`,
-                        {
-                          headers: {
-                            "x-api-key":
-                              process.env.NEXT_PUBLIC_ADMIN_API_KEY || "",
-                            "Content-Type": "application/json",
-                          },
-                        },
-                      );
-                      if (!response.ok) {
-                        const errorData = await response.json();
-                        throw new Error(errorData.detail || "CSV ダウンロードに失敗しました");
-                      }
-                      const blob = await response.blob();
-                      const url = window.URL.createObjectURL(blob);
-                      const link = document.createElement("a");
-                      link.href = url;
-                      link.download = `kouchou_${report.slug}.csv`;
-                      link.click();
-                      window.URL.revokeObjectURL(url);
-                    } catch (error) {
-                      console.error(error);
-                    }
-                  }}
+              <Popover.Root>
+                <Tooltip
+                  content="CSVファイルをダウンロード"
+                  openDelay={0}
+                  closeDelay={0}
                 >
-                  <Icon>
-                    <DownloadIcon />
-                  </Icon>
-                </Button>
-              </Tooltip>
+                  <Popover.Trigger asChild>
+                    <Button variant="ghost">
+                      <Icon>
+                        <DownloadIcon />
+                      </Icon>
+                    </Button>
+                  </Popover.Trigger>
+                </Tooltip>
+                <Popover.Content width="200px">
+                  <Popover.Arrow />
+                  <Popover.Body p={0}>
+                    <VStack align="stretch" gap={0}>
+                      <Button
+                        variant="ghost"
+                        justifyContent="flex-start"
+                        borderRadius={0}
+                        py={2}
+                        onClick={async (e) => {
+                          e.stopPropagation();
+                          try {
+                            const response = await fetch(
+                              `${getApiBaseUrl()}/admin/comments/${report.slug}/csv`,
+                              {
+                                headers: {
+                                  "x-api-key":
+                                    process.env.NEXT_PUBLIC_ADMIN_API_KEY || "",
+                                  "Content-Type": "application/json",
+                                },
+                              },
+                            );
+                            if (!response.ok) {
+                              const errorData = await response.json();
+                              throw new Error(errorData.detail || "CSV ダウンロードに失敗しました");
+                            }
+                            const blob = await response.blob();
+                            const url = window.URL.createObjectURL(blob);
+                            const link = document.createElement("a");
+                            link.href = url;
+                            link.download = `kouchou_${report.slug}.csv`;
+                            link.click();
+                            window.URL.revokeObjectURL(url);
+                          } catch (error) {
+                            console.error(error);
+                          }
+                        }}
+                      >
+                        CSV
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        justifyContent="flex-start"
+                        borderRadius={0}
+                        py={2}
+                        onClick={async (e) => {
+                          e.stopPropagation();
+                          try {
+                            const response = await fetch(
+                              `${getApiBaseUrl()}/admin/comments/${report.slug}/csv`,
+                              {
+                                headers: {
+                                  "x-api-key":
+                                    process.env.NEXT_PUBLIC_ADMIN_API_KEY || "",
+                                  "Content-Type": "application/json",
+                                },
+                              },
+                            );
+                            if (!response.ok) {
+                              const errorData = await response.json();
+                              throw new Error(errorData.detail || "CSV ダウンロードに失敗しました");
+                            }
+                            const blob = await response.blob();
+                            const text = await blob.text();
+                            // UTF-8 BOMを追加
+                            const bom = "\uFEFF";
+                            const bomBlob = new Blob([bom + text], { type: "text/csv;charset=utf-8" });
+                            const url = window.URL.createObjectURL(bomBlob);
+                            const link = document.createElement("a");
+                            link.href = url;
+                            link.download = `kouchou_${report.slug}_excel.csv`;
+                            link.click();
+                            window.URL.revokeObjectURL(url);
+                          } catch (error) {
+                            console.error(error);
+                          }
+                        }}
+                      >
+                        CSV for Excel(Windows)
+                      </Button>
+                    </VStack>
+                  </Popover.Body>
+                </Popover.Content>
+              </Popover.Root>
             )}
             {report.status === "ready" && (
               <>

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -11374,6 +11374,96 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "15.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.2.3.tgz",
+      "integrity": "sha512-uaBhA8aLbXLqwjnsHSkxs353WrRgQgiFjduDpc7YXEU0B54IKx3vU+cxQlYwPCyC8uYEEX7THhtQQsfHnvv8dw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "15.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.2.3.tgz",
+      "integrity": "sha512-pVwKvJ4Zk7h+4hwhqOUuMx7Ib02u3gDX3HXPKIShBi9JlYllI0nU6TWLbPT94dt7FSi6mSBhfc2JrHViwqbOdw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "15.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.2.3.tgz",
+      "integrity": "sha512-50ibWdn2RuFFkOEUmo9NCcQbbV9ViQOrUfG48zHBCONciHjaUKtHcYFiCwBVuzD08fzvzkWuuZkd4AqbvKO7UQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "15.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.2.3.tgz",
+      "integrity": "sha512-2gAPA7P652D3HzR4cLyAuVYwYqjG0mt/3pHSWTCyKZq/N/dJcUAEoNQMyUmwTZWCJRKofB+JPuDVP2aD8w2J6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "15.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.2.3.tgz",
+      "integrity": "sha512-+G2FrDcfm2YDbhDiObDU/qPriWeiz/9cRR0yMWJeTLGGX6/x8oryO3tt7HhodA1vZ8r2ddJPCjtLcpaVl7TE2Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "15.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.2.3.tgz",
+      "integrity": "sha512-gHYS9tc+G2W0ZC8rBL+H6RdtXIyk40uLiaos0yj5US85FNhbFEndMA2nW3z47nzOWiSvXTZ5kBClc3rD0zJg0w==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   }
 }


### PR DESCRIPTION
# 変更の概要
- CSVダウンロードボタンを押してCSVをダウンロードするのを、Popoverを表示して通常CSVとUTF-8 BOM (Byte Order Mark) 付きのCSVを選んでダウンロードできるようにした
- 通常のCSVは「CSV」で、BOM付きは「CSV for Excel (Windows)」とした
- UTF-8 BoM付きCSVは `original-name_excel.csv` のような形式でダウンロードする

![](https://i.gyazo.com/c900123a1fdd45ee8ced48243eba6aa4.png)

# 変更の背景
- WindowsユーザーがExcelを開くとBOM付きでないCSVは文字化けする問題がある
- 「UTF-8 BOM」という表記は非技術者に伝わりづらいため、CSV for Excel (Windows)と表現した。

# 関連Issue
#297

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました