### PR TITLE
CSVダウンロード機能に用いるcsvを、Azure Blob Storage連携時の削除対象から除外

### DIFF
--- a/server/src/services/report_sync.py
+++ b/server/src/services/report_sync.py
@@ -41,7 +41,7 @@ class ReportSyncService:
         try:
             for root, _, files in os.walk(report_dir):
                 for file in files:
-                    # 保持すべきファイル（JSONとrelations.csv）は残し、それ以外は削除
+                    # 保持すべきファイルは残し、それ以外は削除
                     if not file.endswith(self.PRESERVED_REPORT_FILES):
                         file_path = os.path.join(root, file)
                         os.remove(file_path)

--- a/server/src/services/report_sync.py
+++ b/server/src/services/report_sync.py
@@ -15,6 +15,7 @@ class ReportSyncService:
     REMOTE_STATUS_FILE_PREFIX = "status"
     REMOTE_CONFIG_DIR_PREFIX = "configs"
     LOCAL_STATUS_FILE_PATH = settings.DATA_DIR / "report_status.json"
+    PRESERVED_REPORT_FILES = (".json", "final_result_with_comments.csv")
 
     def __init__(self):
         self.storage_service = get_storage_service()
@@ -29,7 +30,7 @@ class ReportSyncService:
         self.storage_service.upload_file(str(self.LOCAL_STATUS_FILE_PATH), remote_status_file_path)
 
     def _cleanup_report_files(self, report_dir: Path) -> bool:
-        """レポートディレクトリからJSONファイル以外を削除する
+        """レポートディレクトリから保持すべきファイル以外を削除する
 
         Args:
             report_dir: 削除対象のレポートディレクトリパス
@@ -40,13 +41,13 @@ class ReportSyncService:
         try:
             for root, _, files in os.walk(report_dir):
                 for file in files:
-                    # JSONファイルはレポートの描画に必要なため残し、それ以外は削除
-                    if not file.endswith(".json"):
+                    # 保持すべきファイル（JSONとrelations.csv）は残し、それ以外は削除
+                    if not file.endswith(self.PRESERVED_REPORT_FILES):
                         file_path = os.path.join(root, file)
                         os.remove(file_path)
                         logger.info(f"ファイルを削除しました: {file_path}")
 
-            logger.info(f"レポートディレクトリからJSONファイル以外を削除しました: {report_dir}")
+            logger.info(f"レポートディレクトリから保持すべきファイル以外を削除しました: {report_dir}")
             return True
         except Exception as e:
             logger.error(f"レポートディレクトリのクリーンアップに失敗しました: {report_dir} エラー: {str(e)}")
@@ -70,7 +71,7 @@ class ReportSyncService:
             return False
 
     def sync_report_files_to_storage(self, slug: str) -> None:
-        """レポートの中間ファイルと結果ファイルをストレージにアップロードし、JSONファイル以外を削除する"""
+        """レポートの中間ファイルと結果ファイルをストレージにアップロードし、保持すべきファイル以外を削除する"""
 
         report_dir = settings.REPORT_DIR / slug
         if not report_dir.exists():
@@ -83,7 +84,7 @@ class ReportSyncService:
         # ファイルをストレージにアップロード
         upload_success = self.storage_service.upload_directory(str(local_dir), remote_dir_prefix)
 
-        # アップロードが成功した場合、JSONファイル以外を削除
+        # アップロードが成功した場合、保持すべきファイル以外を削除
         if upload_success:
             self._cleanup_report_files(local_dir)
 
@@ -150,7 +151,7 @@ class ReportSyncService:
             self.storage_service.download_directory(
                 str(self.REMOTE_REPORT_DIR_PREFIX),
                 str(settings.REPORT_DIR),
-                target_suffixes=("json",),
+                target_suffixes=self.PRESERVED_REPORT_FILES,
             )
             return True
         except FileNotFoundError:

--- a/server/tests/services/test_report_sync.py
+++ b/server/tests/services/test_report_sync.py
@@ -173,7 +173,7 @@ class TestReportSyncService:
         mock_storage_service.download_directory.assert_called_once_with(
             str(report_sync_service.REMOTE_REPORT_DIR_PREFIX),
             str(settings.REPORT_DIR),
-            target_suffixes=("json",),
+            target_suffixes=report_sync_service.PRESERVED_REPORT_FILES,
         )
 
     def test_download_all_report_results_from_storage_file_not_found(


### PR DESCRIPTION
# 変更の概要
* CSVダウンロード機能に用いるcsv( `final_result_with_comments.csv` )を、Azure Blob Storage連携時の削除対象から除外
  * 従来は誤って削除対象になっていた
* アプリ起動時の同期対象に同ファイルを含めるよう修正

# 変更の背景
ストレージ連携をしている場合は、ストレージに出力ファイル等をアップロードをした後に容量節約のために不要なファイルを削除しているが、その際に当該のCSVファイルも削除されてしまっているためDLできなくなっていた。
当該ファイルはAzure Blob Storage上には保存されているが、アプリ起動時の同期対象からも外れておりアプリ上には存在しないため、アプリの再起動やコンテナの更新を行った場合もDLできなくなっていた。
ストレージにはcsvは保管されているので、今回の修正を反映した上でアプリ（コンテナ）を再起動すれば、以降はCSVをDLできるようになる。


# 関連Issue
Close https://github.com/digitaldemocracy2030/kouchou-ai/issues/325

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました