### PR TITLE
第1階層の意見グループ数の上限を 20 -> 40に増加

### DIFF
--- a/client-admin/app/create/page.tsx
+++ b/client-admin/app/create/page.tsx
@@ -773,11 +773,11 @@ export default function Page() {
                     type="number"
                     value={clusterLv1.toString()}
                     min={2}
-                    max={20}
+                    max={40}
                     onChange={(e) => {
                       const v = Number(e.target.value);
                       if (!Number.isNaN(v)) {
-                        const newClusterLv1 = Math.max(2, Math.min(20, v));
+                        const newClusterLv1 = Math.max(2, Math.min(40, v));
                         setClusterLv1(newClusterLv1);
 
                         // 第一階層のクラスタ数 * 2 > 第二階層のクラスタ数の場合のみ、第二階層の値を更新
@@ -791,7 +791,7 @@ export default function Page() {
                   />
                   <Button
                     onClick={() => {
-                      const newClusterLv1 = Math.min(20, clusterLv1 + 1);
+                      const newClusterLv1 = Math.min(40, clusterLv1 + 1);
                       setClusterLv1(newClusterLv1);
 
                       // 第一階層のクラスタ数 * 2 > 第二階層のクラスタ数の場合のみ、第二階層の値を更新


### PR DESCRIPTION
# 変更の概要
- 第1階層の意見グループ数の上限を 20 -> 40に増やした

# 変更の背景
* 現在、全体図などの散布図において意見グループの個数上限は20となっている
  * ラベルが重なってしまう問題があったため上限を20にしていたが、この問題は回避策のPR（ https://github.com/digitaldemocracy2030/kouchou-ai/pull/329 ）が出されている

# 備考
 https://github.com/digitaldemocracy2030/kouchou-ai/pull/329 がmergeされた後にmergeする
特に論点ないと思われるので、self mergeします

# 関連Issue
close https://github.com/digitaldemocracy2030/kouchou-ai/issues/330

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました