### PR TITLE
make azure-cleanup 時に確認メッセージを出す

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -491,6 +491,13 @@ azure-restart-admin:
 # リソースの完全削除
 azure-cleanup:
 	$(call read-env)
+	@echo "警告: この操作はリソースグループ $(AZURE_RESOURCE_GROUP) を完全に削除します。"
+	@echo "この操作は元に戻せません。すべてのサービスやデータが失われます。"
+	@read -p "本当に削除しますか？ [y/N]: " confirm; \
+	if [ "$$confirm" != "y" ] && [ "$$confirm" != "Y" ]; then \
+	    echo "操作をキャンセルしました。"; \
+	    exit 1; \
+	fi
 	docker run -it --rm -v $(HOME)/.azure:/root/.azure mcr.microsoft.com/azure-cli az group delete --name $(AZURE_RESOURCE_GROUP) --yes
 
 # ヘルスチェック設定とイメージプルポリシーの適用


### PR DESCRIPTION
# 変更の概要
- make azure-cleanup 時に確認メッセージを出すようにします

# 変更の背景
- make azure-cleaup は、作成した Azure 環境をすべて削除するコマンドのため、誤って実行したときのために確認メッセージを出したほうがよいのではないか？と思いました
- 別件の作業時に make azure-cleanup を実行する機会があり、その際に気が付きました

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました