### PR TITLE
client-admin/app/create/page.tsx のリファクタリング

### DIFF
--- a/client-admin/app/create/api/report.ts
+++ b/client-admin/app/create/api/report.ts
@@ -1,0 +1,63 @@
+import { CsvData } from "../parseCsv";
+import { PromptSettings } from "../types";
+import { handleApiError } from "../utils/error-handler";
+
+/**
+ * レポート作成APIを呼び出す
+ */
+export async function createReport({
+  input,
+  question,
+  intro,
+  comments,
+  cluster,
+  model,
+  workers,
+  prompt,
+  is_pubcom,
+  inputType,
+}: {
+  input: string;
+  question: string;
+  intro: string;
+  comments: CsvData[];
+  cluster: [number, number];
+  model: string;
+  workers: number;
+  prompt: PromptSettings;
+  is_pubcom: boolean;
+  inputType: string;
+}): Promise<void> {
+  try {
+    const response = await fetch(
+      `${process.env.NEXT_PUBLIC_API_BASEPATH}/admin/reports`,
+      {
+        method: "POST",
+        headers: {
+          "x-api-key": process.env.NEXT_PUBLIC_ADMIN_API_KEY || "",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          input,
+          question,
+          intro,
+          comments,
+          cluster,
+          model,
+          workers,
+          prompt,
+          is_pubcom,
+          inputType,
+        }),
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error(response.statusText);
+    }
+
+    return;
+  } catch (error) {
+    throw handleApiError(error, "レポート作成に失敗しました");
+  }
+}

--- a/client-admin/app/create/api/spreadsheet.ts
+++ b/client-admin/app/create/api/spreadsheet.ts
@@ -1,0 +1,82 @@
+import { SpreadsheetComment } from "../types";
+import { handleApiError } from "../utils/error-handler";
+
+/**
+ * スプレッドシートをインポートする
+ */
+export async function importSpreadsheet(url: string, fileName: string): Promise<void> {
+  try {
+    const response = await fetch(
+      `${process.env.NEXT_PUBLIC_API_BASEPATH}/admin/spreadsheet/import`,
+      {
+        method: "POST",
+        headers: {
+          "x-api-key": process.env.NEXT_PUBLIC_ADMIN_API_KEY || "",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          url,
+          file_name: fileName,
+        }),
+      }
+    );
+
+    if (!response.ok) {
+      const errorData = await response.json();
+      throw new Error(errorData.detail || "不明なエラーが発生しました");
+    }
+
+    return await response.json();
+  } catch (error) {
+    throw handleApiError(error, "スプレッドシートのインポートに失敗しました");
+  }
+}
+
+/**
+ * スプレッドシートのデータを取得する
+ */
+export async function getSpreadsheetData(id: string): Promise<{ comments: SpreadsheetComment[] }> {
+  try {
+    const response = await fetch(
+      `${process.env.NEXT_PUBLIC_API_BASEPATH}/admin/spreadsheet/data/${id}`,
+      {
+        headers: {
+          "x-api-key": process.env.NEXT_PUBLIC_ADMIN_API_KEY || "",
+        },
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error("スプレッドシートデータの取得に失敗しました");
+    }
+
+    return await response.json();
+  } catch (error) {
+    throw handleApiError(error, "スプレッドシートデータの取得に失敗しました");
+  }
+}
+
+/**
+ * スプレッドシートのデータを削除する
+ */
+export async function deleteSpreadsheetData(id: string): Promise<void> {
+  try {
+    const response = await fetch(
+      `${process.env.NEXT_PUBLIC_API_BASEPATH}/admin/inputs/${id}`,
+      {
+        method: "DELETE",
+        headers: {
+          "x-api-key": process.env.NEXT_PUBLIC_ADMIN_API_KEY || "",
+        },
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error("データのクリアに失敗しました");
+    }
+
+    return;
+  } catch (error) {
+    throw handleApiError(error, "データのクリアに失敗しました");
+  }
+}

--- a/client-admin/app/create/components/AISettingsSection.tsx
+++ b/client-admin/app/create/components/AISettingsSection.tsx
@@ -1,0 +1,153 @@
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+    Button,
+    Field,
+    HStack,
+    Input,
+    NativeSelect,
+    Textarea,
+    VStack
+} from "@chakra-ui/react";
+import { usePromptSettings } from "../hooks/usePromptSettings";
+
+/**
+ * AI設定セクションコンポーネント
+ */
+export function AISettingsSection({
+  model,
+  workers,
+  isPubcomMode,
+  onModelChange,
+  onWorkersChange,
+  onIncreaseWorkers,
+  onDecreaseWorkers,
+  onPubcomModeChange,
+  getModelDescription,
+}: {
+  model: string;
+  workers: number;
+  isPubcomMode: boolean;
+  onModelChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
+  onWorkersChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onIncreaseWorkers: () => void;
+  onDecreaseWorkers: () => void;
+  onPubcomModeChange: (checked: boolean | "indeterminate") => void;
+  getModelDescription: () => string;
+}) {
+  // プロンプト設定のカスタムフック
+  const promptSettings = usePromptSettings();
+
+  return (
+    <VStack gap={10}>
+      <Field.Root>
+        <Checkbox
+          checked={isPubcomMode}
+          onCheckedChange={(details) => {
+            const { checked } = details;
+            onPubcomModeChange(checked);
+          }}
+        >
+          csv出力モード
+        </Checkbox>
+        <Field.HelperText>
+          元のコメントと要約された意見をCSV形式で出力します。完成したCSVファイルはレポート一覧ページからダウンロードできます。
+        </Field.HelperText>
+      </Field.Root>
+
+      <Field.Root>
+        <Field.Label>並列実行数</Field.Label>
+        <HStack>
+          <Button
+            onClick={onDecreaseWorkers}
+            variant="outline"
+          >
+            -
+          </Button>
+          <Input
+            type="number"
+            value={workers.toString()}
+            min={1}
+            max={100}
+            onChange={onWorkersChange}
+          />
+          <Button
+            onClick={onIncreaseWorkers}
+            variant="outline"
+          >
+            +
+          </Button>
+        </HStack>
+        <Field.HelperText>
+          OpenAI
+          APIの並列実行数です。値を大きくすることでレポート出力が速くなりますが、OpenAIアカウントのTierによってはレートリミットの上限に到達し、レポート出力が失敗する可能性があります。
+        </Field.HelperText>
+      </Field.Root>
+
+      <Field.Root>
+        <Field.Label>AIモデル</Field.Label>
+        <NativeSelect.Root w={"40%"}>
+          <NativeSelect.Field
+            value={model}
+            onChange={onModelChange}
+          >
+            <option value={"gpt-4o-mini"}>OpenAI GPT-4o mini</option>
+            <option value={"gpt-4o"}>OpenAI GPT-4o</option>
+            <option value={"o3-mini"}>OpenAI o3-mini</option>
+          </NativeSelect.Field>
+          <NativeSelect.Indicator />
+        </NativeSelect.Root>
+        <Field.HelperText>
+          {getModelDescription()}
+        </Field.HelperText>
+      </Field.Root>
+
+      <Field.Root>
+        <Field.Label>抽出プロンプト</Field.Label>
+        <Textarea
+          h={"150px"}
+          value={promptSettings.extraction}
+          onChange={(e) => promptSettings.setExtraction(e.target.value)}
+        />
+        <Field.HelperText>
+          AIに提示する抽出プロンプトです(通常は変更不要です)
+        </Field.HelperText>
+      </Field.Root>
+
+      <Field.Root>
+        <Field.Label>初期ラベリングプロンプト</Field.Label>
+        <Textarea
+          h={"150px"}
+          value={promptSettings.initialLabelling}
+          onChange={(e) => promptSettings.setInitialLabelling(e.target.value)}
+        />
+        <Field.HelperText>
+          AIに提示する初期ラベリングプロンプトです(通常は変更不要です)
+        </Field.HelperText>
+      </Field.Root>
+
+      <Field.Root>
+        <Field.Label>統合ラベリングプロンプト</Field.Label>
+        <Textarea
+          h={"150px"}
+          value={promptSettings.mergeLabelling}
+          onChange={(e) => promptSettings.setMergeLabelling(e.target.value)}
+        />
+        <Field.HelperText>
+          AIに提示する統合ラベリングプロンプトです(通常は変更不要です)
+        </Field.HelperText>
+      </Field.Root>
+
+      <Field.Root>
+        <Field.Label>要約プロンプト</Field.Label>
+        <Textarea
+          h={"150px"}
+          value={promptSettings.overview}
+          onChange={(e) => promptSettings.setOverview(e.target.value)}
+        />
+        <Field.HelperText>
+          AIに提示する要約プロンプトです(通常は変更不要です)
+        </Field.HelperText>
+      </Field.Root>
+    </VStack>
+  );
+}

--- a/client-admin/app/create/components/BasicInfoSection.tsx
+++ b/client-admin/app/create/components/BasicInfoSection.tsx
@@ -1,0 +1,69 @@
+import { Field, Input, Text } from "@chakra-ui/react";
+
+/**
+ * 基本情報セクションコンポーネント
+ */
+export function BasicInfoSection({
+  input,
+  question,
+  intro,
+  isIdValid,
+  onIdChange,
+  onQuestionChange,
+  onIntroChange,
+}: {
+  input: string;
+  question: string;
+  intro: string;
+  isIdValid: boolean;
+  onIdChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onQuestionChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onIntroChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}) {
+  return (
+    <>
+      <Field.Root>
+        <Field.Label>タイトル</Field.Label>
+        <Input
+          value={question}
+          onChange={onQuestionChange}
+          placeholder="例：人類が人工知能を開発・展開する上で、最優先すべき課題は何でしょうか？"
+        />
+        <Field.HelperText>レポートのタイトルを記載します</Field.HelperText>
+      </Field.Root>
+
+      <Field.Root>
+        <Field.Label>調査概要</Field.Label>
+        <Input
+          value={intro}
+          onChange={onIntroChange}
+          placeholder="例：このAI生成レポートは、パブリックコメントにおいて寄せられた意見に基づいています。"
+        />
+        <Field.HelperText>
+          コメントの集計期間や、コメントの収集元など、調査の概要を記載します
+        </Field.HelperText>
+      </Field.Root>
+
+      <Field.Root>
+        <Field.Label>ID</Field.Label>
+        <Input
+          w={"40%"}
+          value={input}
+          onChange={onIdChange}
+          placeholder="例：example"
+          aria-invalid={!isIdValid}
+          borderColor={!isIdValid ? "red.300" : undefined}
+          _hover={!isIdValid ? { borderColor: "red.400" } : undefined}
+        />
+        {!isIdValid && (
+          <Text color="red.500" fontSize="sm" mt={1}>
+            IDは英小文字、数字、ハイフンのみ使用できます
+          </Text>
+        )}
+        <Field.HelperText>
+          英字小文字と数字とハイフンのみ(URLで利用されます)
+        </Field.HelperText>
+      </Field.Root>
+    </>
+  );
+}

--- a/client-admin/app/create/components/ClusterSettingsSection.tsx
+++ b/client-admin/app/create/components/ClusterSettingsSection.tsx
@@ -1,0 +1,95 @@
+import { Button, Field, HStack, Input, Text } from "@chakra-ui/react";
+import { ChevronRightIcon } from "lucide-react";
+import { ClusterSettings } from "../types";
+
+// クラスタ設定コンポーネント
+export function ClusterSettingsSection({
+  clusterLv1,
+  clusterLv2,
+  recommendedClusters,
+  autoAdjusted,
+  onLv1Change,
+  onLv2Change
+}: {
+  clusterLv1: number;
+  clusterLv2: number;
+  recommendedClusters: ClusterSettings | null;
+  autoAdjusted: boolean;
+  onLv1Change: (value: number) => void;
+  onLv2Change: (value: number) => void;
+}) {
+  if (!recommendedClusters) return null;
+
+  return (
+    <Field.Root mt={4}>
+      <Field.Label>クラスタ数設定</Field.Label>
+      <HStack w={"100%"}>
+        <Button
+          onClick={() => onLv1Change(clusterLv1 - 1)}
+          variant="outline"
+        >
+          -
+        </Button>
+        <Input
+          type="number"
+          value={clusterLv1.toString()}
+          min={2}
+          max={20}
+          onChange={(e) => {
+            const v = Number(e.target.value);
+            if (!Number.isNaN(v)) {
+              onLv1Change(v);
+            }
+          }}
+        />
+        <Button
+          onClick={() => onLv1Change(clusterLv1 + 1)}
+          variant="outline"
+        >
+          +
+        </Button>
+        <ChevronRightIcon width="100px" />
+        <Button
+          onClick={() => onLv2Change(clusterLv2 - 1)}
+          variant="outline"
+        >
+          -
+        </Button>
+        <Input
+          type="number"
+          value={clusterLv2.toString()}
+          min={2}
+          max={1000}
+          onChange={(e) => {
+            const inputValue = e.target.value;
+            if (inputValue === "") return;
+            const v = Number(inputValue);
+            if (!Number.isNaN(v)) {
+              onLv2Change(v);
+            }
+          }}
+          onBlur={(e) => {
+            const v = Number(e.target.value);
+            if (!Number.isNaN(v)) {
+              onLv2Change(v);
+            }
+          }}
+        />
+        <Button
+          onClick={() => onLv2Change(clusterLv2 + 1)}
+          variant="outline"
+        >
+          +
+        </Button>
+      </HStack>
+      <Field.HelperText>
+        階層ごとの意見グループ生成数です。初期値はコメント数に基づいた推奨クラスタ数です。
+      </Field.HelperText>
+      {autoAdjusted && (
+        <Text color="orange.500" fontSize="sm" mt={2}>
+          第2階層の意見グループ数が自動調整されました。第2階層の意見グループ数は第1階層の意見グループ数の2倍以上に設定してください。
+        </Text>
+      )}
+    </Field.Root>
+  );
+}

--- a/client-admin/app/create/components/CommentColumnSelector.tsx
+++ b/client-admin/app/create/components/CommentColumnSelector.tsx
@@ -1,0 +1,37 @@
+import { Field, NativeSelect } from "@chakra-ui/react";
+
+// コメントカラム選択コンポーネント
+export function CommentColumnSelector({
+  columns,
+  selectedColumn,
+  onColumnChange
+}: {
+  columns: string[];
+  selectedColumn: string;
+  onColumnChange: (column: string) => void;
+}) {
+  if (columns.length === 0) return null;
+
+  return (
+    <Field.Root mt={4}>
+      <Field.Label>コメントカラム選択</Field.Label>
+      <NativeSelect.Root w={"60%"}>
+        <NativeSelect.Field
+          value={selectedColumn}
+          onChange={(e) => onColumnChange(e.target.value)}
+        >
+          <option value="">選択してください</option>
+          {columns.map((col) => (
+            <option key={col} value={col}>
+              {col}
+            </option>
+          ))}
+        </NativeSelect.Field>
+        <NativeSelect.Indicator />
+      </NativeSelect.Root>
+      <Field.HelperText>
+        分析対象のコメントが含まれるカラムを選んでください（それ以外のカラムは無視されます）。
+      </Field.HelperText>
+    </Field.Root>
+  );
+}

--- a/client-admin/app/create/components/CsvFileTab.tsx
+++ b/client-admin/app/create/components/CsvFileTab.tsx
@@ -1,0 +1,104 @@
+import { FileUploadDropzone, FileUploadList, FileUploadRoot } from "@/components/ui/file-upload";
+import { Box, Tabs, VStack } from "@chakra-ui/react";
+import { DownloadIcon } from "lucide-react";
+import Link from "next/link";
+import { useClusterSettings } from "../hooks/useClusterSettings";
+import { parseCsv } from "../parseCsv";
+import { ClusterSettingsSection } from "./ClusterSettingsSection";
+import { CommentColumnSelector } from "./CommentColumnSelector";
+
+// CSVファイルタブコンポーネント
+export function CsvFileTab({
+  csv,
+  setCsv,
+  csvColumns,
+  setCsvColumns,
+  selectedCommentColumn,
+  setSelectedCommentColumn,
+  clusterSettings
+}: {
+  csv: File | null;
+  setCsv: (file: File | null) => void;
+  csvColumns: string[];
+  setCsvColumns: (columns: string[]) => void;
+  selectedCommentColumn: string;
+  setSelectedCommentColumn: (column: string) => void;
+  clusterSettings: ReturnType<typeof useClusterSettings>;
+}) {
+  return (
+    <Tabs.Content value="file">
+      <VStack alignItems="stretch" w="full">
+        <Link
+          href="/sample_comments.csv"
+          download
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: "4px",
+            marginLeft: "8px",
+            textDecoration: "underline",
+            fontSize: "0.8rem",
+          }}
+        >
+          <DownloadIcon size={14} />
+          サンプルCSVをダウンロード
+        </Link>
+        <FileUploadRoot
+          w={"full"}
+          alignItems="stretch"
+          accept={["text/csv"]}
+          inputProps={{ multiple: false }}
+          onFileChange={async (e) => {
+            const file = e.acceptedFiles[0];
+            setCsv(file);
+            if (file) {
+              const parsed = await parseCsv(file);
+              if (parsed.length > 0) {
+                const columns = Object.keys(parsed[0]);
+                setCsvColumns(columns);
+                if (columns.includes("comment")) {
+                  setSelectedCommentColumn("comment");
+                }
+                clusterSettings.setRecommended(parsed.length);
+              }
+            }
+          }}
+        >
+          <Box
+            opacity={csv ? 0.5 : 1}
+            pointerEvents={csv ? "none" : "auto"}
+          >
+            <FileUploadDropzone
+              label="分析するコメントファイルを選択してください"
+              description=".csv"
+            />
+          </Box>
+          <FileUploadList
+            clearable={true}
+            onRemove={() => {
+              setCsv(null);
+              setCsvColumns([]);
+              setSelectedCommentColumn("");
+              clusterSettings.resetClusterSettings();
+            }}
+          />
+        </FileUploadRoot>
+        
+        <CommentColumnSelector
+          columns={csvColumns}
+          selectedColumn={selectedCommentColumn}
+          onColumnChange={setSelectedCommentColumn}
+        />
+        
+        <ClusterSettingsSection
+          clusterLv1={clusterSettings.clusterLv1}
+          clusterLv2={clusterSettings.clusterLv2}
+          recommendedClusters={clusterSettings.recommendedClusters}
+          autoAdjusted={clusterSettings.autoAdjusted}
+          onLv1Change={clusterSettings.handleLv1Change}
+          onLv2Change={clusterSettings.handleLv2Change}
+        />
+      </VStack>
+    </Tabs.Content>
+  );
+}

--- a/client-admin/app/create/components/SpreadsheetTab.tsx
+++ b/client-admin/app/create/components/SpreadsheetTab.tsx
@@ -1,0 +1,108 @@
+import { Button, Field, HStack, Input, Tabs, Text, VStack } from "@chakra-ui/react";
+import { useClusterSettings } from "../hooks/useClusterSettings";
+import { SpreadsheetComment } from "../types";
+import { ClusterSettingsSection } from "./ClusterSettingsSection";
+import { CommentColumnSelector } from "./CommentColumnSelector";
+
+// スプレッドシートタブコンポーネント
+export function SpreadsheetTab({
+  spreadsheetUrl,
+  setSpreadsheetUrl,
+  spreadsheetImported,
+  spreadsheetLoading,
+  spreadsheetData,
+  importedId,
+  canImport,
+  csvColumns,
+  selectedCommentColumn,
+  setSelectedCommentColumn,
+  clusterSettings,
+  onImport,
+  onClearData
+}: {
+  spreadsheetUrl: string;
+  setSpreadsheetUrl: (url: string) => void;
+  spreadsheetImported: boolean;
+  spreadsheetLoading: boolean;
+  spreadsheetData: SpreadsheetComment[];
+  importedId: string;
+  canImport: boolean; // 型を明示的にbooleanに修正
+  csvColumns: string[];
+  selectedCommentColumn: string;
+  setSelectedCommentColumn: (column: string) => void;
+  clusterSettings: ReturnType<typeof useClusterSettings>;
+  onImport: () => Promise<void>;
+  onClearData: () => Promise<void>;
+}) {
+  return (
+    <Tabs.Content value="spreadsheet">
+      <VStack alignItems="stretch" w="full" gap={4}>
+        <Field.Root>
+          <Field.Label>スプレッドシートURL</Field.Label>
+          <HStack
+            w="full"
+            flexDir={["column", "column", "row"]}
+            alignItems={["stretch", "stretch", "center"]}
+            gap={[2, 2, 4]}
+          >
+            <Input
+              flex="1"
+              value={spreadsheetUrl}
+              onChange={(e) => setSpreadsheetUrl(e.target.value)}
+              placeholder="https://docs.google.com/spreadsheets/d/xxxxxxxxxxxx/edit"
+              disabled={spreadsheetImported}
+            />
+            <Button
+              onClick={onImport}
+              loading={spreadsheetLoading}
+              disabled={!canImport}
+              whiteSpace="nowrap"
+              width={["full", "full", "auto"]}
+            >
+              {spreadsheetImported ? "取得済み" : "データを取得"}
+            </Button>
+          </HStack>
+          <Field.HelperText>
+            公開されているGoogleスプレッドシートのURLを入力してください
+            <br />
+          </Field.HelperText>
+          
+          <CommentColumnSelector
+            columns={csvColumns}
+            selectedColumn={selectedCommentColumn}
+            onColumnChange={setSelectedCommentColumn}
+          />
+          
+          <ClusterSettingsSection
+            clusterLv1={clusterSettings.clusterLv1}
+            clusterLv2={clusterSettings.clusterLv2}
+            recommendedClusters={clusterSettings.recommendedClusters}
+            autoAdjusted={clusterSettings.autoAdjusted}
+            onLv1Change={clusterSettings.handleLv1Change}
+            onLv2Change={clusterSettings.handleLv2Change}
+          />
+        </Field.Root>
+        
+        {spreadsheetImported && (
+          <Text color="green.500" fontSize="sm">
+            スプレッドシートのデータ {spreadsheetData.length}{" "}
+            件を取得しました
+          </Text>
+        )}
+
+        {spreadsheetImported && (
+          <Button
+            onClick={onClearData}
+            colorScheme="red"
+            variant="outline"
+            size="sm"
+            loading={spreadsheetLoading}
+            loadingText="クリア中..."
+          >
+            データをクリアして再入力
+          </Button>
+        )}
+      </VStack>
+    </Tabs.Content>
+  );
+}

--- a/client-admin/app/create/components/WarningSection.tsx
+++ b/client-admin/app/create/components/WarningSection.tsx
@@ -1,0 +1,23 @@
+import { Alert, Stack } from "@chakra-ui/react";
+
+/**
+ * 警告メッセージセクションコンポーネント
+ */
+export function WarningSection() {
+  return (
+    <Stack gap="4" width="full">
+      <Alert.Root status="warning">
+        <Alert.Indicator />
+        <Alert.Title>
+          レポートの作成には数分から数十分程度の時間がかかります
+        </Alert.Title>
+      </Alert.Root>
+      <Alert.Root status="warning">
+        <Alert.Indicator />
+        <Alert.Title>
+          作成が完了したレポートが一覧画面に反映されるまで5分程度かかります
+        </Alert.Title>
+      </Alert.Root>
+    </Stack>
+  );
+}

--- a/client-admin/app/create/hooks/useAISettings.ts
+++ b/client-admin/app/create/hooks/useAISettings.ts
@@ -1,0 +1,83 @@
+import { useState } from "react";
+
+/**
+ * AIモデル設定を管理するカスタムフック
+ */
+export function useAISettings() {
+  // AIモデル関連の状態
+  const [model, setModel] = useState<string>("gpt-4o-mini");
+  const [workers, setWorkers] = useState<number>(30);
+  const [isPubcomMode, setIsPubcomMode] = useState<boolean>(true);
+
+  /**
+   * ワーカー数変更時のハンドラー
+   */
+  const handleWorkersChange = (value: number) => {
+    setWorkers(Math.max(1, Math.min(100, value)));
+  };
+
+  /**
+   * ワーカー数増加ハンドラー
+   */
+  const increaseWorkers = () => {
+    setWorkers((prev) => Math.min(100, prev + 1));
+  };
+
+  /**
+   * ワーカー数減少ハンドラー
+   */
+  const decreaseWorkers = () => {
+    setWorkers((prev) => Math.max(1, prev - 1));
+  };
+
+  /**
+   * モデル変更時のハンドラー
+   */
+  const handleModelChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setModel(e.target.value);
+  };
+
+  /**
+   * パブコムモード変更時のハンドラー
+   */
+  const handlePubcomModeChange = (checked: boolean | "indeterminate") => {
+    if (checked === "indeterminate") return;
+    setIsPubcomMode(checked);
+  };
+
+  /**
+   * モデル説明文を取得
+   */
+  const getModelDescription = () => {
+    if (model === "gpt-4o-mini") {
+      return "GPT-4o mini：最も安価に利用できるモデルです。価格の詳細はOpenAIが公開しているAPI料金のページをご参照ください。";
+    } else if (model === "gpt-4o") {
+      return "GPT-4o：gpt-4o-miniと比較して高性能なモデルです。性能は高くなりますが、gpt-4o-miniと比較してOpenAI APIの料金は高くなります。";
+    } else if (model === "o3-mini") {
+      return "o3-mini：gpt-4oよりも高度な推論能力を備えたモデルです。性能はより高くなりますが、gpt-4oと比較してOpenAI APIの料金は高くなります。";
+    }
+    return "";
+  };
+
+  /**
+   * AI設定をリセット
+   */
+  const resetAISettings = () => {
+    setModel("gpt-4o-mini");
+    setWorkers(30);
+    setIsPubcomMode(true);
+  };
+
+  return {
+    model,
+    workers,
+    isPubcomMode,
+    handleModelChange,
+    handleWorkersChange,
+    increaseWorkers,
+    decreaseWorkers,
+    handlePubcomModeChange,
+    getModelDescription,
+    resetAISettings,
+  };
+}

--- a/client-admin/app/create/hooks/useBasicInfo.ts
+++ b/client-admin/app/create/hooks/useBasicInfo.ts
@@ -1,0 +1,58 @@
+import { useState } from "react";
+import { v4 } from "uuid";
+import { isValidId } from "../utils/validation";
+
+/**
+ * 基本情報を管理するカスタムフック
+ */
+export function useBasicInfo() {
+  // 基本情報の状態
+  const [input, setInput] = useState<string>(v4());
+  const [question, setQuestion] = useState<string>("");
+  const [intro, setIntro] = useState<string>("");
+  const [isIdValid, setIsIdValid] = useState<boolean>(true);
+
+  /**
+   * ID変更時のハンドラー
+   */
+  const handleIdChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newId = e.target.value;
+    setInput(newId);
+    setIsIdValid(isValidId(newId));
+  };
+
+  /**
+   * タイトル変更時のハンドラー
+   */
+  const handleQuestionChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setQuestion(e.target.value);
+  };
+
+  /**
+   * 調査概要変更時のハンドラー
+   */
+  const handleIntroChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setIntro(e.target.value);
+  };
+
+  /**
+   * 基本情報をリセット
+   */
+  const resetBasicInfo = () => {
+    setInput(v4());
+    setQuestion("");
+    setIntro("");
+    setIsIdValid(true);
+  };
+
+  return {
+    input,
+    question,
+    intro,
+    isIdValid,
+    handleIdChange,
+    handleQuestionChange,
+    handleIntroChange,
+    resetBasicInfo,
+  };
+}

--- a/client-admin/app/create/hooks/useClusterSettings.ts
+++ b/client-admin/app/create/hooks/useClusterSettings.ts
@@ -1,0 +1,95 @@
+import { useCallback, useState } from "react";
+import { ClusterSettings } from "../types";
+
+// カスタムフック: クラスタ設定の管理
+export function useClusterSettings(initialLv1 = 5, initialLv2 = 50) {
+  const [clusterLv1, setClusterLv1] = useState<number>(initialLv1);
+  const [clusterLv2, setClusterLv2] = useState<number>(initialLv2);
+  const [recommendedClusters, setRecommendedClusters] = useState<ClusterSettings | null>(null);
+  const [autoAdjusted, setAutoAdjusted] = useState<boolean>(false);
+
+  // コメント数からクラスタ数を計算
+  const calculateRecommendedClusters = useCallback((commentCount: number) => {
+    const lv1 = Math.max(2, Math.min(20, Math.round(Math.cbrt(commentCount))));
+    const lv2 = Math.max(2, Math.min(1000, Math.round(lv1 * lv1)));
+    return { lv1, lv2 };
+  }, []);
+
+  // 推奨クラスタ数を設定
+  const setRecommended = useCallback((commentCount: number) => {
+    const recommended = calculateRecommendedClusters(commentCount);
+    setRecommendedClusters(recommended);
+    setClusterLv1(recommended.lv1);
+    setClusterLv2(recommended.lv2);
+    return recommended;
+  }, [calculateRecommendedClusters]);
+
+  // クラスタLv1の値を変更
+  const handleLv1Change = useCallback((newValue: number) => {
+    const limitedValue = Math.max(2, Math.min(20, newValue));
+    setClusterLv1(limitedValue);
+
+    // 第一階層のクラスタ数 * 2 > 第二階層のクラスタ数の場合のみ、第二階層の値を更新
+    const newClusterLv2 = limitedValue * 2;
+    if (newClusterLv2 > clusterLv2) {
+      setClusterLv2(newClusterLv2);
+      setAutoAdjusted(true);
+      
+      // 推奨クラスタ数表示を更新（nullでない場合のみ）
+      if (recommendedClusters) {
+        setRecommendedClusters({
+          lv1: limitedValue,
+          lv2: newClusterLv2
+        });
+      }
+    } else if (recommendedClusters) {
+      setRecommendedClusters({
+        lv1: limitedValue,
+        lv2: clusterLv2
+      });
+    }
+  }, [clusterLv2, recommendedClusters]);
+
+  // クラスタLv2の値を変更
+  const handleLv2Change = useCallback((newValue: number) => {
+    let limitedValue = Math.max(2, Math.min(1000, newValue));
+
+    // 第二階層の値が第一階層の値の2倍未満の場合は自動調整
+    if (limitedValue < clusterLv1 * 2) {
+      limitedValue = clusterLv1 * 2;
+      setAutoAdjusted(true);
+    } else {
+      setAutoAdjusted(false);
+    }
+
+    setClusterLv2(limitedValue);
+    
+    // 推奨クラスタ数表示を更新（nullでない場合のみ）
+    if (recommendedClusters) {
+      setRecommendedClusters({
+        lv1: recommendedClusters.lv1,
+        lv2: limitedValue
+      });
+    }
+  }, [clusterLv1, recommendedClusters]);
+
+  // リセット
+  const resetClusterSettings = useCallback(() => {
+    setClusterLv1(initialLv1);
+    setClusterLv2(initialLv2);
+    setRecommendedClusters(null);
+    setAutoAdjusted(false);
+  }, [initialLv1, initialLv2]);
+
+  return {
+    clusterLv1,
+    clusterLv2,
+    recommendedClusters,
+    autoAdjusted,
+    calculateRecommendedClusters,
+    setRecommended,
+    handleLv1Change,
+    handleLv2Change,
+    resetClusterSettings
+  };
+}

--- a/client-admin/app/create/hooks/useInputData.ts
+++ b/client-admin/app/create/hooks/useInputData.ts
@@ -1,0 +1,189 @@
+import { toaster } from "@/components/ui/toaster";
+import { useCallback, useState } from "react";
+import { deleteSpreadsheetData, getSpreadsheetData, importSpreadsheet } from "../api/spreadsheet";
+import { parseCsv } from "../parseCsv";
+import { InputType, SpreadsheetComment } from "../types";
+import { showErrorToast } from "../utils/error-handler";
+
+/**
+ * 入力データを管理するカスタムフック
+ */
+export function useInputData(
+  onDataLoaded: (commentCount: number) => void
+) {
+  // 入力タイプの状態
+  const [inputType, setInputType] = useState<InputType>("file");
+  
+  // CSVファイル関連の状態
+  const [csv, setCsv] = useState<File | null>(null);
+  
+  // スプレッドシート関連の状態
+  const [spreadsheetUrl, setSpreadsheetUrl] = useState<string>("");
+  const [spreadsheetImported, setSpreadsheetImported] = useState<boolean>(false);
+  const [spreadsheetLoading, setSpreadsheetLoading] = useState<boolean>(false);
+  const [spreadsheetData, setSpreadsheetData] = useState<SpreadsheetComment[]>([]);
+  const [importedId, setImportedId] = useState<string>("");
+  
+  // カラム関連の状態
+  const [csvColumns, setCsvColumns] = useState<string[]>([]);
+  const [selectedCommentColumn, setSelectedCommentColumn] = useState<string>("");
+
+  /**
+   * CSVファイル変更時のハンドラー
+   */
+  const handleCsvChange = useCallback(async (file: File | null) => {
+    setCsv(file);
+    if (file) {
+      try {
+        const parsed = await parseCsv(file);
+        if (parsed.length > 0) {
+          const columns = Object.keys(parsed[0]);
+          setCsvColumns(columns);
+          if (columns.includes("comment")) {
+            setSelectedCommentColumn("comment");
+          }
+          onDataLoaded(parsed.length);
+        }
+      } catch (error) {
+        showErrorToast(toaster, error, "CSVファイルの読み込みに失敗しました");
+      }
+    } else {
+      setCsvColumns([]);
+      setSelectedCommentColumn("");
+    }
+  }, [onDataLoaded]);
+
+  /**
+   * スプレッドシートのインポート
+   */
+  const handleImportSpreadsheet = useCallback(async (id: string) => {
+    if (!spreadsheetUrl.trim()) {
+      toaster.create({
+        type: "error",
+        title: "入力エラー",
+        description: "スプレッドシートのURLを入力してください",
+      });
+      return;
+    }
+
+    setSpreadsheetLoading(true);
+    try {
+      await importSpreadsheet(spreadsheetUrl, id);
+      setImportedId(id);
+
+      // スプレッドシートのデータを取得
+      const commentData = await getSpreadsheetData(id);
+      setSpreadsheetData(commentData.comments);
+
+      if (commentData.comments.length > 0) {
+        const columns = Object.keys(commentData.comments[0]);
+        setCsvColumns(columns);
+        if (columns.includes("comment")) {
+          setSelectedCommentColumn("comment");
+        }
+      }
+
+      // 推奨クラスタ数を設定
+      onDataLoaded(commentData.comments.length);
+
+      toaster.create({
+        type: "success",
+        title: "成功",
+        description: `スプレッドシートのデータ ${commentData.comments.length} 件を取得しました`,
+      });
+      setSpreadsheetImported(true);
+    } catch (error) {
+      showErrorToast(toaster, error, "データ取得エラー");
+      setSpreadsheetImported(false);
+    } finally {
+      setSpreadsheetLoading(false);
+    }
+  }, [spreadsheetUrl, onDataLoaded]);
+
+  /**
+   * スプレッドシートデータのクリア
+   */
+  const handleClearSpreadsheetData = useCallback(async () => {
+    try {
+      setSpreadsheetLoading(true);
+      if (importedId) {
+        await deleteSpreadsheetData(importedId);
+      }
+
+      toaster.create({
+        type: "success",
+        title: "成功",
+        description: "データをクリアしました",
+      });
+    } catch (error) {
+      showErrorToast(toaster, error, "警告");
+    } finally {
+      // UIの状態をリセット
+      setSpreadsheetImported(false);
+      setSpreadsheetData([]);
+      setSpreadsheetLoading(false);
+      setImportedId("");
+      setSpreadsheetUrl("");
+      setSelectedCommentColumn("");
+      setCsvColumns([]);
+    }
+  }, [importedId]);
+
+  /**
+   * 入力タイプ変更時のハンドラー
+   */
+  const handleInputTypeChange = useCallback((newType: InputType) => {
+    setInputType(newType);
+
+    if (newType === "file" && csv) {
+      // CSVのカラムを再構築
+      parseCsv(csv).then((parsed) => {
+        if (parsed.length > 0) {
+          const columns = Object.keys(parsed[0]);
+          setCsvColumns(columns);
+          if (columns.includes("comment")) {
+            setSelectedCommentColumn("comment");
+          }
+          onDataLoaded(parsed.length);
+        }
+      });
+    } else if (newType === "spreadsheet" && spreadsheetData.length > 0) {
+      // スプレッドシートのカラムを再構築
+      const columns = Object.keys(spreadsheetData[0]);
+      setCsvColumns(columns);
+      if (columns.includes("comment")) {
+        setSelectedCommentColumn("comment");
+      }
+      onDataLoaded(spreadsheetData.length);
+    } else {
+      // データがない場合はカラムリセット
+      setCsvColumns([]);
+      setSelectedCommentColumn("");
+    }
+  }, [csv, spreadsheetData, onDataLoaded]);
+
+  /**
+   * スプレッドシートのインポートが可能かどうか
+   */
+  const canImport = spreadsheetUrl.trim() !== "" && !spreadsheetImported;
+
+  return {
+    inputType,
+    csv,
+    spreadsheetUrl,
+    spreadsheetImported,
+    spreadsheetLoading,
+    spreadsheetData,
+    importedId,
+    csvColumns,
+    selectedCommentColumn,
+    canImport,
+    setInputType: handleInputTypeChange,
+    setCsv: handleCsvChange,
+    setSpreadsheetUrl,
+    setSelectedCommentColumn,
+    setCsvColumns,
+    importSpreadsheet: handleImportSpreadsheet,
+    clearSpreadsheetData: handleClearSpreadsheetData,
+  };
+}

--- a/client-admin/app/create/hooks/usePromptSettings.ts
+++ b/client-admin/app/create/hooks/usePromptSettings.ts
@@ -1,0 +1,30 @@
+import { useState } from "react";
+import { extractionPrompt } from "../extractionPrompt";
+import { initialLabellingPrompt } from "../initialLabellingPrompt";
+import { mergeLabellingPrompt } from "../mergeLabellingPrompt";
+import { overviewPrompt } from "../overviewPrompt";
+
+// カスタムフック: プロンプト設定の管理
+export function usePromptSettings() {
+  const [extraction, setExtraction] = useState<string>(extractionPrompt);
+  const [initialLabelling, setInitialLabelling] = useState<string>(initialLabellingPrompt);
+  const [mergeLabelling, setMergeLabelling] = useState<string>(mergeLabellingPrompt);
+  const [overview, setOverview] = useState<string>(overviewPrompt);
+
+  return {
+    extraction,
+    initialLabelling,
+    mergeLabelling,
+    overview,
+    setExtraction,
+    setInitialLabelling,
+    setMergeLabelling,
+    setOverview,
+    getPromptSettings: () => ({
+      extraction,
+      initialLabelling,
+      mergeLabelling,
+      overview
+    })
+  };
+}

--- a/client-admin/app/create/page.tsx
+++ b/client-admin/app/create/page.tsx
@@ -1,273 +1,84 @@
 "use client";
 
 import { Header } from "@/components/Header";
-import { Checkbox } from "@/components/ui/checkbox";
 import { toaster } from "@/components/ui/toaster";
 import {
-  Alert,
   Box,
   Button,
   Field,
   HStack,
   Heading,
-  Input,
-  NativeSelect,
   Presence,
-  Stack,
   Tabs,
-  Text,
-  Textarea,
   VStack,
   useDisclosure,
 } from "@chakra-ui/react";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
-import { v4 } from "uuid";
+import { createReport } from "./api/report";
+import { AISettingsSection } from "./components/AISettingsSection";
+import { BasicInfoSection } from "./components/BasicInfoSection";
 import { CsvFileTab } from "./components/CsvFileTab";
 import { SpreadsheetTab } from "./components/SpreadsheetTab";
+import { WarningSection } from "./components/WarningSection";
+import { useAISettings } from "./hooks/useAISettings";
+import { useBasicInfo } from "./hooks/useBasicInfo";
 import { useClusterSettings } from "./hooks/useClusterSettings";
+import { useInputData } from "./hooks/useInputData";
 import { usePromptSettings } from "./hooks/usePromptSettings";
-import { type CsvData, parseCsv } from "./parseCsv";
-import { InputType, SpreadsheetComment } from "./types";
+import { CsvData, parseCsv } from "./parseCsv";
+import { showErrorToast } from "./utils/error-handler";
+import { validateFormValues } from "./utils/validation";
 
-// IDのバリデーション関数
-const isValidId = (id: string): boolean => {
-  return /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(id) && id.length <= 255;
-};
-
-// メインコンポーネント
+/**
+ * レポート作成ページ
+ */
 export default function Page() {
   const router = useRouter();
   const { open, onToggle } = useDisclosure();
   const [loading, setLoading] = useState<boolean>(false);
-  const [input, setInput] = useState<string>(v4());
-  const [importedId, setImportedId] = useState<string>("");
-  const [question, setQuestion] = useState<string>("");
-  const [intro, setIntro] = useState<string>("");
-  const [csv, setCsv] = useState<File | null>(null);
-  const [inputType, setInputType] = useState<InputType>("file");
-  const [spreadsheetUrl, setSpreadsheetUrl] = useState<string>("");
-  const [spreadsheetImported, setSpreadsheetImported] = useState<boolean>(false);
-  const [spreadsheetLoading, setSpreadsheetLoading] = useState<boolean>(false);
-  const [spreadsheetData, setSpreadsheetData] = useState<SpreadsheetComment[]>([]);
-  const [model, setModel] = useState<string>("gpt-4o-mini");
-  const [workers, setWorkers] = useState<number>(30);
-  const [isPubcomMode, setIsPubcomMode] = useState<boolean>(true);
-  const [csvColumns, setCsvColumns] = useState<string[]>([]);
-  const [selectedCommentColumn, setSelectedCommentColumn] = useState<string>("");
-  const [isIdValid, setIsIdValid] = useState<boolean>(true);
 
   // カスタムフックの使用
+  const basicInfo = useBasicInfo();
   const clusterSettings = useClusterSettings();
   const promptSettings = usePromptSettings();
+  const aiSettings = useAISettings();
+  const inputData = useInputData(clusterSettings.setRecommended);
 
-  // 入力変更時にバリデーションを実行
-  const handleIdChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const newId = e.target.value;
-    setInput(newId);
-    setIsIdValid(isValidId(newId));
+  /**
+   * タブ切り替え時の処理
+   */
+  const handleTabValueChange = (details: { value: string }) => {
+    inputData.setInputType(details.value as any);
   };
 
-  // canImportの型を明示的にbooleanにする
-  const canImport: boolean = spreadsheetUrl.trim() !== "" && isIdValid && !spreadsheetImported;
-
-  // スプレッドシートのインポート
-  const importSpreadsheet = async () => {
-    if (!canImport) {
-      toaster.create({
-        type: "error",
-        title: "入力エラー",
-        description: !isIdValid
-          ? "IDは英小文字、数字、ハイフンのみ使用できます"
-          : "スプレッドシートのURLを入力してください",
-      });
-      return;
-    }
-
-    setSpreadsheetLoading(true);
-    try {
-      const response = await fetch(
-        `${process.env.NEXT_PUBLIC_API_BASEPATH}/admin/spreadsheet/import`,
-        {
-          method: "POST",
-          headers: {
-            "x-api-key": process.env.NEXT_PUBLIC_ADMIN_API_KEY || "",
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            url: spreadsheetUrl,
-            file_name: input,
-          }),
-        },
-      );
-
-      if (!response.ok) {
-        const errorData = await response.json();
-        throw new Error(errorData.detail || "不明なエラーが発生しました");
-      }
-
-      await response.json();
-      setImportedId(input);
-
-      // スプレッドシートのデータを取得
-      const commentResponse = await fetch(
-        `${process.env.NEXT_PUBLIC_API_BASEPATH}/admin/spreadsheet/data/${input}`,
-        {
-          headers: {
-            "x-api-key": process.env.NEXT_PUBLIC_ADMIN_API_KEY || "",
-          },
-        },
-      );
-
-      if (!commentResponse.ok) {
-        throw new Error("スプレッドシートデータの取得に失敗しました");
-      }
-
-      const commentData = await commentResponse.json();
-      setSpreadsheetData(commentData.comments);
-
-      if (commentData.comments.length > 0) {
-        const columns = Object.keys(commentData.comments[0]);
-        setCsvColumns(columns);
-        if (columns.includes("comment")) {
-          setSelectedCommentColumn("comment");
-        }
-      }
-
-      // 推奨クラスタ数を設定
-      clusterSettings.setRecommended(commentData.comments.length);
-
-      toaster.create({
-        type: "success",
-        title: "成功",
-        description: `スプレッドシートのデータ ${commentData.comments.length} 件を取得しました`,
-      });
-      setSpreadsheetImported(true);
-    } catch (e) {
-      console.error(e);
-
-      // エラーメッセージを解析して、より適切な短いメッセージに変換
-      const errorMessage =
-        e instanceof Error ? e.message : "不明なエラーが発生しました";
-      let displayErrorMessage = "";
-
-      // URLやアクセス権限のエラー
-      if (
-        errorMessage.includes("Unauthorized") ||
-        errorMessage.includes("401")
-      ) {
-        displayErrorMessage =
-          "スプレッドシートへのアクセス権限がありません。公開設定を確認してください。";
-      }
-      // 存在しないシートなど
-      else if (
-        errorMessage.includes("404") ||
-        errorMessage.includes("Not Found")
-      ) {
-        displayErrorMessage =
-          "スプレッドシートが見つかりません。URLを確認してください。";
-      }
-      // スプレッドシート形式の問題
-      else if (
-        errorMessage.includes("comment") ||
-        errorMessage.includes("カラム")
-      ) {
-        displayErrorMessage =
-          "スプレッドシートの形式が正しくありません。commentカラムが必要です。";
-      }
-      // その他のエラー
-      else {
-        displayErrorMessage =
-          "スプレッドシートの取得に失敗しました。URLと公開設定を確認してください。";
-      }
-
-      toaster.create({
-        type: "error",
-        title: "データ取得エラー",
-        description: displayErrorMessage,
-      });
-      setSpreadsheetImported(false);
-    } finally {
-      setSpreadsheetLoading(false);
-    }
-  };
-
-  // スプレッドシートデータのクリア
-  const clearSpreadsheetData = async () => {
-    try {
-      setSpreadsheetLoading(true);
-      // サーバー側のデータを削除するAPI呼び出し - インポート時のIDを使用
-      const response = await fetch(
-        `${process.env.NEXT_PUBLIC_API_BASEPATH}/admin/inputs/${importedId}`,
-        {
-          method: "DELETE",
-          headers: {
-            "x-api-key": process.env.NEXT_PUBLIC_ADMIN_API_KEY || "",
-          },
-        },
-      );
-
-      if (!response.ok) {
-        throw new Error("データのクリアに失敗しました");
-      }
-
-      toaster.create({
-        type: "success",
-        title: "成功",
-        description: "データをクリアしました",
-      });
-    } catch (e) {
-      console.error(e);
-      toaster.create({
-        type: "warning",
-        title: "警告",
-        description: "サーバー側のデータクリアに失敗しましたが、入力をリセットしました",
-      });
-    } finally {
-      // UIの状態をリセット
-      setSpreadsheetImported(false);
-      setSpreadsheetData([]);
-      setSpreadsheetLoading(false);
-      setImportedId("");
-      setSpreadsheetUrl("");
-      setSelectedCommentColumn("");
-      setCsvColumns([]);
-    }
-  };
-
-  // レポート作成の送信
+  /**
+   * レポート作成の送信
+   */
   const onSubmit = async () => {
     setLoading(true);
 
-    const commonCheck = [
-      /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(input),
-      question.length > 0,
-      intro.length > 0,
-      clusterSettings.clusterLv1 > 0,
-      clusterSettings.clusterLv2 > 0,
-      model.length > 0,
-      promptSettings.extraction.length > 0,
-    ].every(Boolean);
+    // フォーム入力値のバリデーション
+    const validation = validateFormValues({
+      input: basicInfo.input,
+      question: basicInfo.question,
+      intro: basicInfo.intro,
+      clusterLv1: clusterSettings.clusterLv1,
+      clusterLv2: clusterSettings.clusterLv2,
+      model: aiSettings.model,
+      extractionPrompt: promptSettings.extraction,
+      inputType: inputData.inputType,
+      csv: inputData.csv,
+      spreadsheetImported: inputData.spreadsheetImported,
+      selectedCommentColumn: inputData.selectedCommentColumn,
+      csvColumns: inputData.csvColumns,
+    });
 
-    const sourceCheck =
-      (inputType === "file" && !!csv) ||
-      (inputType === "spreadsheet" && spreadsheetImported);
-
-    if (!commonCheck || !sourceCheck) {
+    if (!validation.isValid) {
       toaster.create({
         type: "error",
         title: "入力エラー",
-        description: "全ての項目が入力されているか確認してください",
-      });
-      setLoading(false);
-      return;
-    }
-    
-    if (csvColumns.length > 0 && !selectedCommentColumn) {
-      toaster.create({
-        type: "error",
-        title: "カラム未選択",
-        description: "コメントカラムを選択してください",
+        description: validation.errorMessage,
       });
       setLoading(false);
       return;
@@ -275,12 +86,12 @@ export default function Page() {
 
     let comments: CsvData[] = [];
     try {
-      if (inputType === "file" && csv) {
-        const parsed = await parseCsv(csv);
+      if (inputData.inputType === "file" && inputData.csv) {
+        const parsed = await parseCsv(inputData.csv);
         comments = parsed.map((row, index) => ({
           id: `csv-${index + 1}`,
           comment: (row as unknown as Record<string, unknown>)[
-            selectedCommentColumn
+            inputData.selectedCommentColumn
           ] as string,
           source: null,
           url: null,
@@ -297,11 +108,11 @@ export default function Page() {
             return;
           }
         }
-      } else if (inputType === "spreadsheet" && spreadsheetImported) {
-        comments = spreadsheetData.map((row, index) => ({
+      } else if (inputData.inputType === "spreadsheet" && inputData.spreadsheetImported) {
+        comments = inputData.spreadsheetData.map((row, index) => ({
           id: row.id || `spreadsheet-${index + 1}`,
           comment: (row as unknown as Record<string, unknown>)[
-            selectedCommentColumn
+            inputData.selectedCommentColumn
           ] as string,
           source: row.source || null,
           url: row.url || null,
@@ -319,36 +130,19 @@ export default function Page() {
 
     try {
       const promptData = promptSettings.getPromptSettings();
-      const payload = {
-        input,
-        question,
-        intro,
+      
+      await createReport({
+        input: basicInfo.input,
+        question: basicInfo.question,
+        intro: basicInfo.intro,
         comments,
         cluster: [clusterSettings.clusterLv1, clusterSettings.clusterLv2],
-        model,
-        workers,
+        model: aiSettings.model,
+        workers: aiSettings.workers,
         prompt: promptData,
-        is_pubcom: isPubcomMode,
-        inputType,
-      };
-
-      console.log("送信されるJSON:", payload);
-
-      const response = await fetch(
-        `${process.env.NEXT_PUBLIC_API_BASEPATH}/admin/reports`,
-        {
-          method: "POST",
-          headers: {
-            "x-api-key": process.env.NEXT_PUBLIC_ADMIN_API_KEY || "",
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify(payload),
-        },
-      );
-      
-      if (!response.ok) {
-        throw new Error(response.statusText);
-      }
+        is_pubcom: aiSettings.isPubcomMode,
+        inputType: inputData.inputType,
+      });
       
       toaster.create({
         duration: 5000,
@@ -358,48 +152,9 @@ export default function Page() {
       
       router.replace("/");
     } catch (e) {
-      console.error(e);
-      toaster.create({
-        duration: 5000,
-        type: "error",
-        title: "レポート作成に失敗しました",
-        description: "問題が解決しない場合は開発者に問い合わせください",
-      });
+      showErrorToast(toaster, e, "レポート作成に失敗しました");
     } finally {
       setLoading(false);
-    }
-  };
-
-  // タブ切り替え時の処理
-  const handleTabValueChange = (details: { value: string }) => {
-    const newType = details.value as InputType;
-    setInputType(newType);
-
-    if (newType === "file" && csv) {
-      // CSVのカラムを再構築
-      parseCsv(csv).then((parsed) => {
-        if (parsed.length > 0) {
-          const columns = Object.keys(parsed[0]);
-          setCsvColumns(columns);
-          if (columns.includes("comment")) {
-            setSelectedCommentColumn("comment");
-          }
-          clusterSettings.setRecommended(parsed.length);
-        }
-      });
-    } else if (newType === "spreadsheet" && spreadsheetData.length > 0) {
-      // スプレッドシートのカラムを再構築
-      const columns = Object.keys(spreadsheetData[0]);
-      setCsvColumns(columns);
-      if (columns.includes("comment")) {
-        setSelectedCommentColumn("comment");
-      }
-      clusterSettings.setRecommended(spreadsheetData.length);
-    } else {
-      // データがない場合はカラムリセット
-      setCsvColumns([]);
-      setSelectedCommentColumn("");
-      clusterSettings.resetClusterSettings();
     }
   };
 
@@ -413,33 +168,22 @@ export default function Page() {
         </Heading>
         <VStack gap={5}>
           {/* 基本情報セクション */}
-          <Field.Root>
-            <Field.Label>タイトル</Field.Label>
-            <Input
-              value={question}
-              onChange={(e) => setQuestion(e.target.value)}
-              placeholder="例：人類が人工知能を開発・展開する上で、最優先すべき課題は何でしょうか？"
-            />
-            <Field.HelperText>レポートのタイトルを記載します</Field.HelperText>
-          </Field.Root>
-          <Field.Root>
-            <Field.Label>調査概要</Field.Label>
-            <Input
-              value={intro}
-              onChange={(e) => setIntro(e.target.value)}
-              placeholder="例：このAI生成レポートは、パブリックコメントにおいて寄せられた意見に基づいています。"
-            />
-            <Field.HelperText>
-              コメントの集計期間や、コメントの収集元など、調査の概要を記載します
-            </Field.HelperText>
-          </Field.Root>
+          <BasicInfoSection
+            input={basicInfo.input}
+            question={basicInfo.question}
+            intro={basicInfo.intro}
+            isIdValid={basicInfo.isIdValid}
+            onIdChange={basicInfo.handleIdChange}
+            onQuestionChange={basicInfo.handleQuestionChange}
+            onIntroChange={basicInfo.handleIntroChange}
+          />
 
           {/* 入力データセクション */}
           <Field.Root>
             <Field.Label>入力データ</Field.Label>
             <Tabs.Root
               defaultValue="file"
-              value={inputType}
+              value={inputData.inputType}
               onValueChange={handleTabValueChange}
               variant="enclosed"
               width="100%"
@@ -455,30 +199,30 @@ export default function Page() {
               <Box p={4}>
                 {/* CSVファイルタブ */}
                 <CsvFileTab
-                  csv={csv}
-                  setCsv={setCsv}
-                  csvColumns={csvColumns}
-                  setCsvColumns={setCsvColumns}
-                  selectedCommentColumn={selectedCommentColumn}
-                  setSelectedCommentColumn={setSelectedCommentColumn}
+                  csv={inputData.csv}
+                  setCsv={inputData.setCsv}
+                  csvColumns={inputData.csvColumns}
+                  setCsvColumns={inputData.setCsvColumns}
+                  selectedCommentColumn={inputData.selectedCommentColumn}
+                  setSelectedCommentColumn={inputData.setSelectedCommentColumn}
                   clusterSettings={clusterSettings}
                 />
 
                 {/* スプレッドシートタブ */}
                 <SpreadsheetTab
-                  spreadsheetUrl={spreadsheetUrl}
-                  setSpreadsheetUrl={setSpreadsheetUrl}
-                  spreadsheetImported={spreadsheetImported}
-                  spreadsheetLoading={spreadsheetLoading}
-                  spreadsheetData={spreadsheetData}
-                  importedId={importedId}
-                  canImport={canImport}
-                  csvColumns={csvColumns}
-                  selectedCommentColumn={selectedCommentColumn}
-                  setSelectedCommentColumn={setSelectedCommentColumn}
+                  spreadsheetUrl={inputData.spreadsheetUrl}
+                  setSpreadsheetUrl={inputData.setSpreadsheetUrl}
+                  spreadsheetImported={inputData.spreadsheetImported}
+                  spreadsheetLoading={inputData.spreadsheetLoading}
+                  spreadsheetData={inputData.spreadsheetData}
+                  importedId={inputData.importedId}
+                  canImport={inputData.canImport}
+                  csvColumns={inputData.csvColumns}
+                  selectedCommentColumn={inputData.selectedCommentColumn}
+                  setSelectedCommentColumn={inputData.setSelectedCommentColumn}
                   clusterSettings={clusterSettings}
-                  onImport={importSpreadsheet}
-                  onClearData={clearSpreadsheetData}
+                  onImport={() => inputData.importSpreadsheet(basicInfo.input)}
+                  onClearData={inputData.clearSpreadsheetData}
                 />
               </Box>
             </Tabs.Root>
@@ -493,163 +237,26 @@ export default function Page() {
 
           {/* AI詳細設定セクション */}
           <Presence present={open} w={"full"}>
-            <VStack gap={10}>
-              <Field.Root>
-                <Field.Label>ID</Field.Label>
-                <Input
-                  w={"40%"}
-                  value={input}
-                  onChange={handleIdChange}
-                  placeholder="例：example"
-                  aria-invalid={!isIdValid}
-                  borderColor={!isIdValid ? "red.300" : undefined}
-                  _hover={!isIdValid ? { borderColor: "red.400" } : undefined}
-                />
-                {!isIdValid && (
-                  <Text color="red.500" fontSize="sm" mt={1}>
-                    IDは英小文字、数字、ハイフンのみ使用できます
-                  </Text>
-                )}
-                <Field.HelperText>
-                  英字小文字と数字とハイフンのみ(URLで利用されます)
-                </Field.HelperText>
-              </Field.Root>
-              <Field.Root>
-                <Checkbox
-                  checked={isPubcomMode}
-                  onCheckedChange={(details) => {
-                    const { checked } = details;
-                    if (checked === "indeterminate") return;
-                    setIsPubcomMode(checked);
-                  }}
-                >
-                  csv出力モード
-                </Checkbox>
-                <Field.HelperText>
-                  元のコメントと要約された意見をCSV形式で出力します。完成したCSVファイルはレポート一覧ページからダウンロードできます。
-                </Field.HelperText>
-              </Field.Root>
-              <Field.Root>
-                <Field.Label>並列実行数</Field.Label>
-                <HStack>
-                  <Button
-                    onClick={() => {
-                      setWorkers(Math.max(1, workers - 1));
-                    }}
-                    variant="outline"
-                  >
-                    -
-                  </Button>
-                  <Input
-                    type="number"
-                    value={workers.toString()}
-                    min={1}
-                    max={100}
-                    onChange={(e) => {
-                      const v = Number(e.target.value);
-                      if (!Number.isNaN(v)) {
-                        setWorkers(Math.max(1, Math.min(100, v)));
-                      }
-                    }}
-                  />
-                  <Button
-                    onClick={() => {
-                      setWorkers(Math.min(100, workers + 1));
-                    }}
-                    variant="outline"
-                  >
-                    +
-                  </Button>
-                </HStack>
-                <Field.HelperText>
-                  OpenAI
-                  APIの並列実行数です。値を大きくすることでレポート出力が速くなりますが、OpenAIアカウントのTierによってはレートリミットの上限に到達し、レポート出力が失敗する可能性があります。
-                </Field.HelperText>
-              </Field.Root>
-              <Field.Root>
-                <Field.Label>AIモデル</Field.Label>
-                <NativeSelect.Root w={"40%"}>
-                  <NativeSelect.Field
-                    value={model}
-                    onChange={(e) => setModel(e.target.value)}
-                  >
-                    <option value={"gpt-4o-mini"}>OpenAI GPT-4o mini</option>
-                    <option value={"gpt-4o"}>OpenAI GPT-4o</option>
-                    <option value={"o3-mini"}>OpenAI o3-mini</option>
-                  </NativeSelect.Field>
-                  <NativeSelect.Indicator />
-                </NativeSelect.Root>
-                <Field.HelperText>
-                  {model === "gpt-4o-mini" &&
-                    "GPT-4o mini：最も安価に利用できるモデルです。価格の詳細はOpenAIが公開しているAPI料金のページをご参照ください。"}
-                  {model === "gpt-4o" &&
-                    "GPT-4o：gpt-4o-miniと比較して高性能なモデルです。性能は高くなりますが、gpt-4o-miniと比較してOpenAI APIの料金は高くなります。"}
-                  {model === "o3-mini" &&
-                    "o3-mini：gpt-4oよりも高度な推論能力を備えたモデルです。性能はより高くなりますが、gpt-4oと比較してOpenAI APIの料金は高くなります。"}
-                </Field.HelperText>
-              </Field.Root>
-              <Field.Root>
-                <Field.Label>抽出プロンプト</Field.Label>
-                <Textarea
-                  h={"150px"}
-                  value={promptSettings.extraction}
-                  onChange={(e) => promptSettings.setExtraction(e.target.value)}
-                />
-                <Field.HelperText>
-                  AIに提示する抽出プロンプトです(通常は変更不要です)
-                </Field.HelperText>
-              </Field.Root>
-              <Field.Root>
-                <Field.Label>初期ラベリングプロンプト</Field.Label>
-                <Textarea
-                  h={"150px"}
-                  value={promptSettings.initialLabelling}
-                  onChange={(e) => promptSettings.setInitialLabelling(e.target.value)}
-                />
-                <Field.HelperText>
-                  AIに提示する初期ラベリングプロンプトです(通常は変更不要です)
-                </Field.HelperText>
-              </Field.Root>
-              <Field.Root>
-                <Field.Label>統合ラベリングプロンプト</Field.Label>
-                <Textarea
-                  h={"150px"}
-                  value={promptSettings.mergeLabelling}
-                  onChange={(e) => promptSettings.setMergeLabelling(e.target.value)}
-                />
-                <Field.HelperText>
-                  AIに提示する統合ラベリングプロンプトです(通常は変更不要です)
-                </Field.HelperText>
-              </Field.Root>
-              <Field.Root>
-                <Field.Label>要約プロンプト</Field.Label>
-                <Textarea
-                  h={"150px"}
-                  value={promptSettings.overview}
-                  onChange={(e) => promptSettings.setOverview(e.target.value)}
-                />
-                <Field.HelperText>
-                  AIに提示する要約プロンプトです(通常は変更不要です)
-                </Field.HelperText>
-              </Field.Root>
-            </VStack>
+            <AISettingsSection
+              model={aiSettings.model}
+              workers={aiSettings.workers}
+              isPubcomMode={aiSettings.isPubcomMode}
+              onModelChange={aiSettings.handleModelChange}
+              onWorkersChange={(e) => {
+                const v = Number(e.target.value);
+                if (!Number.isNaN(v)) {
+                  aiSettings.handleWorkersChange(v);
+                }
+              }}
+              onIncreaseWorkers={aiSettings.increaseWorkers}
+              onDecreaseWorkers={aiSettings.decreaseWorkers}
+              onPubcomModeChange={aiSettings.handlePubcomModeChange}
+              getModelDescription={aiSettings.getModelDescription}
+            />
           </Presence>
 
           {/* 警告メッセージ */}
-          <Stack gap="4" width="full">
-            <Alert.Root status="warning">
-              <Alert.Indicator />
-                <Alert.Title>
-                  レポートの作成には数分から数十分程度の時間がかかります
-                </Alert.Title>
-            </Alert.Root>
-            <Alert.Root status="warning">
-              <Alert.Indicator />
-                <Alert.Title>
-                  作成が完了したレポートが一覧画面に反映されるまで5分程度かかります
-                </Alert.Title>
-            </Alert.Root>
-          </Stack>
+          <WarningSection />
 
           {/* 送信ボタン */}
           <Button

--- a/client-admin/app/create/types/index.ts
+++ b/client-admin/app/create/types/index.ts
@@ -1,0 +1,21 @@
+// 型定義
+export interface SpreadsheetComment {
+  id?: string;
+  comment: string;
+  source?: string | null;
+  url?: string | null;
+}
+
+export interface ClusterSettings {
+  lv1: number;
+  lv2: number;
+}
+
+export interface PromptSettings {
+  extraction: string;
+  initialLabelling: string;
+  mergeLabelling: string;
+  overview: string;
+}
+
+export type InputType = "file" | "spreadsheet";

--- a/client-admin/app/create/utils/error-handler.ts
+++ b/client-admin/app/create/utils/error-handler.ts
@@ -1,0 +1,52 @@
+/**
+ * APIエラーを処理する
+ * @param error エラーオブジェクト
+ * @param defaultMessage デフォルトのエラーメッセージ
+ * @returns 処理済みのエラーオブジェクト
+ */
+export function handleApiError(error: unknown, defaultMessage: string): Error {
+  console.error(error);
+  
+  if (error instanceof Error) {
+    const errorMessage = error.message;
+    
+    // URLやアクセス権限のエラー
+    if (errorMessage.includes("Unauthorized") || errorMessage.includes("401")) {
+      return new Error("スプレッドシートへのアクセス権限がありません。公開設定を確認してください。");
+    }
+    // 存在しないシートなど
+    else if (errorMessage.includes("404") || errorMessage.includes("Not Found")) {
+      return new Error("スプレッドシートが見つかりません。URLを確認してください。");
+    }
+    // スプレッドシート形式の問題
+    else if (errorMessage.includes("comment") || errorMessage.includes("カラム")) {
+      return new Error("スプレッドシートの形式が正しくありません。commentカラムが必要です。");
+    }
+    // その他のエラー
+    else {
+      return new Error(defaultMessage);
+    }
+  }
+  
+  return new Error(defaultMessage);
+}
+
+/**
+ * トーストエラーメッセージを表示する
+ * @param toaster トースターオブジェクト
+ * @param error エラーオブジェクト
+ * @param title エラータイトル
+ */
+export function showErrorToast(
+  toaster: { create: (options: { type: string; title: string; description?: string; duration?: number }) => void },
+  error: unknown,
+  title: string
+): void {
+  const errorMessage = error instanceof Error ? error.message : "不明なエラーが発生しました";
+  
+  toaster.create({
+    type: "error",
+    title,
+    description: errorMessage,
+  });
+}

--- a/client-admin/app/create/utils/validation.ts
+++ b/client-admin/app/create/utils/validation.ts
@@ -1,0 +1,82 @@
+/**
+ * IDのバリデーション
+ * 英小文字、数字、ハイフンのみ使用可能
+ * @param id バリデーション対象のID
+ * @returns バリデーション結果
+ */
+export function isValidId(id: string): boolean {
+  return /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(id) && id.length <= 255;
+}
+
+/**
+ * フォーム入力値のバリデーション
+ * @param values バリデーション対象の値
+ * @returns バリデーション結果と、エラーメッセージ
+ */
+export function validateFormValues({
+  input,
+  question,
+  intro,
+  clusterLv1,
+  clusterLv2,
+  model,
+  extractionPrompt,
+  inputType,
+  csv,
+  spreadsheetImported,
+  selectedCommentColumn,
+  csvColumns,
+}: {
+  input: string;
+  question: string;
+  intro: string;
+  clusterLv1: number;
+  clusterLv2: number;
+  model: string;
+  extractionPrompt: string;
+  inputType: string;
+  csv: File | null;
+  spreadsheetImported: boolean;
+  selectedCommentColumn: string;
+  csvColumns: string[];
+}): { isValid: boolean; errorMessage?: string } {
+  // 共通チェック
+  const commonCheck = [
+    isValidId(input),
+    question.length > 0,
+    intro.length > 0,
+    clusterLv1 > 0,
+    clusterLv2 > 0,
+    model.length > 0,
+    extractionPrompt.length > 0,
+  ].every(Boolean);
+
+  if (!commonCheck) {
+    return {
+      isValid: false,
+      errorMessage: "全ての項目が入力されているか確認してください",
+    };
+  }
+
+  // 入力ソースのチェック
+  const sourceCheck =
+    (inputType === "file" && !!csv) ||
+    (inputType === "spreadsheet" && spreadsheetImported);
+
+  if (!sourceCheck) {
+    return {
+      isValid: false,
+      errorMessage: "入力データが選択されていません",
+    };
+  }
+
+  // カラム選択のチェック
+  if (csvColumns.length > 0 && !selectedCommentColumn) {
+    return {
+      isValid: false,
+      errorMessage: "コメントカラムを選択してください",
+    };
+  }
+
+  return { isValid: true };
+}


### PR DESCRIPTION
# 変更の概要

このPRでは、レポート生成ページ（client-admin/app/create/page.tsx）のリファクタリングを行いました。今後の機能追加や保守性を考慮し、コードの可読性と保守性を向上させることを目的としています。

## 1. 状態管理の整理
関連する状態を各カスタムフックにまとめました
- useBasicInfo: 基本情報（タイトル、調査概要、ID）
- useInputData: 入力データ（CSVファイル、スプレッドシート）
- useAISettings: AIモデル設定（モデル、並列実行数、出力モード）
- useClusterSettings: クラスタ設定
- usePromptSettings: プロンプト設定

## 2. コンポーネントの分割
UIを独立したコンポーネントに分割しました
- BasicInfoSection: 基本情報入力セクション
- AISettingsSection: AI詳細設定セクション
- WarningSection: 警告メッセージセクション
- ClusterSettingsSection: クラスタ設定セクション
- CommentColumnSelector: コメントカラム選択コンポーネント
- CsvFileTab: CSVファイル入力タブ
- SpreadsheetTab: スプレッドシート入力タブ

## 3. ロジックの分離
ビジネスロジックをUIから分離しました
- api/report.ts: レポート作成API
- api/spreadsheet.ts: スプレッドシートAPI
- utils/validation.ts: バリデーション関数
- utils/error-handler.ts: エラーハンドリング関数

## 4. 型定義の整理
型定義を types/index.ts にまとめました

# 変更の背景
- client-admin/app/create/page.tsxが1200行を超えており、LLMが読むのに苦労していた

# 関連Issue
#350

# その他

Rooで別のに取り掛かっていたら読み込みに相当苦労していたので一旦リファクタリングさせてみました。
Next.jsのベストプラクティス的な知識は弱いので、お手数ですが確認よろしくお願いします。
あとテスト方法もよくわかっておらず、手動でCSVとかを試して確認しているくらいです。

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました