### PR TITLE
第1階層の意見グループ数の上限を 20 -> 40に増加

### DIFF
--- a/client-admin/app/create/components/ClusterSettingsSection.tsx
+++ b/client-admin/app/create/components/ClusterSettingsSection.tsx
@@ -34,7 +34,7 @@ export function ClusterSettingsSection({
           type="number"
           value={clusterLv1.toString()}
           min={2}
-          max={20}
+          max={40}
           onChange={(e) => {
             const v = Number(e.target.value);
             if (!Number.isNaN(v)) {

--- a/client-admin/app/create/hooks/useClusterSettings.ts
+++ b/client-admin/app/create/hooks/useClusterSettings.ts
@@ -10,7 +10,7 @@ export function useClusterSettings(initialLv1 = 5, initialLv2 = 50) {
 
   // コメント数からクラスタ数を計算
   const calculateRecommendedClusters = useCallback((commentCount: number) => {
-    const lv1 = Math.max(2, Math.min(20, Math.round(Math.cbrt(commentCount))));
+    const lv1 = Math.max(2, Math.min(10, Math.round(Math.cbrt(commentCount))));
     const lv2 = Math.max(2, Math.min(1000, Math.round(lv1 * lv1)));
     return { lv1, lv2 };
   }, []);
@@ -26,7 +26,7 @@ export function useClusterSettings(initialLv1 = 5, initialLv2 = 50) {
 
   // クラスタLv1の値を変更
   const handleLv1Change = useCallback((newValue: number) => {
-    const limitedValue = Math.max(2, Math.min(20, newValue));
+    const limitedValue = Math.max(2, Math.min(40, newValue));
     setClusterLv1(limitedValue);
 
     // 第一階層のクラスタ数 * 2 > 第二階層のクラスタ数の場合のみ、第二階層の値を更新


### PR DESCRIPTION
# 変更の概要
- 第1階層の意見グループ数の上限を 20 -> 40に増やした
- レコメンドされる最大クラスタ数を10に変更
  - こちらの議論を踏まえて修正: https://github.com/digitaldemocracy2030/kouchou-ai/pull/335#issuecomment-2816448667
  - （元々のissueとは関係ない変更ですが、最大クラスタ数にかかわる変更なのでついでに修正しています）

# 変更の背景
* 現在、全体図などの散布図において意見グループの個数上限は20となっており、実際のユースケースでは20だと足りない場合があるので上限を上げたい
  * ラベルが重なってしまう問題があったため上限を20にしていたが、この問題は回避策のPR（ https://github.com/digitaldemocracy2030/kouchou-ai/pull/329 ）が出されている


# 関連Issue
close https://github.com/digitaldemocracy2030/kouchou-ai/issues/330

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました