### PR TITLE
Cluster lv2のmin valueを2から4に変更

### DIFF
--- a/client-admin/app/create/components/ClusterSettingsSection.tsx
+++ b/client-admin/app/create/components/ClusterSettingsSection.tsx
@@ -58,7 +58,7 @@ export function ClusterSettingsSection({
         <Input
           type="number"
           value={clusterLv2.toString()}
-          min={2}
+          min={4}
           max={1000}
           onChange={(e) => {
             const inputValue = e.target.value;

--- a/client-admin/app/create/hooks/useClusterSettings.ts
+++ b/client-admin/app/create/hooks/useClusterSettings.ts
@@ -11,7 +11,7 @@ export function useClusterSettings(initialLv1 = 5, initialLv2 = 50) {
   // コメント数からクラスタ数を計算
   const calculateRecommendedClusters = useCallback((commentCount: number) => {
     const lv1 = Math.max(2, Math.min(10, Math.round(Math.cbrt(commentCount))));
-    const lv2 = Math.max(2, Math.min(1000, Math.round(lv1 * lv1)));
+    const lv2 = Math.max(4, Math.min(1000, Math.round(lv1 * lv1)));
     return { lv1, lv2 };
   }, []);
 
@@ -52,7 +52,7 @@ export function useClusterSettings(initialLv1 = 5, initialLv2 = 50) {
 
   // クラスタLv2の値を変更
   const handleLv2Change = useCallback((newValue: number) => {
-    let limitedValue = Math.max(2, Math.min(1000, newValue));
+    let limitedValue = Math.max(4, Math.min(1000, newValue));
 
     // 第二階層の値が第一階層の値の2倍未満の場合は自動調整
     if (limitedValue < clusterLv1 * 2) {


### PR DESCRIPTION
# 変更の概要
- クラスター第2階層の最小値を2から4に変更した

## 最低値2
![](https://i.gyazo.com/d5f5bd0754b1f78a1ef6f58ca4d6f657.gif)

## 最低値4
![](https://i.gyazo.com/85bb15aeeab7648e395352048145d486.gif)

# 変更の背景
- 第1階層の最低値が2であり、第2階層は第1階層の2倍以上となるように動的に補正がかけられている
- 理論上は4が最低値となるが、4以下に数値を設定できるため、そのたびに補正表示が出ていて少し気になる

# 関連Issue
#356 こちらのレビュー段階で見つけた

レビュー中に軽微な修正をされていたのでそのような変更ができるのかなと思ったのですが、コードに変更が入るとapproveし直しになるのかな、と思い別PRにしました。

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました