### PR TITLE
client-admin/app/page.tsxのリファクタリング (関連: #336)

### DIFF
--- a/client-admin/app/page.tsx
+++ b/client-admin/app/page.tsx
@@ -369,7 +369,7 @@ function ReportCard({
               display="flex"
               alignItems="center"
               justifyContent="center"
-              backgroundColor="rgba(0, 0, 0, 0.05)"
+              backgroundColor="blackAlpha.100"
               opacity="0"
               transition="opacity 0.2s"
               _hover={{ opacity: 1 }}
@@ -626,13 +626,11 @@ function ReportCard({
         trapFocus={true}
       >
         <Dialog.Backdrop
-          style={{
-            zIndex: 1000,
-            position: "fixed",
-            inset: 0,
-            backgroundColor: "rgba(0, 0, 0, 0.4)",
-            backdropFilter: "blur(2px)"
-          }}
+          zIndex={1000}
+          position="fixed"
+          inset={0}
+          backgroundColor="rgba(0, 0, 0, 0.4)"
+          backdropFilter="blur(2px)"
           onClick={(e) => {
             e.preventDefault();
             e.stopPropagation();
@@ -646,12 +644,10 @@ function ReportCard({
               e.stopPropagation();
               return false;
             }}
-            style={{
-              pointerEvents: "auto",
-              position: "relative",
-              zIndex: 1001,
-              boxShadow: "0 4px 6px rgba(0, 0, 0, 0.1), 0 1px 3px rgba(0, 0, 0, 0.08)"
-            }}
+            pointerEvents="auto"
+            position="relative"
+            zIndex={1001}
+            boxShadow="md"
           >
             <Dialog.CloseTrigger position="absolute" top={3} right={3} />
             <Dialog.Header>

--- a/client-admin/app/page.tsx
+++ b/client-admin/app/page.tsx
@@ -21,6 +21,8 @@ import {
   Heading,
   Icon,
   Input,
+  LinkBox,
+  LinkOverlay,
   Popover,
   Portal,
   Spinner,
@@ -250,8 +252,7 @@ function ReportCard({
     }
   }, [progress, lastProgress, reports, setReports, report.slug]);
   return (
-    <Card.Root
-      size="md"
+    <LinkBox as={Card.Root}
       key={report.slug}
       mb={4}
       borderLeftWidth={10}
@@ -282,11 +283,15 @@ function ReportCard({
               )}
             </Box>
             <Box>
-              <Card.Title>
-                <Text fontSize="md" color={isErrorState ? "red.600" : statusDisplay.textColor}>
+              <LinkOverlay
+                href={`/${report.slug}`}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Text fontSize="md" fontWeight="bold" color={isErrorState ? "red.600" : statusDisplay.textColor}>
                   {report.title}
                 </Text>
-              </Card.Title>
+              </LinkOverlay>
               <Card.Description>
                 {`${process.env.NEXT_PUBLIC_CLIENT_BASEPATH}/${report.slug}`}
               </Card.Description>
@@ -615,111 +620,114 @@ function ReportCard({
         open={isEditDialogOpen}
         onOpenChange={({ open }) => setIsEditDialogOpen(open)}
         modal={true}
-        closeOnInteractOutside={false}
+        closeOnInteractOutside={true}
         trapFocus={true}
       >
-        <Dialog.Backdrop
-          zIndex={1000}
-          position="fixed"
-          inset={0}
-          backgroundColor="blackAlpha.100"
-          backdropFilter="blur(2px)"
-        />
-        <Dialog.Positioner>
-          <Dialog.Content
-            pointerEvents="auto"
-            position="relative"
-            zIndex={1001}
-            boxShadow="md"
-          >
-            <Dialog.CloseTrigger position="absolute" top={3} right={3} />
-            <Dialog.Header>
-              <Dialog.Title>レポートを編集</Dialog.Title>
-            </Dialog.Header>
-            <Dialog.Body>
-              <VStack gap={4} align="stretch">
-                <Box>
-                  <Text mb={2} fontWeight="bold">タイトル</Text>
-                  <Input
-                    value={editTitle}
-                    onChange={(e) => setEditTitle(e.target.value)}
-                    placeholder="レポートのタイトルを入力"
-                  />
-                </Box>
-                <Box>
-                  <Text mb={2} fontWeight="bold">調査概要</Text>
-                  <Textarea
-                    value={editDescription}
-                    onChange={(e) => setEditDescription(e.target.value)}
-                    placeholder="調査の概要を入力"
-                  />
-                </Box>
-              </VStack>
-            </Dialog.Body>
-            <Dialog.Footer>
-              <Button variant="outline" onClick={() => setIsEditDialogOpen(false)}>
-                キャンセル
-              </Button>
-              <Button
-                ml={3}
-                onClick={async () => {
-                  try {
-                    const response = await fetch(
-                      `${getApiBaseUrl()}/admin/reports/${report.slug}/metadata`,
-                      {
-                        method: "PATCH",
-                        headers: {
-                          "x-api-key": process.env.NEXT_PUBLIC_ADMIN_API_KEY || "",
-                          "Content-Type": "application/json",
-                        },
-                        body: JSON.stringify({
-                          title: editTitle,
-                          description: editDescription,
-                        }),
-                      }
-                    );
-
-                    if (!response.ok) {
-                      const errorData = await response.json();
-                      throw new Error(errorData.detail || "メタデータの更新に失敗しました");
-                    }
-
-                    // レポート一覧を更新
-                    if (setReports && reports) {
-                      const updatedReports = reports.map((r) =>
-                        r.slug === report.slug
-                          ? { ...r, title: editTitle, description: editDescription }
-                          : r
+        <Portal>
+          <Dialog.Backdrop
+            zIndex={1000}
+            position="fixed"
+            inset={0}
+            backgroundColor="blackAlpha.100"
+            backdropFilter="blur(2px)"
+          />
+          <Dialog.Positioner>
+            <Dialog.Content
+              pointerEvents="auto"
+              position="relative"
+              zIndex={1001}
+              boxShadow="md"
+              onClick={e => e.stopPropagation()}
+            >
+              <Dialog.CloseTrigger position="absolute" top={3} right={3} />
+              <Dialog.Header>
+                <Dialog.Title>レポートを編集</Dialog.Title>
+              </Dialog.Header>
+              <Dialog.Body>
+                <VStack gap={4} align="stretch">
+                  <Box>
+                    <Text mb={2} fontWeight="bold">タイトル</Text>
+                    <Input
+                      value={editTitle}
+                      onChange={(e) => setEditTitle(e.target.value)}
+                      placeholder="レポートのタイトルを入力"
+                    />
+                  </Box>
+                  <Box>
+                    <Text mb={2} fontWeight="bold">調査概要</Text>
+                    <Textarea
+                      value={editDescription}
+                      onChange={(e) => setEditDescription(e.target.value)}
+                      placeholder="調査の概要を入力"
+                    />
+                  </Box>
+                </VStack>
+              </Dialog.Body>
+              <Dialog.Footer>
+                <Button variant="outline" onClick={() => setIsEditDialogOpen(false)}>
+                  キャンセル
+                </Button>
+                <Button
+                  ml={3}
+                  onClick={async () => {
+                    try {
+                      const response = await fetch(
+                        `${getApiBaseUrl()}/admin/reports/${report.slug}/metadata`,
+                        {
+                          method: "PATCH",
+                          headers: {
+                            "x-api-key": process.env.NEXT_PUBLIC_ADMIN_API_KEY || "",
+                            "Content-Type": "application/json",
+                          },
+                          body: JSON.stringify({
+                            title: editTitle,
+                            description: editDescription,
+                          }),
+                        }
                       );
-                      setReports(updatedReports);
+
+                      if (!response.ok) {
+                        const errorData = await response.json();
+                        throw new Error(errorData.detail || "メタデータの更新に失敗しました");
+                      }
+
+                      // レポート一覧を更新
+                      if (setReports && reports) {
+                        const updatedReports = reports.map((r) =>
+                          r.slug === report.slug
+                            ? { ...r, title: editTitle, description: editDescription }
+                            : r
+                        );
+                        setReports(updatedReports);
+                      }
+
+                      // 成功メッセージを表示
+                      toaster.create({
+                        type: "success",
+                        title: "更新完了",
+                        description: "レポート情報が更新されました",
+                      });
+
+                      // ダイアログを閉じる
+                      setIsEditDialogOpen(false);
+                    } catch (error) {
+                      console.error("メタデータの更新に失敗しました:", error);
+                      toaster.create({
+                        type: "error",
+                        title: "更新エラー",
+                        description: "メタデータの更新に失敗しました",
+                      });
                     }
-
-                    // 成功メッセージを表示
-                    toaster.create({
-                      type: "success",
-                      title: "更新完了",
-                      description: "レポート情報が更新されました",
-                    });
-
-                    // ダイアログを閉じる
-                    setIsEditDialogOpen(false);
-                  } catch (error) {
-                    console.error("メタデータの更新に失敗しました:", error);
-                    toaster.create({
-                      type: "error",
-                      title: "更新エラー",
-                      description: "メタデータの更新に失敗しました",
-                    });
-                  }
-                }}
-              >
-                保存
-              </Button>
-            </Dialog.Footer>
-          </Dialog.Content>
-        </Dialog.Positioner>
+                  }}
+                >
+                  保存
+                </Button>
+              </Dialog.Footer>
+            </Dialog.Content>
+          </Dialog.Positioner>
+        </Portal>
       </Dialog.Root>
-    </Card.Root>
+    </LinkBox>
   );
 }
 

--- a/client-admin/app/page.tsx
+++ b/client-admin/app/page.tsx
@@ -265,13 +265,6 @@ function ReportCard({
         cursor: "pointer",
       } : {}}
       onClick={(e) => {
-        // ダイアログが開いている場合は何もしない
-        if (isEditDialogOpen) {
-          e.preventDefault();
-          e.stopPropagation();
-          return false;
-        }
-        
         if (report.status === "ready") {
           window.open(`${process.env.NEXT_PUBLIC_CLIENT_BASEPATH}/${report.slug}`, "_blank");
         }
@@ -629,21 +622,11 @@ function ReportCard({
           zIndex={1000}
           position="fixed"
           inset={0}
-          backgroundColor="rgba(0, 0, 0, 0.4)"
+          backgroundColor="blackAlpha.100"
           backdropFilter="blur(2px)"
-          onClick={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            return false;
-          }}
         />
         <Dialog.Positioner>
           <Dialog.Content
-            onClick={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              return false;
-            }}
             pointerEvents="auto"
             position="relative"
             zIndex={1001}


### PR DESCRIPTION
# 変更の概要
- styleを直接記述している箇所をChakra UIのStyle propsに変更
- 不要なクリック防止イベントの廃棄( #336 で触った範囲 )
  - 「レポートを編集する」Dialogに関して必要な箇所をクリック防止イベントを残した
  - 「レポートを編集する」Dialog外をクリックした際は、Dialogを閉じるように変更した(下記に詳細)
- レポートのクリック範囲拡大用の記述をChakra UIの LinkBox に変更 ( #316)

「レポートを編集する」に関して、Dialog表示中にDialog内とDialog外両方(=全画面)をクリックするとレポートに遷移してしまうのを防ぐためにクリック防止を導入していた。
`<Dialog.Content>` に `onClick={e => e.stopPropagation()}` を記述するとDialog内の’クリックは防止されるがDialog外をクリックすると依然として遷移する問題が残った。
`<Dialog.Root>` に `closeOnInteractOutside` を true に設定し、そもそもDialog外のクリックでDialogを閉じるようにしたところ、遷移しなくなった。挙動としては自然なので一旦この方法にした。(詳しい人いたら修正してほしい。)

# 変更の背景
- #336 のフロントのコードレビューの追加PR

# 関連Issue
#316 クリック可能範囲を広げるPR
#336 フロントのコードレビュー

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました