### PR TITLE
WIP Solve issue #290 階層図のUI/UX改善

### DIFF
--- a/client/components/report/Chart.tsx
+++ b/client/components/report/Chart.tsx
@@ -1,9 +1,9 @@
 import { ScatterChart } from "@/components/charts/ScatterChart";
 import { TreemapChart } from "@/components/charts/TreemapChart";
 import { Tooltip } from "@/components/ui/tooltip";
-import type { Result } from "@/type";
-import { Box, Button, Icon } from "@chakra-ui/react";
-import { Undo2Icon } from "lucide-react";
+import type { Cluster, Result } from "@/type";
+import { Box, Button, HStack, Icon } from "@chakra-ui/react";
+import { Minimize2 } from "lucide-react";
 
 type ReportProps = {
   result: Result;
@@ -12,6 +12,8 @@ type ReportProps = {
   onExitFullscreen: () => void;
   showClusterLabels: boolean;
   onToggleClusterLabels: (show: boolean) => void;
+  treemapLevel: string;
+  onTreeZoom: (level: string) => void;
 };
 
 export function Chart({
@@ -21,7 +23,16 @@ export function Chart({
   onExitFullscreen,
   showClusterLabels,
   onToggleClusterLabels,
+  treemapLevel,
+  onTreeZoom,
 }: ReportProps) {
+  function goUp() {
+    const parentLevel = result.clusters.filter(
+      (cluster: Cluster) => cluster.id === treemapLevel,
+    )[0].parent;
+    onTreeZoom(parentLevel);
+  }
+
   if (isFullscreen) {
     return (
       <Box
@@ -35,22 +46,30 @@ export function Chart({
         bgColor={"#fff"}
         zIndex={1000}
       >
-        <Tooltip content={"全画面終了"} openDelay={0} closeDelay={0}>
-          <Button
-            id={"shrinkButton"}
-            onClick={onExitFullscreen}
-            h={"50px"}
-            position={"fixed"}
-            top={5}
-            right={5}
-            zIndex={1}
-            borderWidth={2}
-          >
-            <Icon>
-              <Undo2Icon />
-            </Icon>
-          </Button>
-        </Tooltip>
+        <HStack
+          id={"fullScreenButtons"}
+          position={"fixed"}
+          top={5}
+          right={5}
+          zIndex={1}
+        >
+          {/* {selectedChart === "treemap" && treemapLevel !== "0" && (
+            <Tooltip content={"1つ上の階層に戻る"} openDelay={0} closeDelay={0}>
+              <Button onClick={goUp} h={"50px"} borderWidth={2}>
+                <Icon>
+                  <MoveUpIcon />
+                </Icon>
+              </Button>
+            </Tooltip>
+          )} */}
+          <Tooltip content={"全画面終了"} openDelay={0} closeDelay={0}>
+            <Button onClick={onExitFullscreen} h={"50px"} borderWidth={2}>
+              <Icon>
+                <Minimize2 />
+              </Icon>
+            </Button>
+          </Tooltip>
+        </HStack>
         {(selectedChart === "scatterAll" ||
           selectedChart === "scatterDensity") && (
           <ScatterChart
@@ -67,9 +86,12 @@ export function Chart({
         )}
         {selectedChart === "treemap" && (
           <TreemapChart
+            key={treemapLevel}
             clusterList={result.clusters}
             argumentList={result.arguments}
             onHover={avoidHoverTextCoveringShrinkButton}
+            level={treemapLevel}
+            onTreeZoom={onTreeZoom}
           />
         )}
       </Box>
@@ -81,8 +103,11 @@ export function Chart({
       <Box h={"500px"} mb={5}>
         {selectedChart === "treemap" && (
           <TreemapChart
+            key={treemapLevel}
             clusterList={result.clusters}
             argumentList={result.arguments}
+            level={treemapLevel}
+            onTreeZoom={onTreeZoom}
           />
         )}
         {(selectedChart === "scatterAll" ||
@@ -108,7 +133,7 @@ export function Chart({
  */
 function avoidHoverTextCoveringShrinkButton(): void {
   const hoverlayer = document.querySelector(".hoverlayer");
-  const shrinkButton = document.getElementById("shrinkButton");
+  const shrinkButton = document.getElementById("fullScreenButtons");
   if (!hoverlayer || !shrinkButton) return;
   const hoverPos = hoverlayer.getBoundingClientRect();
   const btnPos = shrinkButton.getBoundingClientRect();

--- a/client/components/report/ClientContainer.tsx
+++ b/client/components/report/ClientContainer.tsx
@@ -20,6 +20,7 @@ export function ClientContainer({ result }: Props) {
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [isDenseGroupEnabled, setIsDenseGroupEnabled] = useState(true);
   const [showClusterLabels, setShowClusterLabels] = useState(true);
+  const [treemapLevel, setTreemapLevel] = useState("0");
 
   // maxDensityやminValueが変化するたびに密度フィルターの結果をチェック
   useEffect(() => {
@@ -94,6 +95,8 @@ export function ClientContainer({ result }: Props) {
         }}
         showClusterLabels={showClusterLabels}
         onToggleClusterLabels={setShowClusterLabels}
+        treemapLevel={treemapLevel}
+        onTreeZoom={setTreemapLevel}
       />
     </>
   );
@@ -120,11 +123,11 @@ function getDenseClusters(
     `Total clusters at deepest level (${deepestLevel}): ${deepestLevelClusters.length}`,
   );
 
-  deepestLevelClusters.forEach((cluster) => {
+  for (const cluster of deepestLevelClusters) {
     console.log(
       `Cluster ID: ${cluster.id}, Label: ${cluster.label}, Density: ${cluster.density_rank_percentile}, Elements: ${cluster.value}`,
     );
-  });
+  }
 
   const filteredDeepestLevelClusters = deepestLevelClusters
     .filter((c) => c.density_rank_percentile <= maxDensity)


### PR DESCRIPTION
# 変更の概要
- 全体図、濃い意見グループ、階層図、全画面表示を行き来するときに階層図の表示階層を保持する
- パンくずリストの色を濃くして目立たせる
- 全画面終了のアイコンを戻るっぽいものから縮小っぽいものに変更 https://lucide.dev/icons/minimize-2
- 現在のクラスタのラベルを極力折り返さない（折り返しの文字数を15から幅いっぱいの50にする）

# 変更の背景
4/12 の meetup で意見の出た階層図の使いにくさを解消するための変更です。
検討事項や修正方針の詳細は下記のIssueをご確認ください。

# 関連Issue
https://github.com/digitaldemocracy2030/kouchou-ai/issues/290

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。
- [x] CLAの内容を読み、同意しました