### PR TITLE
文脈埋め込み（エンベデッド）の処理をローカルで動かせるようにする

### DIFF
--- a/client-admin/app/create/api/report.ts
+++ b/client-admin/app/create/api/report.ts
@@ -16,6 +16,7 @@ export async function createReport({
   prompt,
   is_pubcom,
   inputType,
+  is_embedded_at_local,
 }: {
   input: string;
   question: string;
@@ -27,6 +28,7 @@ export async function createReport({
   prompt: PromptSettings;
   is_pubcom: boolean;
   inputType: string;
+  is_embedded_at_local: boolean;
 }): Promise<void> {
   try {
     const response = await fetch(
@@ -48,6 +50,7 @@ export async function createReport({
           prompt,
           is_pubcom,
           inputType,
+          is_embedded_at_local,
         }),
       }
     );

--- a/client-admin/app/create/components/AISettingsSection.tsx
+++ b/client-admin/app/create/components/AISettingsSection.tsx
@@ -23,6 +23,8 @@ export function AISettingsSection({
   onPubcomModeChange,
   getModelDescription,
   promptSettings,
+  isEmbeddedAtLocal,
+  onEmbeddedAtLocalChange,
 }: {
   model: string;
   workers: number;
@@ -43,6 +45,8 @@ export function AISettingsSection({
     setMergeLabelling: (value: string) => void;
     setOverview: (value: string) => void;
   };
+  isEmbeddedAtLocal: boolean;
+  onEmbeddedAtLocalChange: (checked: boolean | "indeterminate") => void;
 }) {
 
   return (
@@ -154,6 +158,22 @@ export function AISettingsSection({
         />
         <Field.HelperText>
           AIに提示する要約プロンプトです(通常は変更不要です)
+        </Field.HelperText>
+      </Field.Root>
+      <Field.Root>
+        <Checkbox
+          checked={isEmbeddedAtLocal}
+          onCheckedChange={(details) => {
+            const { checked } = details;
+            if (checked === "indeterminate") return;
+            onEmbeddedAtLocalChange(checked);
+          }}
+        >
+          埋め込み処理をサーバ内で行う
+        </Checkbox>
+        <Field.HelperText>
+          埋め込み処理をサーバ内で行うことで、APIの利用料金を削減します。
+          精度に関しては未検証であり、OpenAIを使った場合と大きく異なる結果になる可能性があります。
         </Field.HelperText>
       </Field.Root>
     </VStack>

--- a/client-admin/app/create/hooks/useAISettings.ts
+++ b/client-admin/app/create/hooks/useAISettings.ts
@@ -8,6 +8,7 @@ export function useAISettings() {
   const [model, setModel] = useState<string>("gpt-4o-mini");
   const [workers, setWorkers] = useState<number>(30);
   const [isPubcomMode, setIsPubcomMode] = useState<boolean>(true);
+  const [isEmbeddedAtLocal, setIsEmbeddedAtLocal] = useState<boolean>(false);
 
   /**
    * ワーカー数変更時のハンドラー
@@ -66,12 +67,14 @@ export function useAISettings() {
     setModel("gpt-4o-mini");
     setWorkers(30);
     setIsPubcomMode(true);
+    setIsEmbeddedAtLocal(false);
   };
 
   return {
     model,
     workers,
     isPubcomMode,
+    isEmbeddedAtLocal,
     handleModelChange,
     handleWorkersChange,
     increaseWorkers,
@@ -79,5 +82,6 @@ export function useAISettings() {
     handlePubcomModeChange,
     getModelDescription,
     resetAISettings,
+    setIsEmbeddedAtLocal,
   };
 }

--- a/client-admin/app/create/page.tsx
+++ b/client-admin/app/create/page.tsx
@@ -142,6 +142,7 @@ export default function Page() {
         prompt: promptData,
         is_pubcom: aiSettings.isPubcomMode,
         inputType: inputData.inputType,
+        is_embedded_at_local: aiSettings.isEmbeddedAtLocal,
       });
       
       toaster.create({
@@ -241,6 +242,7 @@ export default function Page() {
               model={aiSettings.model}
               workers={aiSettings.workers}
               isPubcomMode={aiSettings.isPubcomMode}
+              isEmbeddedAtLocal={aiSettings.isEmbeddedAtLocal}
               onModelChange={aiSettings.handleModelChange}
               onWorkersChange={(e) => {
                 const v = Number(e.target.value);
@@ -251,6 +253,10 @@ export default function Page() {
               onIncreaseWorkers={aiSettings.increaseWorkers}
               onDecreaseWorkers={aiSettings.decreaseWorkers}
               onPubcomModeChange={aiSettings.handlePubcomModeChange}
+              onEmbeddedAtLocalChange={(checked) => {
+                if (checked === "indeterminate") return;
+                aiSettings.setIsEmbeddedAtLocal(checked);
+              }}
               getModelDescription={aiSettings.getModelDescription}
               promptSettings={promptSettings}
             />

--- a/server/broadlistening/pipeline/hierarchical_utils.py
+++ b/server/broadlistening/pipeline/hierarchical_utils.py
@@ -12,7 +12,7 @@ def validate_config(config):
         raise Exception("Missing required field 'input' in config")
     if "question" not in config:
         raise Exception("Missing required field 'question' in config")
-    valid_fields = ["input", "question", "model", "name", "intro", "is_pubcom"]
+    valid_fields = ["input", "question", "model", "name", "intro", "is_pubcom", "is_embedded_at_local"]
     step_names = [x["step"] for x in specs]
     for key in config:
         if key not in valid_fields and key not in step_names:

--- a/server/broadlistening/pipeline/steps/embedding.py
+++ b/server/broadlistening/pipeline/steps/embedding.py
@@ -6,6 +6,9 @@ from services.llm import request_to_embed
 
 def embedding(config):
     model = config["embedding"]["model"]
+    is_embedded_at_local = config["is_embedded_at_local"]
+    #print("start embedding")
+    #print(f"embedding model: {model}, is_embedded_at_local: {is_embedded_at_local}")
 
     dataset = config["output_dir"]
     path = f"outputs/{dataset}/embeddings.pkl"
@@ -14,7 +17,7 @@ def embedding(config):
     batch_size = 1000
     for i in tqdm(range(0, len(arguments), batch_size)):
         args = arguments["argument"].tolist()[i : i + batch_size]
-        embeds = request_to_embed(args, model)
+        embeds = request_to_embed(args, model, is_embedded_at_local)
         embeddings.extend(embeds)
     df = pd.DataFrame([{"arg-id": arguments.iloc[i]["arg-id"], "embedding": e} for i, e in enumerate(embeddings)])
     df.to_pickle(path)

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -25,6 +25,8 @@ dependencies = [
     "azure-core>=1.32.0",
     "pytest>=8.3.5",
     "azure-identity>=1.21.0",
+    "sentence-transformers>=2.7.0",
+    "hf_xet>=0.1.0",
 ]
 readme = "README.md"
 requires-python = ">= 3.12"

--- a/server/src/schemas/admin_report.py
+++ b/server/src/schemas/admin_report.py
@@ -31,6 +31,7 @@ class ReportInput(SchemaBaseModel):
     comments: list[Comment]  # コメントのリスト
     is_pubcom: bool = False  # CSV出力モード出力フラグ
     inputType: Literal["file", "spreadsheet"] = "file"  # 入力タイプ
+    is_embedded_at_local: bool = False  # エンベデッド処理をローカルで行うかどうか
 
 
 class ReportMetadataUpdate(SchemaBaseModel):

--- a/server/src/services/report_launcher.py
+++ b/server/src/services/report_launcher.py
@@ -25,6 +25,7 @@ def _build_config(report_input: ReportInput) -> dict[str, Any]:
         "intro": report_input.intro,
         "model": report_input.model,
         "is_pubcom": report_input.is_pubcom,
+        "is_embedded_at_local": report_input.is_embedded_at_local,
         "extraction": {
             "prompt": report_input.prompt.extraction,
             "workers": report_input.workers,


### PR DESCRIPTION
# 変更の概要
- 埋め込み処理のためのSentenseTransformerを導入

# スクリーンショット
- 埋め込み処理をサーバ内で行う、というチェックボックスを作成しました
![image](https://github.com/user-attachments/assets/43339bad-79fd-410f-bb5e-49296e9ef627)

# 変更の背景
- 自治体職員が利用する場合、OpenAIのアカウント作成や、APIの利用料金で躊躇する可能性があるため、エンベデッド処理をSentenseTransformerを使ってローカル化することで、そのコストを抑制する

# 関連Issue
関連するIssueのリンクをこちらに記載してください

#385

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました