### PR TITLE
散布図にズームとパンを追加（あとスクショもできるようになった）

### DIFF
--- a/client/components/charts/ChartCore.tsx
+++ b/client/components/charts/ChartCore.tsx
@@ -3,7 +3,6 @@
 import { LoadingBar } from "@/components/report/LoadingBar";
 import jaLocale from "@/lib/plotly-locale-ja";
 import dynamic from "next/dynamic";
-import React from "react";
 
 export const ChartCore = dynamic(
   async () => {
@@ -11,11 +10,14 @@ export const ChartCore = dynamic(
     const Scatter = await import("plotly.js/lib/scatter");
     const Sunburst = await import("plotly.js/lib/sunburst");
     const Treemap = await import("plotly.js/lib/treemap");
+    
+    // ズームとパン機能のために必要なモジュール
+    const ScatterGL = await import("plotly.js/lib/scattergl");  
 
     const createPlotlyComponent = (await import("react-plotly.js/factory"))
       .default;
 
-    Plotly.register([Scatter, Sunburst, Treemap]);
+    Plotly.register([Scatter, Sunburst, Treemap, ScatterGL]);
     Plotly.register(jaLocale);
 
     return createPlotlyComponent(Plotly);

--- a/client/components/charts/ScatterChart.tsx
+++ b/client/components/charts/ScatterChart.tsx
@@ -130,6 +130,7 @@ export function ScatterChart({
           showticklabels: false,
         },
         hovermode: "closest",
+        dragmode: "pan", // ドラッグによる移動（パン）を有効化
         annotations: showClusterLabels ? clusterData.map((data) => ({
           x: data.centerX,
           y: data.centerY,
@@ -152,7 +153,8 @@ export function ScatterChart({
       style={{ width: "100%", height: "100%" }}
       config={{
         responsive: true,
-        displayModeBar: false,
+        displayModeBar: "hover", // 操作時にツールバーを表示
+        scrollZoom: true, // マウスホイールによるズームを有効化
         locale: "ja",
       }}
       onHover={onHover}


### PR DESCRIPTION
# 変更の概要
散布図をズームとパンで操作できるようにするために、Plotlyのコンフィグを変更した

副次的効果として、スクリーンショットボタンが付いた

# スクリーンショット

![image](https://github.com/user-attachments/assets/90365c4d-4b9a-4f77-81f1-37f9827a5769)

# 変更の背景
範囲選択して拡大がめんどくさすぎた

# 関連Issue
関連するIssueのリンクをこちらに記載してください

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました