### PR TITLE
Client-AdminにChatGPTのAPIKeyの確認画面の追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,8 +39,6 @@ NEXT_PUBLIC_SITE_URL="http://localhost:3000"
 NEXT_PUBLIC_GA_MEASUREMENT_ID=
 # client-admin用 Google Analytics 測定ID
 NEXT_PUBLIC_ADMIN_GA_MEASUREMENT_ID=
-# Client-side environment variable for API choice
-NEXT_PUBLIC_USE_AZURE=false
 
 # Next.jsのキャッシュを破棄するためのシークレットキー
 REVALIDATE_SECRET=revalidate-secret

--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,8 @@ NEXT_PUBLIC_SITE_URL="http://localhost:3000"
 NEXT_PUBLIC_GA_MEASUREMENT_ID=
 # client-admin用 Google Analytics 測定ID
 NEXT_PUBLIC_ADMIN_GA_MEASUREMENT_ID=
+# Client-side environment variable for API choice
+NEXT_PUBLIC_USE_AZURE=false
 
 # Next.jsのキャッシュを破棄するためのシークレットキー
 REVALIDATE_SECRET=revalidate-secret

--- a/client-admin/app/environment/page.tsx
+++ b/client-admin/app/environment/page.tsx
@@ -74,7 +74,7 @@ export default function Page() {
 
             <Button
               onClick={verifyChatGptApiKey}
-              isLoading={isVerifying}
+              loading={isVerifying}
               loadingText="検証中..."
               mb={4}
             >

--- a/client-admin/app/environment/page.tsx
+++ b/client-admin/app/environment/page.tsx
@@ -24,14 +24,7 @@ export default function Page() {
     use_azure: boolean;
     available_models: string[];
     error_type?: string;
-    balance_info?: {
-      total_available: number;
-      grants: Array<{
-        grant_amount: number;
-        used_amount: number;
-        expires_at: number;
-      }>;
-    };
+    error_detail?: string;
   } | null>(null);
 
   const verifyChatGptApiKey = async () => {
@@ -121,23 +114,10 @@ export default function Page() {
                       </Text>
                     )}
                     
-                    {!verificationResult.use_azure && verificationResult.balance_info && (
-                      <Box mt={2} mb={2} p={3} borderWidth="1px" borderRadius="md" backgroundColor="blue.50">
-                        <Text fontWeight="bold" mb={1}>アカウント残高情報:</Text>
-                        <Text>利用可能な残高: ${verificationResult.balance_info.total_available.toFixed(2)}</Text>
-                        {verificationResult.balance_info.grants && verificationResult.balance_info.grants.length > 0 && (
-                          <Box mt={2}>
-                            <Text fontWeight="bold" fontSize="sm">クレジット詳細:</Text>
-                            {verificationResult.balance_info.grants.map((grant, index) => (
-                              <Box key={index} mt={1} fontSize="sm">
-                                <Text>付与額: ${grant.grant_amount.toFixed(2)}</Text>
-                                <Text>使用額: ${grant.used_amount.toFixed(2)}</Text>
-                                <Text>有効期限: {new Date(grant.expires_at * 1000).toLocaleDateString()}</Text>
-                              </Box>
-                            ))}
-                          </Box>
-                        )}
-                      </Box>
+                    {verificationResult.error_detail && (
+                      <Text mb={1} fontSize="sm" color="gray.600">
+                        詳細: {verificationResult.error_detail}
+                      </Text>
                     )}
                     <Text mb={1}>
                       使用モード:{" "}

--- a/client-admin/app/environment/page.tsx
+++ b/client-admin/app/environment/page.tsx
@@ -68,7 +68,8 @@ export default function Page() {
           </Card.Header>
           <Card.Body>
             <Text mb={4}>
-              ChatGPT API キーの設定を検証します。API キーが正しく設定されているか確認できます。 
+              ChatGPT API キーの設定を検証します。API キーが正しく設定されているか確認できます。 <br/>
+              （注意、検証のためにChatGPTのAPIを利用するため、約0.005円の費用がかかります）
             </Text>
 
             <Button

--- a/client-admin/app/environment/page.tsx
+++ b/client-admin/app/environment/page.tsx
@@ -23,6 +23,7 @@ export default function Page() {
     message: string;
     use_azure: boolean;
     available_models: string[];
+    error_type?: string;
   } | null>(null);
 
   const verifyChatGptApiKey = async () => {
@@ -106,6 +107,11 @@ export default function Page() {
                         : "検証失敗"}
                     </Text>
                     <Text mb={1}>{verificationResult.message}</Text>
+                    {verificationResult.error_type === "insufficient_quota" && (
+                      <Text mb={1} color="orange.600" fontWeight="bold">
+                        デポジット残高不足: APIキーのデポジット残高が不足しています。残高を追加してください。
+                      </Text>
+                    )}
                     <Text mb={1}>
                       使用モード:{" "}
                       {verificationResult.use_azure

--- a/client-admin/app/environment/page.tsx
+++ b/client-admin/app/environment/page.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { getApiBaseUrl } from "@/app/utils/api";
+import { Header } from "@/components/Header";
+import { toaster } from "@/components/ui/toaster";
+import {
+  Box,
+  Button,
+  Card,
+  Flex,
+  Heading,
+  HStack,
+  Text,
+  VStack,
+} from "@chakra-ui/react";
+import { CircleCheckIcon, CircleAlertIcon } from "lucide-react";
+import { useState } from "react";
+
+export default function Page() {
+  const [isVerifying, setIsVerifying] = useState(false);
+  const [verificationResult, setVerificationResult] = useState<{
+    success: boolean;
+    message: string;
+    use_azure: boolean;
+  } | null>(null);
+
+  const verifyChatGptApiKey = async () => {
+    setIsVerifying(true);
+    try {
+      const response = await fetch(
+        `${getApiBaseUrl()}/admin/environment/verify-chatgpt`,
+        {
+          method: "GET",
+          headers: {
+            "x-api-key": process.env.NEXT_PUBLIC_ADMIN_API_KEY || "",
+            "Content-Type": "application/json",
+          },
+        }
+      );
+
+      const result = await response.json();
+      setVerificationResult(result);
+    } catch (error) {
+      console.error("Error verifying API key:", error);
+      toaster.create({
+        type: "error",
+        title: "検証エラー",
+        description: "API キーの検証中にエラーが発生しました",
+      });
+    } finally {
+      setIsVerifying(false);
+    }
+  };
+
+  return (
+    <div className="container">
+      <Header />
+      <Box mx="auto" maxW="800px" mb={5}>
+        <Heading textAlign="center" fontSize="xl" mb={5}>
+          環境検証
+        </Heading>
+
+        <Card.Root p={5} mb={5}>
+          <Card.Header>
+            <Heading size="md">ChatGPT API キー検証</Heading>
+          </Card.Header>
+          <Card.Body>
+            <Text mb={4}>
+              ChatGPT API キーの設定を検証します。API キーが正しく設定されているか確認できます。
+            </Text>
+            <Text mb={4}>
+              現在の設定: {process.env.NEXT_PUBLIC_USE_AZURE === "true" ? "Azure OpenAI Service" : "OpenAI API"}
+            </Text>
+
+            <Button
+              onClick={verifyChatGptApiKey}
+              isLoading={isVerifying}
+              loadingText="検証中..."
+              mb={4}
+            >
+              API キーを検証
+            </Button>
+
+            {verificationResult && (
+              <Box
+                mt={4}
+                p={4}
+                borderRadius="md"
+                backgroundColor={
+                  verificationResult.success ? "green.50" : "red.50"
+                }
+              >
+                <HStack>
+                  <Box color={verificationResult.success ? "green" : "red"}>
+                    {verificationResult.success ? (
+                      <CircleCheckIcon size={24} />
+                    ) : (
+                      <CircleAlertIcon size={24} />
+                    )}
+                  </Box>
+                  <VStack align="flex-start" spacing={1}>
+                    <Text fontWeight="bold">
+                      {verificationResult.success
+                        ? "検証成功"
+                        : "検証失敗"}
+                    </Text>
+                    <Text>{verificationResult.message}</Text>
+                    <Text>
+                      使用モード:{" "}
+                      {verificationResult.use_azure
+                        ? "Azure OpenAI Service"
+                        : "OpenAI API"}
+                    </Text>
+                  </VStack>
+                </HStack>
+              </Box>
+            )}
+          </Card.Body>
+        </Card.Root>
+
+        <Text fontSize="sm" color="gray.500" mt={8} textAlign="center">
+          注意: API キーの検証は既存の環境設定を確認するだけで、設定自体は変更しません。
+          設定を変更するには .env ファイルを直接編集してください。
+        </Text>
+      </Box>
+    </div>
+  );
+}

--- a/client-admin/app/environment/page.tsx
+++ b/client-admin/app/environment/page.tsx
@@ -22,6 +22,7 @@ export default function Page() {
     success: boolean;
     message: string;
     use_azure: boolean;
+    available_models: string[];
   } | null>(null);
 
   const verifyChatGptApiKey = async () => {
@@ -105,12 +106,28 @@ export default function Page() {
                         : "検証失敗"}
                     </Text>
                     <Text mb={1}>{verificationResult.message}</Text>
-                    <Text>
+                    <Text mb={1}>
                       使用モード:{" "}
                       {verificationResult.use_azure
                         ? "Azure OpenAI Service"
                         : "OpenAI API"}
                     </Text>
+                    {verificationResult.success && verificationResult.available_models && verificationResult.available_models.length > 0 && (
+                      <Box mt={2}>
+                        <Text fontWeight="bold" mb={1}>利用可能なモデル:</Text>
+                        <Box 
+                          maxH="200px" 
+                          overflowY="auto" 
+                          p={2} 
+                          borderWidth="1px" 
+                          borderRadius="md"
+                        >
+                          {verificationResult.available_models.map((model: string, index: number) => (
+                            <Text key={index} fontSize="sm">{model}</Text>
+                          ))}
+                        </Box>
+                      </Box>
+                    )}
                   </VStack>
                 </HStack>
               </Box>

--- a/client-admin/app/environment/page.tsx
+++ b/client-admin/app/environment/page.tsx
@@ -22,7 +22,7 @@ export default function Page() {
     success: boolean;
     message: string;
     use_azure: boolean;
-    available_models: string[];
+    available_models?: string[];
     error_type?: string;
     error_detail?: string;
   } | null>(null);
@@ -125,22 +125,6 @@ export default function Page() {
                         ? "Azure OpenAI Service"
                         : "OpenAI API"}
                     </Text>
-                    {verificationResult.success && verificationResult.available_models && verificationResult.available_models.length > 0 && (
-                      <Box mt={2}>
-                        <Text fontWeight="bold" mb={1}>利用可能なモデル:</Text>
-                        <Box 
-                          maxH="200px" 
-                          overflowY="auto" 
-                          p={2} 
-                          borderWidth="1px" 
-                          borderRadius="md"
-                        >
-                          {verificationResult.available_models.map((model: string, index: number) => (
-                            <Text key={index} fontSize="sm">{model}</Text>
-                          ))}
-                        </Box>
-                      </Box>
-                    )}
                   </VStack>
                 </HStack>
               </Box>

--- a/client-admin/app/environment/page.tsx
+++ b/client-admin/app/environment/page.tsx
@@ -98,13 +98,13 @@ export default function Page() {
                       <CircleAlertIcon size={24} />
                     )}
                   </Box>
-                  <VStack align="flex-start" spacing={1}>
-                    <Text fontWeight="bold">
+                  <VStack align="flex-start">
+                    <Text fontWeight="bold" mb={1}>
                       {verificationResult.success
                         ? "検証成功"
                         : "検証失敗"}
                     </Text>
-                    <Text>{verificationResult.message}</Text>
+                    <Text mb={1}>{verificationResult.message}</Text>
                     <Text>
                       使用モード:{" "}
                       {verificationResult.use_azure

--- a/client-admin/app/environment/page.tsx
+++ b/client-admin/app/environment/page.tsx
@@ -24,6 +24,14 @@ export default function Page() {
     use_azure: boolean;
     available_models: string[];
     error_type?: string;
+    balance_info?: {
+      total_available: number;
+      grants: Array<{
+        grant_amount: number;
+        used_amount: number;
+        expires_at: number;
+      }>;
+    };
   } | null>(null);
 
   const verifyChatGptApiKey = async () => {
@@ -111,6 +119,25 @@ export default function Page() {
                       <Text mb={1} color="orange.600" fontWeight="bold">
                         デポジット残高不足: APIキーのデポジット残高が不足しています。残高を追加してください。
                       </Text>
+                    )}
+                    
+                    {!verificationResult.use_azure && verificationResult.balance_info && (
+                      <Box mt={2} mb={2} p={3} borderWidth="1px" borderRadius="md" backgroundColor="blue.50">
+                        <Text fontWeight="bold" mb={1}>アカウント残高情報:</Text>
+                        <Text>利用可能な残高: ${verificationResult.balance_info.total_available.toFixed(2)}</Text>
+                        {verificationResult.balance_info.grants && verificationResult.balance_info.grants.length > 0 && (
+                          <Box mt={2}>
+                            <Text fontWeight="bold" fontSize="sm">クレジット詳細:</Text>
+                            {verificationResult.balance_info.grants.map((grant, index) => (
+                              <Box key={index} mt={1} fontSize="sm">
+                                <Text>付与額: ${grant.grant_amount.toFixed(2)}</Text>
+                                <Text>使用額: ${grant.used_amount.toFixed(2)}</Text>
+                                <Text>有効期限: {new Date(grant.expires_at * 1000).toLocaleDateString()}</Text>
+                              </Box>
+                            ))}
+                          </Box>
+                        )}
+                      </Box>
                     )}
                     <Text mb={1}>
                       使用モード:{" "}

--- a/client-admin/app/environment/page.tsx
+++ b/client-admin/app/environment/page.tsx
@@ -7,13 +7,12 @@ import {
   Box,
   Button,
   Card,
-  Flex,
   Heading,
   HStack,
   Text,
-  VStack,
+  VStack
 } from "@chakra-ui/react";
-import { CircleCheckIcon, CircleAlertIcon } from "lucide-react";
+import { CircleAlertIcon, CircleCheckIcon } from "lucide-react";
 import { useState } from "react";
 
 export default function Page() {
@@ -69,10 +68,7 @@ export default function Page() {
           </Card.Header>
           <Card.Body>
             <Text mb={4}>
-              ChatGPT API キーの設定を検証します。API キーが正しく設定されているか確認できます。
-            </Text>
-            <Text mb={4}>
-              現在の設定: {process.env.NEXT_PUBLIC_USE_AZURE === "true" ? "Azure OpenAI Service" : "OpenAI API"}
+              ChatGPT API キーの設定を検証します。API キーが正しく設定されているか確認できます。 
             </Text>
 
             <Button

--- a/client-admin/app/page.tsx
+++ b/client-admin/app/page.tsx
@@ -842,6 +842,9 @@ export default function Page() {
             <Button size="xl">新しいレポートを作成する</Button>
           </Link>
           <DownloadBuildButton />
+          <Link href="/environment">
+            <Button size="xl" variant="outline">環境検証</Button>
+          </Link>
         </HStack>
       </Box>
     </div>

--- a/server/src/routers/admin_report.py
+++ b/server/src/routers/admin_report.py
@@ -227,7 +227,7 @@ async def verify_chatgpt_api_key(api_key: str = Depends(verify_admin_api_key)) -
                     balance_info = {"total_available": total_available, "grants": grants}
                     if total_available <= 0.01:  # Consider balances below 1 cent as insufficient
                         return {
-                            "success": False,
+                            "succｗｗess": False,
                             "message": "Insufficient account balance",
                             "error_type": "insufficient_quota",
                             "use_azure": use_azure,

--- a/server/src/routers/admin_report.py
+++ b/server/src/routers/admin_report.py
@@ -182,7 +182,7 @@ async def verify_chatgpt_api_key(api_key: str = Depends(verify_admin_api_key)) -
 
         _ = request_to_chat_openai(
             messages=test_messages,
-            model="gpt-3.5-turbo" if not use_azure else None,
+            model="gpt-4o-mini" if not use_azure else None,
             max_tokens=1,
         )
 

--- a/server/src/routers/admin_report.py
+++ b/server/src/routers/admin_report.py
@@ -36,7 +36,7 @@ async def get_reports(api_key: str = Depends(verify_admin_api_key)) -> list[Repo
 
 
 @router.post("/admin/reports", status_code=202)
-async def create_report(report: ReportInput, api_key: str = Depends(verify_admin_api_key)):
+async def create_report(report: ReportInput, api_key: str = Depends(verify_admin_api_key)) -> ORJSONResponse:
     try:
         launch_report_generation(report)
         return ORJSONResponse(
@@ -55,7 +55,7 @@ async def create_report(report: ReportInput, api_key: str = Depends(verify_admin
 
 
 @router.get("/admin/comments/{slug}/csv")
-async def download_comments_csv(slug: str, api_key: str = Depends(verify_admin_api_key)):
+async def download_comments_csv(slug: str, api_key: str = Depends(verify_admin_api_key)) -> FileResponse:
     csv_path = settings.REPORT_DIR / slug / "final_result_with_comments.csv"
     if not csv_path.exists():
         raise HTTPException(status_code=404, detail="CSV file not found")
@@ -63,7 +63,7 @@ async def download_comments_csv(slug: str, api_key: str = Depends(verify_admin_a
 
 
 @router.get("/admin/reports/{slug}/status/step-json", dependencies=[Depends(verify_admin_api_key)])
-async def get_current_step(slug: str):
+async def get_current_step(slug: str) -> dict:
     status_file = settings.REPORT_DIR / slug / "hierarchical_status.json"
     try:
         # ステータスファイルが存在しない場合は "loading" を返す
@@ -96,7 +96,7 @@ async def get_current_step(slug: str):
 
 
 @router.delete("/admin/reports/{slug}")
-async def delete_report(slug: str, api_key: str = Depends(verify_admin_api_key)):
+async def delete_report(slug: str, api_key: str = Depends(verify_admin_api_key)) -> ORJSONResponse:
     try:
         set_status(slug, ReportStatus.DELETED.value)
         return ORJSONResponse(
@@ -161,7 +161,7 @@ async def update_report_metadata_endpoint(
 
 
 @router.get("/admin/environment/verify-chatgpt")
-async def verify_chatgpt_api_key(api_key: str = Depends(verify_admin_api_key)):
+async def verify_chatgpt_api_key(api_key: str = Depends(verify_admin_api_key)) -> dict:
     """Verify the ChatGPT API key configuration by retrieving available models.
 
     Checks both OpenAI and Azure OpenAI configurations based on the USE_AZURE setting.

--- a/server/src/routers/admin_report.py
+++ b/server/src/routers/admin_report.py
@@ -217,8 +217,8 @@ async def verify_chatgpt_api_key(api_key: str = Depends(verify_admin_api_key)) -
                     }
                 raise  # Re-raise to be caught by the outer exception handler
         else:
-            from openai import OpenAI
             import requests
+            from openai import OpenAI
 
             client = OpenAI()
             models = client.models.list()

--- a/server/src/routers/admin_report.py
+++ b/server/src/routers/admin_report.py
@@ -191,13 +191,12 @@ async def verify_chatgpt_api_key(api_key: str = Depends(verify_admin_api_key)) -
                 azure_endpoint=azure_endpoint,
                 api_key=api_key,
             )
-            
             try:
                 models = client.models.list()
                 available_models = [model.id for model in models]
             except Exception as e:
                 slogger.error(f"Error listing Azure models: {str(e)}", exc_info=True)
-            
+
             client.chat.completions.create(
                 model=os.getenv("AZURE_CHATCOMPLETION_DEPLOYMENT_NAME", "gpt-35-turbo"),
                 messages=test_messages,
@@ -207,13 +206,12 @@ async def verify_chatgpt_api_key(api_key: str = Depends(verify_admin_api_key)) -
             from openai import OpenAI
 
             client = OpenAI()
-            
             try:
                 models = client.models.list()
                 available_models = [model.id for model in models]
             except Exception as e:
                 slogger.error(f"Error listing OpenAI models: {str(e)}", exc_info=True)
-            
+
             client.chat.completions.create(
                 model="gpt-3.5-turbo",
                 messages=test_messages,

--- a/server/src/routers/admin_report.py
+++ b/server/src/routers/admin_report.py
@@ -182,7 +182,7 @@ async def verify_chatgpt_api_key(api_key: str = Depends(verify_admin_api_key)) -
 
         _ = request_to_chat_openai(
             messages=test_messages,
-            model="gpt-4o" if not use_azure else None,
+            model="gpt-3.5-turbo" if not use_azure else None,
             max_tokens=1,
         )
 

--- a/server/src/routers/admin_report.py
+++ b/server/src/routers/admin_report.py
@@ -188,12 +188,48 @@ async def verify_chatgpt_api_key(api_key: str = Depends(verify_admin_api_key)):
             )
             models = client.models.list()
             available_models = [model.id for model in models]
+            
+            try:
+                client.chat.completions.create(
+                    model=os.getenv("AZURE_CHATCOMPLETION_DEPLOYMENT_NAME", "gpt-35-turbo"),
+                    messages=[{"role": "user", "content": "Hi"}],
+                    max_tokens=1
+                )
+            except openai.RateLimitError as e:
+                error_str = str(e).lower()
+                if "insufficient_quota" in error_str or "quota exceeded" in error_str:
+                    return {
+                        "success": False,
+                        "message": f"Error: {str(e)}",
+                        "error_type": "insufficient_quota",
+                        "use_azure": use_azure,
+                        "available_models": available_models,
+                    }
+                raise  # Re-raise to be caught by the outer exception handler
         else:
             from openai import OpenAI
 
             client = OpenAI()
             models = client.models.list()
             available_models = [model.id for model in models]
+            
+            try:
+                client.chat.completions.create(
+                    model="gpt-3.5-turbo",
+                    messages=[{"role": "user", "content": "Hi"}],
+                    max_tokens=1
+                )
+            except openai.RateLimitError as e:
+                error_str = str(e).lower()
+                if "insufficient_quota" in error_str or "quota exceeded" in error_str:
+                    return {
+                        "success": False,
+                        "message": f"Error: {str(e)}",
+                        "error_type": "insufficient_quota",
+                        "use_azure": use_azure,
+                        "available_models": available_models,
+                    }
+                raise  # Re-raise to be caught by the outer exception handler
 
         return {
             "success": True,

--- a/server/src/routers/admin_report.py
+++ b/server/src/routers/admin_report.py
@@ -194,7 +194,7 @@ async def verify_chatgpt_api_key(api_key: str = Depends(verify_admin_api_key)) -
             try:
                 client.chat.completions.create(
                     model=os.getenv(
-                        "AZURE_CHATCOMPLETION_DEPLOYMENT_NAME", 
+                        "AZURE_CHATCOMPLETION_DEPLOYMENT_NAME",
                         "gpt-35-turbo"
                     ),
                     messages=[
@@ -234,17 +234,14 @@ async def verify_chatgpt_api_key(api_key: str = Depends(verify_admin_api_key)) -
                     "https://api.openai.com/v1/dashboard/billing/credit_grants",
                     headers=headers
                 )
-                
                 if response.status_code == 200:
                     balance_data = response.json()
                     total_available = balance_data.get("total_available", 0)
                     grants = balance_data.get("grants", [])
-                    
                     balance_info = {
                         "total_available": total_available,
                         "grants": grants
                     }
-                    
                     if total_available <= 0.01:  # Consider balances below 1 cent as insufficient
                         return {
                             "success": False,

--- a/server/src/routers/admin_report.py
+++ b/server/src/routers/admin_report.py
@@ -193,21 +193,13 @@ async def verify_chatgpt_api_key(api_key: str = Depends(verify_admin_api_key)) -
 
             try:
                 client.chat.completions.create(
-                    model=os.getenv(
-                        "AZURE_CHATCOMPLETION_DEPLOYMENT_NAME",
-                        "gpt-35-turbo"
-                    ),
-                    messages=[
-                        {"role": "user", "content": "Hi"}
-                    ],
-                    max_tokens=1
+                    model=os.getenv("AZURE_CHATCOMPLETION_DEPLOYMENT_NAME", "gpt-35-turbo"),
+                    messages=[{"role": "user", "content": "Hi"}],
+                    max_tokens=1,
                 )
             except openai.RateLimitError as e:
                 error_str = str(e).lower()
-                if (
-                    "insufficient_quota" in error_str
-                    or "quota exceeded" in error_str
-                ):
+                if "insufficient_quota" in error_str or "quota exceeded" in error_str:
                     return {
                         "success": False,
                         "message": f"Error: {str(e)}",
@@ -226,22 +218,13 @@ async def verify_chatgpt_api_key(api_key: str = Depends(verify_admin_api_key)) -
 
             try:
                 openai_api_key = os.getenv("OPENAI_API_KEY")
-                headers = {
-                    "Authorization": f"Bearer {openai_api_key}",
-                    "Content-Type": "application/json"
-                }
-                response = requests.get(
-                    "https://api.openai.com/v1/dashboard/billing/credit_grants",
-                    headers=headers
-                )
+                headers = {"Authorization": f"Bearer {openai_api_key}", "Content-Type": "application/json"}
+                response = requests.get("https://api.openai.com/v1/dashboard/billing/credit_grants", headers=headers)
                 if response.status_code == 200:
                     balance_data = response.json()
                     total_available = balance_data.get("total_available", 0)
                     grants = balance_data.get("grants", [])
-                    balance_info = {
-                        "total_available": total_available,
-                        "grants": grants
-                    }
+                    balance_info = {"total_available": total_available, "grants": grants}
                     if total_available <= 0.01:  # Consider balances below 1 cent as insufficient
                         return {
                             "success": False,
@@ -249,7 +232,7 @@ async def verify_chatgpt_api_key(api_key: str = Depends(verify_admin_api_key)) -
                             "error_type": "insufficient_quota",
                             "use_azure": use_azure,
                             "available_models": available_models,
-                            "balance_info": balance_info
+                            "balance_info": balance_info,
                         }
                 elif response.status_code == 401:
                     return {
@@ -266,7 +249,7 @@ async def verify_chatgpt_api_key(api_key: str = Depends(verify_admin_api_key)) -
             "message": "ChatGPT API key is valid",
             "use_azure": use_azure,
             "available_models": available_models,
-            "balance_info": balance_info
+            "balance_info": balance_info,
         }
 
     except openai.AuthenticationError as e:
@@ -278,10 +261,7 @@ async def verify_chatgpt_api_key(api_key: str = Depends(verify_admin_api_key)) -
         }
     except openai.RateLimitError as e:
         error_str = str(e).lower()
-        if (
-            "insufficient_quota" in error_str
-            or "quota exceeded" in error_str
-        ):
+        if "insufficient_quota" in error_str or "quota exceeded" in error_str:
             return {
                 "success": False,
                 "message": f"Error: {str(e)}",

--- a/server/src/routers/admin_report.py
+++ b/server/src/routers/admin_report.py
@@ -159,6 +159,7 @@ async def update_report_metadata_endpoint(
         slogger.error(f"Exception: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail="Internal server error") from e
 
+
 @router.get("/admin/environment/verify-chatgpt")
 async def verify_chatgpt_api_key(api_key: str = Depends(verify_admin_api_key)):
     """Verify the ChatGPT API key configuration by making a test request.

--- a/server/src/routers/admin_report.py
+++ b/server/src/routers/admin_report.py
@@ -182,8 +182,7 @@ async def verify_chatgpt_api_key(api_key: str = Depends(verify_admin_api_key)) -
 
         _ = request_to_chat_openai(
             messages=test_messages,
-            model="gpt-4o-mini" if not use_azure else None,
-            max_tokens=1,
+            model="gpt-4o-mini",
         )
 
         return {

--- a/server/src/routers/admin_report.py
+++ b/server/src/routers/admin_report.py
@@ -209,6 +209,22 @@ async def verify_chatgpt_api_key(api_key: str = Depends(verify_admin_api_key)):
             "use_azure": use_azure,
             "available_models": [],
         }
+    except openai.RateLimitError as e:
+        error_str = str(e).lower()
+        if "insufficient_quota" in error_str or "quota exceeded" in error_str:
+            return {
+                "success": False,
+                "message": f"Error: {str(e)}",
+                "error_type": "insufficient_quota",
+                "use_azure": use_azure,
+                "available_models": [],
+            }
+        return {
+            "success": False,
+            "message": f"Rate limit exceeded: {str(e)}",
+            "use_azure": use_azure,
+            "available_models": [],
+        }
     except Exception as e:
         return {
             "success": False,

--- a/server/src/routers/admin_report.py
+++ b/server/src/routers/admin_report.py
@@ -162,30 +162,30 @@ async def update_report_metadata_endpoint(
 @router.get("/admin/environment/verify-chatgpt")
 async def verify_chatgpt_api_key(api_key: str = Depends(verify_admin_api_key)):
     """Verify the ChatGPT API key configuration by making a test request.
-    
+
     Checks both OpenAI and Azure OpenAI configurations based on the USE_AZURE setting.
-    
+
     Returns:
         dict: Status of the verification and any error messages
     """
     try:
         use_azure = os.getenv("USE_AZURE", "false").lower() == "true"
-        
+
         test_messages = [
             {"role": "system", "content": "This is a test message to verify API key."},
             {"role": "user", "content": "Hello"},
         ]
-        
+
         from broadlistening.pipeline.services.llm import request_to_chat_openai
-        
+
         _ = request_to_chat_openai(messages=test_messages, model="gpt-4o" if not use_azure else None)
-        
+
         return {
             "success": True,
             "message": "ChatGPT API key is valid",
             "use_azure": use_azure,
         }
-        
+
     except openai.AuthenticationError as e:
         return {
             "success": False,

--- a/server/src/routers/admin_report.py
+++ b/server/src/routers/admin_report.py
@@ -191,13 +191,21 @@ async def verify_chatgpt_api_key(api_key: str = Depends(verify_admin_api_key)) -
 
             try:
                 client.chat.completions.create(
-                    model=os.getenv("AZURE_CHATCOMPLETION_DEPLOYMENT_NAME", "gpt-35-turbo"),
-                    messages=[{"role": "user", "content": "Hi"}],
+                    model=os.getenv(
+                        "AZURE_CHATCOMPLETION_DEPLOYMENT_NAME", 
+                        "gpt-35-turbo"
+                    ),
+                    messages=[
+                        {"role": "user", "content": "Hi"}
+                    ],
                     max_tokens=1
                 )
             except openai.RateLimitError as e:
                 error_str = str(e).lower()
-                if "insufficient_quota" in error_str or "quota exceeded" in error_str:
+                if (
+                    "insufficient_quota" in error_str
+                    or "quota exceeded" in error_str
+                ):
                     return {
                         "success": False,
                         "message": f"Error: {str(e)}",
@@ -216,12 +224,17 @@ async def verify_chatgpt_api_key(api_key: str = Depends(verify_admin_api_key)) -
             try:
                 client.chat.completions.create(
                     model="gpt-3.5-turbo",
-                    messages=[{"role": "user", "content": "Hi"}],
+                    messages=[
+                        {"role": "user", "content": "Hi"}
+                    ],
                     max_tokens=1
                 )
             except openai.RateLimitError as e:
                 error_str = str(e).lower()
-                if "insufficient_quota" in error_str or "quota exceeded" in error_str:
+                if (
+                    "insufficient_quota" in error_str
+                    or "quota exceeded" in error_str
+                ):
                     return {
                         "success": False,
                         "message": f"Error: {str(e)}",
@@ -247,7 +260,10 @@ async def verify_chatgpt_api_key(api_key: str = Depends(verify_admin_api_key)) -
         }
     except openai.RateLimitError as e:
         error_str = str(e).lower()
-        if "insufficient_quota" in error_str or "quota exceeded" in error_str:
+        if (
+            "insufficient_quota" in error_str
+            or "quota exceeded" in error_str
+        ):
             return {
                 "success": False,
                 "message": f"Error: {str(e)}",

--- a/server/src/routers/admin_report.py
+++ b/server/src/routers/admin_report.py
@@ -186,12 +186,11 @@ async def verify_chatgpt_api_key(api_key: str = Depends(verify_admin_api_key)):
                 azure_endpoint=azure_endpoint,
                 api_key=api_key,
             )
-            
             models = client.models.list()
             available_models = [model.id for model in models]
         else:
             from openai import OpenAI
-            
+
             client = OpenAI()
             models = client.models.list()
             available_models = [model.id for model in models]

--- a/server/src/routers/admin_report.py
+++ b/server/src/routers/admin_report.py
@@ -188,6 +188,8 @@ async def verify_chatgpt_api_key(api_key: str = Depends(verify_admin_api_key)) -
         return {
             "success": True,
             "message": "ChatGPT API キーは有効です",
+            "error_detail": None,
+            "error_type": None,
             "use_azure": use_azure,
         }
 
@@ -196,6 +198,7 @@ async def verify_chatgpt_api_key(api_key: str = Depends(verify_admin_api_key)) -
             "success": False,
             "message": "認証エラー: APIキーが無効または期限切れです",
             "error_detail": str(e),
+            "error_type": "authentication_error",
             "use_azure": use_azure,
         }
     except openai.RateLimitError as e:
@@ -212,6 +215,7 @@ async def verify_chatgpt_api_key(api_key: str = Depends(verify_admin_api_key)) -
             "success": False,
             "message": "レート制限エラー: APIリクエストの制限を超えました。しばらく待ってから再試行してください。",
             "error_detail": str(e),
+            "error_type": "rate_limit_error",
             "use_azure": use_azure,
         }
     except Exception as e:
@@ -219,5 +223,6 @@ async def verify_chatgpt_api_key(api_key: str = Depends(verify_admin_api_key)) -
             "success": False,
             "message": f"エラーが発生しました: {str(e)}",
             "error_detail": str(e),
+            "error_type": "unknown_error",
             "use_azure": use_azure,
         }

--- a/server/src/routers/admin_report.py
+++ b/server/src/routers/admin_report.py
@@ -188,7 +188,7 @@ async def verify_chatgpt_api_key(api_key: str = Depends(verify_admin_api_key)):
             )
             models = client.models.list()
             available_models = [model.id for model in models]
-            
+
             try:
                 client.chat.completions.create(
                     model=os.getenv("AZURE_CHATCOMPLETION_DEPLOYMENT_NAME", "gpt-35-turbo"),
@@ -212,7 +212,7 @@ async def verify_chatgpt_api_key(api_key: str = Depends(verify_admin_api_key)):
             client = OpenAI()
             models = client.models.list()
             available_models = [model.id for model in models]
-            
+
             try:
                 client.chat.completions.create(
                     model="gpt-3.5-turbo",

--- a/server/src/routers/admin_report.py
+++ b/server/src/routers/admin_report.py
@@ -230,7 +230,7 @@ async def verify_chatgpt_api_key(api_key: str = Depends(verify_admin_api_key)) -
     except openai.AuthenticationError as e:
         return {
             "success": False,
-            "message": f"認証エラー: APIキーが無効または期限切れです",
+            "message": "認証エラー: APIキーが無効または期限切れです",
             "error_detail": str(e),
             "use_azure": use_azure,
             "available_models": [],

--- a/server/src/routers/admin_report.py
+++ b/server/src/routers/admin_report.py
@@ -1,5 +1,7 @@
 import json
+import os
 
+import openai
 from fastapi import APIRouter, Depends, HTTPException, Security
 from fastapi.responses import FileResponse, ORJSONResponse
 from fastapi.security.api_key import APIKeyHeader
@@ -156,3 +158,43 @@ async def update_report_metadata_endpoint(
     except Exception as e:
         slogger.error(f"Exception: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail="Internal server error") from e
+
+@router.get("/admin/environment/verify-chatgpt")
+async def verify_chatgpt_api_key(api_key: str = Depends(verify_admin_api_key)):
+    """Verify the ChatGPT API key configuration by making a test request.
+    
+    Checks both OpenAI and Azure OpenAI configurations based on the USE_AZURE setting.
+    
+    Returns:
+        dict: Status of the verification and any error messages
+    """
+    try:
+        use_azure = os.getenv("USE_AZURE", "false").lower() == "true"
+        
+        test_messages = [
+            {"role": "system", "content": "This is a test message to verify API key."},
+            {"role": "user", "content": "Hello"},
+        ]
+        
+        from broadlistening.pipeline.services.llm import request_to_chat_openai
+        
+        _ = request_to_chat_openai(messages=test_messages, model="gpt-4o" if not use_azure else None)
+        
+        return {
+            "success": True,
+            "message": "ChatGPT API key is valid",
+            "use_azure": use_azure,
+        }
+        
+    except openai.AuthenticationError as e:
+        return {
+            "success": False,
+            "message": f"Authentication failed: {str(e)}",
+            "use_azure": use_azure,
+        }
+    except Exception as e:
+        return {
+            "success": False,
+            "message": f"Error: {str(e)}",
+            "use_azure": use_azure,
+        }


### PR DESCRIPTION
# 変更の概要
- 管理画面の追加
- とりあえずOpenAIのAPIを一発叩いてみて、動作確認
- エラーが出たら、エラーを分かりやすく表示

# スクリーンショット
![image](https://github.com/user-attachments/assets/f4e0a02b-3fb1-4e3d-9eed-c624273ec0cb)
![image](https://github.com/user-attachments/assets/5193c5bc-5ea3-4740-aeca-22ab50a27dce)
![image](https://github.com/user-attachments/assets/e6c4a57d-86fa-4bce-809e-3e59aee058af)


# 変更の背景
- envでAPIKeyが正しく設定されているか分からない
- APIのデポジットに正しくチャージされているか分からない

# 関連Issue

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました