### PR TITLE
client-build-static実行時にルートに.nojekyllファイルを追加する

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ down:
 client-build-static:
 	rm -rf out
 	docker compose up -d --wait api
-	docker compose run --rm -e BASE_PATH=$(NEXT_PUBLIC_STATIC_EXPORT_BASE_PATH) -e NEXT_PUBLIC_OUTPUT_MODE=export -v $(shell pwd)/server:/server -v $(shell pwd)/out:/app/dist client sh -c "npm run build:static && cp -r out/* dist"
+	docker compose run --rm -e BASE_PATH=$(NEXT_PUBLIC_STATIC_EXPORT_BASE_PATH) -e NEXT_PUBLIC_OUTPUT_MODE=export -v $(shell pwd)/server:/server -v $(shell pwd)/out:/app/dist client sh -c "npm run build:static && cp -r out/* dist && touch dist/.nojekyll"
 	docker compose down
 
 client-setup:


### PR DESCRIPTION
# 変更の概要
- client-build-static実行時にルートに.nojekyllファイルを追加する

# 変更の背景
- Github Pagesにデプロイする際にjeykllで処理されてしまうのを防ぐために.nojekyllが必要
- .nojekyll ファイルをユーザーに手動で追加させるよりもビルド時に作成したほうが罠を踏むのを減らせる
- .nojekyll ファイルがあることで他のホスティングへのデプロイに特に影響はない(はず)
- #235 の着手に先立って.nojekyllをルートに追加する

# 関連Issue
#235 

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました