### PR TITLE
[WIP] [実験]軸の性質を推定し、プロット時に軸情報を表示する

### DIFF
--- a/client/components/charts/ScatterChart.tsx
+++ b/client/components/charts/ScatterChart.tsx
@@ -8,6 +8,18 @@ type Props = {
   targetLevel: number;
   onHover?: () => void;
   showClusterLabels?: boolean;
+  axisInfo?: {
+    x: {
+      name: string;
+      min: string;
+      max: string;
+    };
+    y: {
+      name: string;
+      min: string;
+      max: string;
+    };
+  };
 };
 
 export function ScatterChart({
@@ -16,6 +28,7 @@ export function ScatterChart({
   targetLevel,
   onHover,
   showClusterLabels,
+  axisInfo,
 }: Props) {
   const targetClusters = clusterList.filter(
     (cluster) => cluster.level === targetLevel,
@@ -190,32 +203,120 @@ export function ScatterChart({
         },
       }))}
       layout={{
-        margin: { l: 0, r: 0, b: 0, t: 0 },
+        margin: { l: 50, r: 50, b: 50, t: 50 }, // マージンを増やして軸ラベルのスペースを確保
         xaxis: {
           zeroline: false,
-          showticklabels: false,
+          showticklabels: true, // 目盛りラベルを表示
+          title: {
+            text: axisInfo ? axisInfo.x.name : "X軸",
+            font: {
+              size: 14,
+              color: '#333',
+            },
+          },
         },
         yaxis: {
           zeroline: false,
-          showticklabels: false,
+          showticklabels: true, // 目盛りラベルを表示
+          title: {
+            text: axisInfo ? axisInfo.y.name : "Y軸",
+            font: {
+              size: 14,
+              color: '#333',
+            },
+            standoff: 0, // タイトルと軸の間隔を調整
+            // @ts-ignore - Plotlyの型定義にangleがないが実際は機能する
+            angle: -90, // 90度回転（左に倒す）
+          } as any,
         },
         hovermode: "closest",
         dragmode: "pan", // ドラッグによる移動（パン）を有効化
-        annotations: showClusterLabels ? clusterData.map((data) => ({
-          x: data.centerX,
-          y: data.centerY,
-          text: wrapLabelText(data.cluster.label), // ラベルを折り返し処理
-          showarrow: false,
-          font: {
-            color: "white",
-            size: annotationFontsize,
-            weight: 700,
+        annotations: [
+          // X軸の小さい側のラベル
+          {
+            text: axisInfo ? axisInfo.x.min : "小",
+            x: 0,
+            y: 0,
+            xref: 'paper',
+            yref: 'paper',
+            xanchor: 'left',
+            yanchor: 'top',
+            showarrow: false,
+            font: {
+              size: 12,
+              color: '#555',
+            },
+            xshift: 5,
+            yshift: -15,
           },
-          bgcolor: clusterColorMapA[data.cluster.id], // 背景はアルファ付き
-          borderpad: 10,
-          width: annotationLabelWidth,
-          align: 'left',
-        })) : [],
+          // X軸の大きい側のラベル
+          {
+            text: axisInfo ? axisInfo.x.max : "大",
+            x: 1,
+            y: 0,
+            xref: 'paper',
+            yref: 'paper',
+            xanchor: 'right',
+            yanchor: 'top',
+            showarrow: false,
+            font: {
+              size: 12,
+              color: '#555',
+            },
+            xshift: -5,
+            yshift: -15,
+          },
+          // Y軸の小さい側のラベル
+          {
+            text: axisInfo ? axisInfo.y.min : "小",
+            x: 0.02, // グラフ内に配置
+            y: 0.02,
+            xref: 'paper',
+            yref: 'paper',
+            xanchor: 'left',
+            yanchor: 'bottom',
+            showarrow: false,
+            font: {
+              size: 12,
+              color: '#555',
+            },
+            bgcolor: 'rgba(255, 255, 255, 0.8)', // 半透明の背景
+            borderpad: 2,
+          },
+          // Y軸の大きい側のラベル
+          {
+            text: axisInfo ? axisInfo.y.max : "大",
+            x: 0.02, // グラフ内に配置
+            y: 0.98,
+            xref: 'paper',
+            yref: 'paper',
+            xanchor: 'left',
+            yanchor: 'top',
+            showarrow: false,
+            font: {
+              size: 12,
+              color: '#555',
+            },
+            bgcolor: 'rgba(255, 255, 255, 0.8)', // 半透明の背景
+            borderpad: 2,
+          },
+          // クラスターのラベル
+          ...(showClusterLabels ? clusterData.map((data) => ({
+            x: data.centerX,
+            y: data.centerY,
+            text: wrapLabelText(data.cluster.label), // ラベルを折り返し処理
+            showarrow: false,
+            font: {
+              color: "white",
+              size: annotationFontsize,
+              weight: 700,
+            },
+            bgcolor: clusterColorMapA[data.cluster.id], // 背景はアルファ付き
+            borderpad: 10,
+            width: annotationLabelWidth,
+            align: "left" as "left",
+          })) : [])
+        ],
         showlegend: false,
       }}
       useResizeHandler={true}

--- a/client/components/charts/ScatterChart.tsx
+++ b/client/components/charts/ScatterChart.tsx
@@ -8,16 +8,15 @@ type Props = {
   targetLevel: number;
   onHover?: () => void;
   showClusterLabels?: boolean;
+  showAxisLabels?: boolean;
   axisInfo?: {
     x: {
-      name: string;
-      min: string;
-      max: string;
+      min_label: string;
+      max_label: string;
     };
     y: {
-      name: string;
-      min: string;
-      max: string;
+      min_label: string;
+      max_label: string;
     };
   };
 };
@@ -28,6 +27,7 @@ export function ScatterChart({
   targetLevel,
   onHover,
   showClusterLabels,
+  showAxisLabels,
   axisInfo,
 }: Props) {
   const targetClusters = clusterList.filter(
@@ -177,6 +177,80 @@ export function ScatterChart({
     };
   });
 
+  // 軸ラベルのアノテーション
+  const axisAnnotations: any[] = showAxisLabels !== false ? [
+    // X軸の小さい側のラベル（縦中央の左端に90度回転）
+    {
+      text: axisInfo ? axisInfo.x.min_label : "",
+      x: 0,
+      y: 0.5, // 縦中央に配置
+      xref: 'paper',
+      yref: 'paper',
+      xanchor: 'center',
+      yanchor: 'middle',
+      showarrow: false,
+      font: {
+        size: 15,
+        color: '#555',
+      },
+      textangle: 90, // 90度回転
+      xshift: "-15" as any, // 左側に寄せる
+    },
+    // X軸の大きい側のラベル（縦中央の右端に90度回転）
+    {
+      text: axisInfo ? axisInfo.x.max_label : "",
+      x: 1,
+      y: 0.5, // 縦中央に配置
+      xref: 'paper',
+      yref: 'paper',
+      xanchor: 'center',
+      yanchor: 'middle',
+      showarrow: false,
+      font: {
+        size: 15,
+        color: '#555',
+      },
+      textangle: 90, // 90度回転
+      xshift: "15" as any, // 右側に寄せる
+    },
+    // Y軸の小さい側のラベル（横中央の下部に配置）
+    {
+      text: axisInfo ? axisInfo.y.min_label : "",
+      x: 0.5, // 横中央に配置
+      y: 0,
+      xref: 'paper',
+      yref: 'paper',
+      xanchor: 'center',
+      yanchor: 'top',
+      showarrow: false,
+      font: {
+        size: 15,
+        color: '#555',
+      },
+      bgcolor: 'rgba(255, 255, 255, 0.8)', // 半透明の背景
+      borderpad: 2,
+      yshift: "-15" as any, // 下側に寄せる
+    },
+    // Y軸の大きい側のラベル（横中央の上部に配置）
+    {
+      text: axisInfo ? axisInfo.y.max_label : "",
+      x: 0.5, // 横中央に配置
+      y: 1,
+      xref: 'paper',
+      yref: 'paper',
+      xanchor: 'center',
+      yanchor: 'bottom',
+      showarrow: false,
+      font: {
+        size: 15,
+        color: '#555',
+      },
+      bgcolor: 'rgba(255, 255, 255, 0.8)', // 半透明の背景
+      borderpad: 2,
+      yshift: "15" as any, // 上側に寄せる
+    }
+  ] : [];
+
   return (
     <Box width="100%" height="100%" display="flex" flexDirection="column">
       <Box position="relative" flex="1">
@@ -203,103 +277,22 @@ export function ScatterChart({
         },
       }))}
       layout={{
-        margin: { l: 50, r: 50, b: 50, t: 50 }, // マージンを増やして軸ラベルのスペースを確保
+        margin: showAxisLabels ? { l: 50, r: 50, b: 50, t: 50 } : { l: 0, r: 0, b: 0, t: 0 }, // マージンを増やして軸ラベルのスペースを確保
         xaxis: {
           zeroline: false,
-          showticklabels: true, // 目盛りラベルを表示
-          title: {
-            text: axisInfo ? axisInfo.x.name : "X軸",
-            font: {
-              size: 14,
-              color: '#333',
-            },
-          },
+          showticklabels: false, // 目盛りラベルを非表示
+          showgrid: true, // グリッド線を非表示
         },
         yaxis: {
           zeroline: false,
-          showticklabels: true, // 目盛りラベルを表示
-          title: {
-            text: axisInfo ? axisInfo.y.name : "Y軸",
-            font: {
-              size: 14,
-              color: '#333',
-            },
-            standoff: 0, // タイトルと軸の間隔を調整
-            // @ts-ignore - Plotlyの型定義にangleがないが実際は機能する
-            angle: -90, // 90度回転（左に倒す）
-          } as any,
+          showticklabels: false, // 目盛りラベルを非表示
+          showgrid: true, // グリッド線を非表示
         },
         hovermode: "closest",
         dragmode: "pan", // ドラッグによる移動（パン）を有効化
         annotations: [
-          // X軸の小さい側のラベル
-          {
-            text: axisInfo ? axisInfo.x.min : "小",
-            x: 0,
-            y: 0,
-            xref: 'paper',
-            yref: 'paper',
-            xanchor: 'left',
-            yanchor: 'top',
-            showarrow: false,
-            font: {
-              size: 12,
-              color: '#555',
-            },
-            xshift: 5,
-            yshift: -15,
-          },
-          // X軸の大きい側のラベル
-          {
-            text: axisInfo ? axisInfo.x.max : "大",
-            x: 1,
-            y: 0,
-            xref: 'paper',
-            yref: 'paper',
-            xanchor: 'right',
-            yanchor: 'top',
-            showarrow: false,
-            font: {
-              size: 12,
-              color: '#555',
-            },
-            xshift: -5,
-            yshift: -15,
-          },
-          // Y軸の小さい側のラベル
-          {
-            text: axisInfo ? axisInfo.y.min : "小",
-            x: 0.02, // グラフ内に配置
-            y: 0.02,
-            xref: 'paper',
-            yref: 'paper',
-            xanchor: 'left',
-            yanchor: 'bottom',
-            showarrow: false,
-            font: {
-              size: 12,
-              color: '#555',
-            },
-            bgcolor: 'rgba(255, 255, 255, 0.8)', // 半透明の背景
-            borderpad: 2,
-          },
-          // Y軸の大きい側のラベル
-          {
-            text: axisInfo ? axisInfo.y.max : "大",
-            x: 0.02, // グラフ内に配置
-            y: 0.98,
-            xref: 'paper',
-            yref: 'paper',
-            xanchor: 'left',
-            yanchor: 'top',
-            showarrow: false,
-            font: {
-              size: 12,
-              color: '#555',
-            },
-            bgcolor: 'rgba(255, 255, 255, 0.8)', // 半透明の背景
-            borderpad: 2,
-          },
+          // 軸ラベル
+          ...(axisAnnotations as any),
           // クラスターのラベル
           ...(showClusterLabels ? clusterData.map((data) => ({
             x: data.centerX,

--- a/client/components/report/Chart.tsx
+++ b/client/components/report/Chart.tsx
@@ -26,6 +26,35 @@ export function Chart({
   treemapLevel,
   onTreeZoom,
 }: ReportProps) {
+
+  let axisInfo: {
+    x: {
+      name: string;
+      min: string;
+      max: string;
+    };
+    y: {
+      name: string;
+      min: string;
+      max: string;
+    };
+  } | undefined = undefined;
+  console.log(result.x_axis, result.y_axis);
+  if ("x_axis" in result && "y_axis" in result) {
+    axisInfo = {
+      x: {
+        name: result.x_axis.axis_name,
+        min: result.x_axis.min_label,
+        max: result.x_axis.max_label,
+      },
+      y: {
+        name: result.y_axis.axis_name,
+        min: result.y_axis.min_label,
+        max: result.y_axis.max_label,
+      },
+    };
+  }
+
   if (isFullscreen) {
     return (
       <Box
@@ -66,6 +95,7 @@ export function Chart({
             }
             onHover={() => setTimeout(avoidHoverTextCoveringShrinkButton, 500)}
             showClusterLabels={showClusterLabels}
+            axisInfo={axisInfo}
           />
         )}
         {selectedChart === "treemap" && (
@@ -105,6 +135,7 @@ export function Chart({
                 : Math.max(...result.clusters.map((c) => c.level))
             }
             showClusterLabels={showClusterLabels}
+            axisInfo={axisInfo}
           />
         )}
       </Box>

--- a/client/components/report/Chart.tsx
+++ b/client/components/report/Chart.tsx
@@ -12,6 +12,8 @@ type ReportProps = {
   onExitFullscreen: () => void;
   showClusterLabels: boolean;
   onToggleClusterLabels: (show: boolean) => void;
+  showAxisLabels: boolean;
+  onToggleAxisLabels: (show: boolean) => void;
   treemapLevel: string;
   onTreeZoom: (level: string) => void;
 };
@@ -23,34 +25,32 @@ export function Chart({
   onExitFullscreen,
   showClusterLabels,
   onToggleClusterLabels,
+  showAxisLabels,
+  onToggleAxisLabels,
   treemapLevel,
   onTreeZoom,
 }: ReportProps) {
 
   let axisInfo: {
     x: {
-      name: string;
-      min: string;
-      max: string;
+      min_label: string;
+      max_label: string;
     };
     y: {
-      name: string;
-      min: string;
-      max: string;
+      min_label: string;
+      max_label: string;
     };
   } | undefined = undefined;
   console.log(result.x_axis, result.y_axis);
   if ("x_axis" in result && "y_axis" in result) {
     axisInfo = {
       x: {
-        name: result.x_axis.axis_name,
-        min: result.x_axis.min_label,
-        max: result.x_axis.max_label,
+        min_label: result.x_axis.min_label,
+        max_label: result.x_axis.max_label,
       },
       y: {
-        name: result.y_axis.axis_name,
-        min: result.y_axis.min_label,
-        max: result.y_axis.max_label,
+        min_label: result.y_axis.min_label,
+        max_label: result.y_axis.max_label,
       },
     };
   }
@@ -95,6 +95,7 @@ export function Chart({
             }
             onHover={() => setTimeout(avoidHoverTextCoveringShrinkButton, 500)}
             showClusterLabels={showClusterLabels}
+            showAxisLabels={showAxisLabels}
             axisInfo={axisInfo}
           />
         )}
@@ -135,6 +136,7 @@ export function Chart({
                 : Math.max(...result.clusters.map((c) => c.level))
             }
             showClusterLabels={showClusterLabels}
+            showAxisLabels={showAxisLabels}
             axisInfo={axisInfo}
           />
         )}

--- a/client/components/report/ClientContainer.tsx
+++ b/client/components/report/ClientContainer.tsx
@@ -21,6 +21,7 @@ export function ClientContainer({ result }: Props) {
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [isDenseGroupEnabled, setIsDenseGroupEnabled] = useState(true);
   const [showClusterLabels, setShowClusterLabels] = useState(true);
+  const [showAxisLabels, setShowAxisLabels] = useState(false);
   const [treemapLevel, setTreemapLevel] = useState("0");
 
   // maxDensityやminValueが変化するたびに密度フィルターの結果をチェック
@@ -71,6 +72,8 @@ export function ClientContainer({ result }: Props) {
           onChangeFilter={onChangeDensityFilter}
           showClusterLabels={showClusterLabels}
           onToggleClusterLabels={setShowClusterLabels}
+          showAxisLabels={showAxisLabels}
+          onToggleAxisLabels={setShowAxisLabels}
         />
       )}
       <SelectChartButton
@@ -101,6 +104,8 @@ export function ClientContainer({ result }: Props) {
         }}
         showClusterLabels={showClusterLabels}
         onToggleClusterLabels={setShowClusterLabels}
+        showAxisLabels={showAxisLabels}
+        onToggleAxisLabels={setShowAxisLabels}
         treemapLevel={treemapLevel}
         onTreeZoom={setTreemapLevel}
       />

--- a/client/components/report/DisplaySettingDialog.tsx
+++ b/client/components/report/DisplaySettingDialog.tsx
@@ -17,6 +17,8 @@ type Props = {
   currentMinValue: number;
   showClusterLabels?: boolean;
   onToggleClusterLabels?: (show: boolean) => void;
+  showAxisLabels?: boolean;
+  onToggleAxisLabels?: (show: boolean) => void;
 };
 
 export function DisplaySettingDialog({
@@ -26,6 +28,8 @@ export function DisplaySettingDialog({
   currentMinValue,
   showClusterLabels = false,
   onToggleClusterLabels,
+  showAxisLabels = false,
+  onToggleAxisLabels,
 }: Props) {
   const [maxDensity, setMaxDensity] = useState(currentMaxDensity);
   const [minValue, setMinValue] = useState(currentMinValue);
@@ -61,6 +65,30 @@ export function DisplaySettingDialog({
                   size="sm"
                 />
               </HStack>
+            </Box>
+            
+            <Box 
+              p={2} 
+              borderRadius="md" 
+              borderWidth="1px" 
+              borderColor="gray.200"
+              mb={2}
+            >
+              <Box>
+                <HStack gap={2} alignItems="center" mb={1}>
+                  <Text fontSize="sm">軸ラベルを表示（試験中）</Text>
+                  <Spacer />
+                  <Switch 
+                    checked={showAxisLabels} 
+                    onChange={() => onToggleAxisLabels?.(!showAxisLabels)}
+                    size="sm"
+                  />
+                </HStack>
+                <Text fontSize="xs" color="gray.500" ml={1}>
+                  ※AIが生成したラベルのため、内容は不確かな場合があります。<br/>
+                  データの多様性が高い場合、不確かなラベルが生成されることがあります。
+                </Text>
+              </Box>
             </Box>
           </Box>
 

--- a/client/type.d.ts
+++ b/client/type.d.ts
@@ -28,6 +28,16 @@ export type Result = {
   overview: string; // 解析概要
   config: Config; // 設定情報
   comment_num: number; // コメント数
+  x_axis: {
+    axis_name: string; // X 軸の名前
+    min_label: string; // X 軸の小さい側のラベル
+    max_label: string; // X 軸の大きい側のラベル
+  };
+  y_axis: {
+    axis_name: string; // Y 軸の名前
+    min_label: string; // Y 軸の小さい側のラベル
+    max_label: string; // Y 軸の大きい側のラベル
+  };
 };
 
 type Argument = {


### PR DESCRIPTION
これは実験です、現状の設計を無理くり改造して実装しているので、絶対にマージしてはいけません。

# 変更の概要
TTCの時も、横軸と縦軸は何なのか？というのを尋ねられることが多かった。
いっそのこと、LLMに横軸と縦軸が何なのかを推定させてしまえばよいじゃないか、という実験

# スクリーンショット
![](https://github.com/user-attachments/assets/47654f82-d0e8-4f8a-8873-d90a358abb36)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 散布図チャートにX軸・Y軸の名称および最小・最大ラベルが表示されるようになりました。
  - 軸ラベルや最小・最大値ラベルがチャート内に明示的に表示され、軸の可読性が向上しました。

- **改善**
  - チャートの余白が拡大され、軸ラベルの表示が見やすくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->