### PR TITLE
LocalLLM 接続先の例を修正

### DIFF
--- a/client-admin/app/create/components/AISettingsSection.tsx
+++ b/client-admin/app/create/components/AISettingsSection.tsx
@@ -125,7 +125,7 @@ export function AISettingsSection({
             </Button>
           </HStack>
           <Field.HelperText>
-            ローカルで実行中のLLMサーバーのアドレスを指定してください。例: ollama:11434
+            OpenAI互換インターフェースで動作しているLLMサーバ（ollamaやLM Studio）のアドレスを指定してください。 広聴AIのdockerでollamaサーバを起動している場合は ollama:11434 で接続できます。
           </Field.HelperText>
         </Field.Root>
       )}

--- a/client-admin/app/create/components/AISettingsSection.tsx
+++ b/client-admin/app/create/components/AISettingsSection.tsx
@@ -110,7 +110,7 @@ export function AISettingsSection({
           <Field.Label>LocalLLM接続設定</Field.Label>
           <HStack>
             <Input
-              placeholder="127.0.0.1:1234"
+              placeholder="ollama:11434"
               value={localLLMAddress}
               onChange={(e) => setLocalLLMAddress && setLocalLLMAddress(e.target.value)}
             />
@@ -125,7 +125,7 @@ export function AISettingsSection({
             </Button>
           </HStack>
           <Field.HelperText>
-            ローカルで実行中のLLMサーバーのアドレスを指定してください。例: 127.0.0.1:1234
+            ローカルで実行中のLLMサーバーのアドレスを指定してください。例: ollama:11434
           </Field.HelperText>
         </Field.Root>
       )}


### PR DESCRIPTION
# 変更の概要
- ローカルLLMの接続先の例を修正します

# スクリーンショット
- UIの変更を伴う場合は、変更前後のスクリーンショットもしくはgif画像をこちらに記載してください
## 変更前
![Screenshot From 2025-05-12 14-30-38](https://github.com/user-attachments/assets/6374d60b-5de1-4120-8f87-8b051c1dc276)

## 変更後
![Screenshot From 2025-05-12 14-29-54](https://github.com/user-attachments/assets/f2f4e18d-cad7-49c4-8108-c1f5fc4c5a36)


# 変更の背景
#483 を見ると説明がミスリードしているため

# 関連Issue
#483 

# 動作確認の結果
<!-- 実装者は動作確認の結果を記載してください（例: レポート作成を実行し、正常にレポートが作成されることを確認した） 複数の動作確認を行った場合は、それぞれの結果を記載してください -->
意図通りに画面上の説明が修正されていることを確認した（上記のスクリーンショット）

# マージ前のチェックリスト（レビュアーがマージ前に確認してください）
- [ ] CIが全て通過している
- [ ] 単体テストが実装されているか
- [ ] 今回実装した機能および影響を受けると思われる機能について、適切な動作確認が行われているかを確認する。


動作確認の項目については、実装者による動作確認のケースが適切かを確認してください。
必要に応じてレビュアー自身による動作確認を行っても良いですが、動作確認は必須ではありません。

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **スタイル**
  - LocalLLM接続アドレス入力欄のプレースホルダーを「127.0.0.1:1234」から「ollama:11434」に変更しました。
  - ヘルパーテキストを、OpenAI互換のLLMサーバー（例：ollamaやLM Studio）を指定する詳細な説明に更新し、dockerセットアップ時のアドレス例「ollama:11434」を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->