### PR TITLE
hide ScatterChart grid lines

### DIFF
--- a/client/components/charts/ScatterChart.tsx
+++ b/client/components/charts/ScatterChart.tsx
@@ -194,10 +194,12 @@ export function ScatterChart({
         xaxis: {
           zeroline: false,
           showticklabels: false,
+          showgrid: false,
         },
         yaxis: {
           zeroline: false,
           showticklabels: false,
+          showgrid: false,
         },
         hovermode: "closest",
         dragmode: "pan", // ドラッグによる移動（パン）を有効化


### PR DESCRIPTION
# 変更の概要
ScatterChartのグリッドを非表示にします

# スクリーンショット
<img width="1017" alt="image" src="https://github.com/user-attachments/assets/6d3c3ec9-d4eb-4db9-927f-3acb29a14c8b" />

# 変更の背景
縦軸と横軸に意味があると勘違いさせないため

# 関連Issue
#488 

# 動作確認の結果
上記キャプチャの通りになりました。

# マージ前のチェックリスト（レビュアーがマージ前に確認してください）
- [x] CIが全て通過している
- [x] 単体テストが実装されているか
- [x] 今回実装した機能および影響を受けると思われる機能について、適切な動作確認が行われているかを確認する。

動作確認の項目については、実装者による動作確認のケースが適切かを確認してください。
必要に応じてレビュアー自身による動作確認を行っても良いですが、動作確認は必須ではありません。

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **スタイル**
  - 散布図チャートのX軸およびY軸のグリッド線が非表示になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->