### PR TITLE
Update README.md `docker compose up` の時間短縮

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@
     - ブラウザで http://localhost:4000 にアクセスすることで管理画面にアクセス可能
     - 環境変数（.env）を編集した場合は、`docker compose down` を実行した後、 `docker compose up --build` を実行してアプリケーションを起動してください
       - 一部の環境変数は Docker イメージのビルド時に埋め込まれているため、環境変数を変更した場合はビルドの再実行が必要となります
+    - すべてのモジュールを起動すると遅い場合は `docker compose up --no-deps client api` など適宜絞って起動できます
 
 ### ローカル LLM の使用
 


### PR DESCRIPTION
# 変更の概要
docker compose up の時間を短縮する方法をREADMEに追記

# 変更の背景
docker compose up に時間がかかるため、
UIの軽微な修正を確認したい時など煩雑。

# 関連Issue
なし

# 動作確認の結果
up, down ともに数分かかっていたのが、up が約30秒、　downが1-2秒まで縮まりました。

# マージ前のチェックリスト（レビュアーがマージ前に確認してください）
- [x] CIが全て通過している
- [x] 単体テストが実装されているか
- [x] 今回実装した機能および影響を受けると思われる機能について、適切な動作確認が行われているかを確認する。

動作確認の項目については、実装者による動作確認のケースが適切かを確認してください。
必要に応じてレビュアー自身による動作確認を行っても良いですが、動作確認は必須ではありません。

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **ドキュメント**
  - 開発者向けセットアップ手順に、`docker compose up` で特定サービスのみを `--no-deps` オプション付きで起動する方法に関する注意書きを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->