### PR TITLE
ScatterChartの全画面表示でボタンが重ならないようにする

### DIFF
--- a/client/components/charts/ScatterChart.tsx
+++ b/client/components/charts/ScatterChart.tsx
@@ -19,7 +19,7 @@ export function ScatterChart({
 }: Props) {
   const targetClusters = clusterList.filter(
     (cluster) => cluster.level === targetLevel,
-  );  
+  );
   const softColors = [
     "#7ac943",
     "#3fa9f5",
@@ -74,7 +74,11 @@ export function ScatterChart({
   const clusterColorMapA = targetClusters.reduce(
     (acc, cluster, index) => {
       const alpha = 0.8; // アルファ値を指定
-      acc[cluster.id] = softColors[index % softColors.length] + Math.floor(alpha * 255).toString(16).padStart(2, '0');
+      acc[cluster.id] =
+        softColors[index % softColors.length] +
+        Math.floor(alpha * 255)
+          .toString(16)
+          .padStart(2, "0");
       return acc;
     },
     {} as Record<string, string>,
@@ -90,10 +94,10 @@ export function ScatterChart({
 
     const alphabetWidth = 0.6; // 英字の幅
 
-    let result = '';
-    let currentLine = '';
+    let result = "";
+    let currentLine = "";
     let currentLineLength = 0;
-    
+
     // 文字ごとに処理
     for (let i = 0; i < text.length; i++) {
       const char = text[i];
@@ -113,32 +117,35 @@ export function ScatterChart({
         currentLine += char; // 現在の行に文字を追加
       }
     }
-    
+
     // 最後の行を追加
     if (currentLine) {
       result += `${currentLine}`;
     }
-    
+
     return result;
   };
 
   const onUpdate = (_event: unknown) => {
-    // Plotly単体で設定できないデザインを、onUpdateのタイミングでSVGをオーバーライドして解決する
+    // Plotly単体で設定できないデザインを、onUpdateのタイミングでHTMLをオーバーライドして解決する
 
     // アノテーションの角を丸にする
-    const bgRound = 4
+    const bgRound = 4;
     try {
-      document.querySelectorAll('g.annotation').forEach((g) => {
-        const bg = g.querySelector('rect.bg');
+      for (const g of document.querySelectorAll("g.annotation")) {
+        const bg = g.querySelector("rect.bg");
         if (bg) {
-          bg.setAttribute('rx', `${bgRound}px`);
-          bg.setAttribute('ry', `${bgRound}px`);
+          bg.setAttribute("rx", `${bgRound}px`);
+          bg.setAttribute("ry", `${bgRound}px`);
         }
-      });
+      }
     } catch (error) {
-      console.error('アノテーション要素の角丸化に失敗しました:', error);
+      console.error("アノテーション要素の角丸化に失敗しました:", error);
     }
-  }
+
+    // プロット操作用アイコンのエリアを「全画面終了」ボタンの下に移動する
+    avoidModBarCoveringShrinkButton();
+  };
 
   const clusterData = targetClusters.map((cluster) => {
     const clusterArguments = argumentList.filter((arg) =>
@@ -168,70 +175,94 @@ export function ScatterChart({
     <Box width="100%" height="100%" display="flex" flexDirection="column">
       <Box position="relative" flex="1">
         <ChartCore
-        data={clusterData.map((data) => ({
-        x: data.xValues,
-        y: data.yValues,
-        mode: "markers",
-        marker: {
-          size: 7,
-          color: clusterColorMap[data.cluster.id],
-        },
-        type: "scatter",
-        text: data.texts,
-        hoverinfo: "text",
-        hoverlabel: {
-          align: "left",
-          bgcolor: "white",
-          bordercolor: clusterColorMap[data.cluster.id],
-          font: {
-            size: 12,
-            color: "#333",
-          },
-        },
-      }))}
-      layout={{
-        margin: { l: 0, r: 0, b: 0, t: 0 },
-        xaxis: {
-          zeroline: false,
-          showticklabels: false,
-          showgrid: false,
-        },
-        yaxis: {
-          zeroline: false,
-          showticklabels: false,
-          showgrid: false,
-        },
-        hovermode: "closest",
-        dragmode: "pan", // ドラッグによる移動（パン）を有効化
-        annotations: showClusterLabels ? clusterData.map((data) => ({
-          x: data.centerX,
-          y: data.centerY,
-          text: wrapLabelText(data.cluster.label), // ラベルを折り返し処理
-          showarrow: false,
-          font: {
-            color: "white",
-            size: annotationFontsize,
-            weight: 700,
-          },
-          bgcolor: clusterColorMapA[data.cluster.id], // 背景はアルファ付き
-          borderpad: 10,
-          width: annotationLabelWidth,
-          align: 'left',
-        })) : [],
-        showlegend: false,
-      }}
-      useResizeHandler={true}
-      style={{ width: "100%", height: "100%" }}
-      config={{
-        responsive: true,
-        displayModeBar: "hover", // 操作時にツールバーを表示
-        scrollZoom: true, // マウスホイールによるズームを有効化
-        locale: "ja",
-      }}
-      onHover={onHover}
-      onUpdate={onUpdate}
+          data={clusterData.map((data) => ({
+            x: data.xValues,
+            y: data.yValues,
+            mode: "markers",
+            marker: {
+              size: 7,
+              color: clusterColorMap[data.cluster.id],
+            },
+            type: "scatter",
+            text: data.texts,
+            hoverinfo: "text",
+            hoverlabel: {
+              align: "left",
+              bgcolor: "white",
+              bordercolor: clusterColorMap[data.cluster.id],
+              font: {
+                size: 12,
+                color: "#333",
+              },
+            },
+          }))}
+          layout={{
+            margin: { l: 0, r: 0, b: 0, t: 0 },
+            xaxis: {
+              zeroline: false,
+              showticklabels: false,
+              showgrid: false,
+            },
+            yaxis: {
+              zeroline: false,
+              showticklabels: false,
+              showgrid: false,
+            },
+            hovermode: "closest",
+            dragmode: "pan", // ドラッグによる移動（パン）を有効化
+            annotations: showClusterLabels
+              ? clusterData.map((data) => ({
+                  x: data.centerX,
+                  y: data.centerY,
+                  text: wrapLabelText(data.cluster.label), // ラベルを折り返し処理
+                  showarrow: false,
+                  font: {
+                    color: "white",
+                    size: annotationFontsize,
+                    weight: 700,
+                  },
+                  bgcolor: clusterColorMapA[data.cluster.id], // 背景はアルファ付き
+                  borderpad: 10,
+                  width: annotationLabelWidth,
+                  align: "left",
+                }))
+              : [],
+            showlegend: false,
+          }}
+          useResizeHandler={true}
+          style={{ width: "100%", height: "100%" }}
+          config={{
+            responsive: true,
+            displayModeBar: "hover", // 操作時にツールバーを表示
+            scrollZoom: true, // マウスホイールによるズームを有効化
+            locale: "ja",
+          }}
+          onHover={onHover}
+          onUpdate={onUpdate}
         />
       </Box>
     </Box>
   );
+}
+
+function avoidModBarCoveringShrinkButton(): void {
+  const modeBarContainer = document.querySelector(
+    ".modebar-container",
+  ) as HTMLElement;
+  if (!modeBarContainer) return;
+  const modeBar = modeBarContainer.children[0] as HTMLElement;
+  const shrinkButton = document.getElementById("fullScreenButtons");
+  if (!modeBar || !shrinkButton) return;
+  const modeBarPos = modeBar.getBoundingClientRect();
+  const btnPos = shrinkButton.getBoundingClientRect();
+  const isCovered = !(
+    btnPos.top > modeBarPos.bottom ||
+    btnPos.bottom < modeBarPos.top ||
+    btnPos.left > modeBarPos.right ||
+    btnPos.right < modeBarPos.left
+  );
+  if (!isCovered) return;
+
+  const diff = btnPos.bottom - modeBarPos.top;
+  modeBarContainer.style.top = `${Number.parseInt(modeBarContainer.style.top.slice(0, -2)) + diff + 10}px`;
 }


### PR DESCRIPTION
# 変更の概要
ScatterChartの全画面表示で「全画面終了」ボタンとその他のボタンが重ならないよう、その他のボタンのエリアを下方向に移動する

# スクリーンショット
<img width="455" alt="image" src="https://github.com/user-attachments/assets/e810d116-cc76-461b-830b-767d2144f2b6" />

# 関連Issue
#479 

# 動作確認の結果
- 全画面の場合は上記キャプチャの通り重ならないようになった
- 全画面でない場合は従来通り↓
<img width="361" alt="image" src="https://github.com/user-attachments/assets/a877b5e5-4d97-495a-9d1f-a5f1d3979dba" />

# マージ前のチェックリスト（レビュアーがマージ前に確認してください）
- [x] CIが全て通過している
- [x] 単体テストが実装されているか
- [x] 今回実装した機能および影響を受けると思われる機能について、適切な動作確認が行われているかを確認する。

動作確認の項目については、実装者による動作確認のケースが適切かを確認してください。
必要に応じてレビュアー自身による動作確認を行っても良いですが、動作確認は必須ではありません。

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - Plotlyのモードバーが全画面ボタンと重ならないようにUIを調整しました。

- **スタイル**
  - コードのフォーマットとインデントを改善し、可読性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->