### PR TITLE
Add Windows manual startup support (venv/npm) - resolves #999

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,40 @@ make client-setup
 make client-dev -j 3
 ```
 
+
+### セットアップ・起動 手順（開発用にWindowsでDockerを使わずに実行する場合）
+* リポジトリをクローン
+* `copy .env.example .env` をコンソールで実行
+  * コピー後に各環境変数を設定。各環境変数の意味は.env.exampleに記載。
+* Node.jsの確認 `node -v` `npm -v`
+  * 存在しない場合は https://nodejs.org/ja から LTS バージョンをインストール
+* Pythonの確認 `python --version`
+  * 存在しない場合は https://www.python.org/downloads/windows/ から 3.12以上のバージョンをインストール
+* client フォルダで依存ライブラリをインストール
+``` cmd
+cd client
+npm install
+cd ..
+```
+* client-admin フォルダで依存ライブラリをインストール
+``` cmd
+cd client-admin
+npm install
+cd ..
+``` 
+* server フォルダで Python 仮想環境を作成し、依存ライブラリをインストール
+``` cmd
+cd server
+python -m venv venv
+call venv\Scripts\activate
+pip install --upgrade pip
+pip install .
+cd ..
+```
+* dev_win_direct.bat を実行
+  * ブラウザで http://localhost:3000 にアクセスすることでレポート一覧画面にアクセス可能
+  * ブラウザで http://localhost:4000 にアクセスすることで管理画面にアクセス可能
+
 ## 免責事項
 大規模言語モデル（LLM）にはバイアスがあり、信頼性の低い結果を生成することが知られています。私たちはこれらの問題を軽減する方法に積極的に取り組んでいますが、現段階ではいかなる保証も提供することはできません。特に重要な決定を下す際は、本アプリの出力結果のみに依存せず、必ず内容を検証してください。
 

--- a/dev_win_direct.bat
+++ b/dev_win_direct.bat
@@ -1,0 +1,90 @@
+@echo off
+setlocal enabledelayedexpansion
+
+rem === Check if .env exists ===
+if not exist ".env" (
+    echo [ERROR] .env file not found.
+    echo Please create it using the following steps:
+    echo   1. Copy .env.example to .env
+    echo   2. Edit environment variables - see .env.example for details
+    echo.
+    pause
+    exit /b 1
+)
+
+rem ----- Initialization -----
+set CLIENT_ENV=client\.env
+set ADMIN_ENV=client-admin\.env
+set SERVER_ENV=server\.env
+
+(del %CLIENT_ENV%) >nul 2>&1
+(del %ADMIN_ENV%) >nul 2>&1
+(del %SERVER_ENV%) >nul 2>&1
+
+rem ----- Parse .env and generate per-service env files -----
+for /f "usebackq tokens=1,* delims==" %%A in (".env") do (
+    set KEY=%%A
+    set VALUE=%%B
+
+    rem Skip empty lines and comments
+    echo !KEY! | findstr /b "#" >nul && (
+        rem skip comment
+    ) || if not "!KEY!"=="" (
+        rem server env
+        if /i "!KEY!"=="OPENAI_API_KEY" (
+            echo !KEY!=!VALUE!>>%SERVER_ENV%
+        ) else if /i "!KEY!"=="PUBLIC_API_KEY" (
+            echo !KEY!=!VALUE!>>%SERVER_ENV%
+        ) else if /i "!KEY!"=="ADMIN_API_KEY" (
+            echo !KEY!=!VALUE!>>%SERVER_ENV%
+        ) else if /i "!KEY!"=="ENVIRONMENT" (
+            echo !KEY!=!VALUE!>>%SERVER_ENV%
+        ) else if /i "!KEY!"=="STORAGE_TYPE" (
+            echo !KEY!=!VALUE!>>%SERVER_ENV%
+        )
+
+        rem client env
+        if /i "!KEY!"=="NEXT_PUBLIC_API_BASEPATH" (
+            echo !KEY!=!VALUE!>>%CLIENT_ENV%
+        ) else if /i "!KEY!"=="NEXT_PUBLIC_PUBLIC_API_KEY" (
+            echo !KEY!=!VALUE!>>%CLIENT_ENV%
+        ) else if /i "!KEY!"=="NEXT_PUBLIC_SITE_URL" (
+            echo !KEY!=!VALUE!>>%CLIENT_ENV%
+        ) else if /i "!KEY!"=="NEXT_PUBLIC_GA_MEASUREMENT_ID" (
+            echo !KEY!=!VALUE!>>%CLIENT_ENV%
+        )
+
+        rem client-admin env
+        if /i "!KEY!"=="NEXT_PUBLIC_CLIENT_BASEPATH" (
+            echo !KEY!=!VALUE!>>%ADMIN_ENV%
+        ) else if /i "!KEY!"=="NEXT_PUBLIC_API_BASEPATH" (
+            echo !KEY!=!VALUE!>>%ADMIN_ENV%
+        ) else if /i "!KEY!"=="NEXT_PUBLIC_ADMIN_API_KEY" (
+            echo !KEY!=!VALUE!>>%ADMIN_ENV%
+        ) else if /i "!KEY!"=="BASIC_AUTH_USERNAME" (
+            echo !KEY!=!VALUE!>>%ADMIN_ENV%
+        ) else if /i "!KEY!"=="BASIC_AUTH_PASSWORD" (
+            echo !KEY!=!VALUE!>>%ADMIN_ENV%
+        ) else if /i "!KEY!"=="NEXT_PUBLIC_ADMIN_GA_MEASUREMENT_ID" (
+            echo !KEY!=!VALUE!>>%ADMIN_ENV%
+        )
+    )
+)
+
+rem ----------- Launch all services ------------
+cd server
+call venv\Scripts\activate
+set PYTHON_EXECUTABLE=%CD%\venv\Scripts\python.exe
+start "server" cmd /k "call venv\Scripts\activate && uvicorn src.main:app --host 0.0.0.0 --port 8000 --reload"
+cd ..
+
+cd client
+start "client" cmd /k "npm run dev"
+cd ..
+
+cd client-admin
+start "client-admin" cmd /k "npm run dev"
+cd ..
+
+echo === All services launched!
+pause

--- a/server/src/services/report_launcher.py
+++ b/server/src/services/report_launcher.py
@@ -1,11 +1,11 @@
 import json
+import os
 import subprocess
 import threading
 from pathlib import Path
 from typing import Any
 
 import pandas as pd
-
 from src.config import settings
 from src.schemas.admin_report import ReportInput
 from src.services.report_status import add_new_report_to_status, set_status
@@ -120,7 +120,8 @@ def launch_report_generation(report_input: ReportInput) -> None:
         add_new_report_to_status(report_input)
         config_path = save_config_file(report_input)
         save_input_file(report_input)
-        cmd = ["python", "hierarchical_main.py", config_path, "--skip-interaction", "--without-html"]
+        python_cmd = os.environ.get("PYTHON_EXECUTABLE", "python")
+        cmd = [python_cmd, "hierarchical_main.py", config_path, "--skip-interaction", "--without-html"]
         execution_dir = settings.TOOL_DIR / "pipeline"
         process = subprocess.Popen(cmd, cwd=execution_dir)
         threading.Thread(target=_monitor_process, args=(process, report_input.input), daemon=True).start()


### PR DESCRIPTION
# 変更の概要
- Windows 環境で Docker を使わずに手動でセットアップできるようにするためのスクリプトおよび手順を追加しました。
- `.env` 設定、仮想環境の準備、依存ライブラリのインストール、実行用の補助スクリプトなどを含みます。

# スクリーンショット
- UIの変更はありません。

# 変更の背景
- Issue #254 の調査を進める中で、Windows 環境での実行手段として「生環境構築」も検証しました。
- 開発時には WSL2 や Docker を立ち上げることが比較的重いため、軽量な起動ができる選択肢として「生環境での実行」も許容していただければと思います（どちらかというと私自身の開発効率向上の観点からの提案です、他に使う人もいなそうなら私だけマージして使ってますので、却下でも大丈夫です）。
- 今後も Docker や WSL2 による環境構築の整備は継続される見込みのため、これは補助的な手段として捉えています。

# 関連Issue
- https://github.com/digitaldemocracy2030/kouchou-ai/issues/254
-https://github.com/digitaldemocracy2030/kouchou-ai/issues/496
# CLAへの同意
- [x] コントリビューターライセンス契約（CLA）に同意します。