### PR TITLE
限定公開機能を実装

### DIFF
--- a/client-admin/app/page.tsx
+++ b/client-admin/app/page.tsx
@@ -502,10 +502,10 @@ function ReportCard({
             )}
             {report.status === "ready" && (
               <RadioCardRoot
-                value={report.isPublic ? "public" : "private"}
+                value={report.visibility}
                 onValueChange={async (value) => {
                   const selected = typeof value === "string" ? value : value?.value;
-                  if ((selected === "public" && report.isPublic) || (selected === "private" && !report.isPublic)) return;
+                  if (selected === report.visibility) return;
                   try {
                     const response = await fetch(
                       `${getApiBaseUrl()}/admin/reports/${report.slug}/visibility`,
@@ -523,7 +523,7 @@ function ReportCard({
                     }
                     const data = await response.json();
                     const updatedReports = reports?.map((r) =>
-                      r.slug === report.slug ? { ...r, isPublic: data.isPublic } : r,
+                      r.slug === report.slug ? { ...r, visibility: data.visibility } : r,
                     );
                     if (setReports) {
                       setReports(updatedReports);
@@ -543,6 +543,7 @@ function ReportCard({
                   onPointerDown={e => e.stopPropagation()}
                 >
                   <RadioCardItem value="public" label="公開" px={2} py={0.5} minW="40px" fontSize="sm" style={{whiteSpace: 'nowrap'}} />
+                  <RadioCardItem value="unlisted" label="限定公開" px={2} py={0.5} minW="60px" fontSize="sm" style={{whiteSpace: 'nowrap'}} />
                   <RadioCardItem value="private" label="非公開" px={2} py={0.5} minW="60px" fontSize="sm" style={{whiteSpace: 'nowrap'}} />
                 </Box>
               </RadioCardRoot>

--- a/client-admin/type.d.ts
+++ b/client-admin/type.d.ts
@@ -8,14 +8,20 @@ export type Meta = {
   brandColor?: string; // ブランドカラー
 };
 
+export enum ReportVisibility {
+  PUBLIC = "public",
+  PRIVATE = "private",
+  UNLISTED = "unlisted",
+}
+
 export type Report = {
   slug: string;
   status: string;
   title: string;
   description: string;
-  isPubcom: boolean;
-  isPublic?: boolean;
+  visibility: ReportVisibility;
   createdAt?: string; // 作成日時（ISO形式の文字列）
+  isPubcom: boolean;
 };
 
 export type Result = {

--- a/client-admin/type.d.ts
+++ b/client-admin/type.d.ts
@@ -19,9 +19,9 @@ export type Report = {
   status: string;
   title: string;
   description: string;
+  isPubcom: boolean;
   visibility: ReportVisibility;
   createdAt?: string; // 作成日時（ISO形式の文字列）
-  isPubcom: boolean;
 };
 
 export type Result = {

--- a/client/type.d.ts
+++ b/client/type.d.ts
@@ -19,9 +19,9 @@ export type Report = {
   status: string;
   title: string;
   description: string;
+  isPubcom: boolean;
   visibility: ReportVisibility;
   createdAt?: string; // 作成日時（ISO形式の文字列）
-  isPubcom: boolean;
 };
 
 export type Result = {

--- a/client/type.d.ts
+++ b/client/type.d.ts
@@ -8,13 +8,20 @@ export type Meta = {
   brandColor?: string; // ブランドカラー
 };
 
+export enum ReportVisibility {
+  PUBLIC = "public",
+  PRIVATE = "private",
+  UNLISTED = "unlisted",
+}
+
 export type Report = {
   slug: string;
   status: string;
   title: string;
   description: string;
-  isPublic?: boolean;
+  visibility: ReportVisibility;
   createdAt?: string; // 作成日時（ISO形式の文字列）
+  isPubcom: boolean;
 };
 
 export type Result = {

--- a/server/src/routers/admin_report.py
+++ b/server/src/routers/admin_report.py
@@ -118,9 +118,9 @@ async def delete_report(slug: str, api_key: str = Depends(verify_admin_api_key))
 @router.patch("/admin/reports/{slug}/visibility")
 async def update_report_visibility(slug: str, api_key: str = Depends(verify_admin_api_key)) -> dict:
     try:
-        is_public = toggle_report_public_state(slug)
+        visibility = toggle_report_public_state(slug)
 
-        return {"success": True, "isPublic": is_public}
+        return {"success": True, "visibility": visibility}
     except ValueError as e:
         slogger.error(f"ValueError: {e}", exc_info=True)
         raise HTTPException(status_code=404, detail=str(e)) from e

--- a/server/src/routers/admin_report.py
+++ b/server/src/routers/admin_report.py
@@ -14,8 +14,8 @@ from src.services.report_launcher import launch_report_generation
 from src.services.report_status import (
     load_status_as_reports,
     set_status,
-    toggle_report_visibility_state,
     update_report_metadata,
+    update_report_visibility_state,
 )
 from src.utils.logger import setup_logger
 
@@ -120,7 +120,7 @@ async def update_report_visibility(
     slug: str, visibility_update: ReportVisibilityUpdate, api_key: str = Depends(verify_admin_api_key)
 ) -> dict:
     try:
-        visibility = toggle_report_visibility_state(slug, visibility_update.visibility)
+        visibility = update_report_visibility_state(slug, visibility_update.visibility)
 
         return {"success": True, "visibility": visibility}
     except ValueError as e:

--- a/server/src/routers/admin_report.py
+++ b/server/src/routers/admin_report.py
@@ -116,7 +116,9 @@ async def delete_report(slug: str, api_key: str = Depends(verify_admin_api_key))
 
 
 @router.patch("/admin/reports/{slug}/visibility")
-async def update_report_visibility(slug: str, visibility_update: ReportVisibilityUpdate, api_key: str = Depends(verify_admin_api_key)) -> dict:
+async def update_report_visibility(
+    slug: str, visibility_update: ReportVisibilityUpdate, api_key: str = Depends(verify_admin_api_key)
+) -> dict:
     try:
         visibility = toggle_report_visibility_state(slug, visibility_update.visibility)
 

--- a/server/src/routers/admin_report.py
+++ b/server/src/routers/admin_report.py
@@ -7,14 +7,14 @@ from fastapi.responses import FileResponse, ORJSONResponse
 from fastapi.security.api_key import APIKeyHeader
 
 from src.config import settings
-from src.schemas.admin_report import ReportInput, ReportMetadataUpdate
+from src.schemas.admin_report import ReportInput, ReportMetadataUpdate, ReportVisibilityUpdate
 from src.schemas.report import Report, ReportStatus
 from src.services.llm_models import get_models_by_provider
 from src.services.report_launcher import launch_report_generation
 from src.services.report_status import (
     load_status_as_reports,
     set_status,
-    toggle_report_public_state,
+    toggle_report_visibility_state,
     update_report_metadata,
 )
 from src.utils.logger import setup_logger
@@ -116,9 +116,9 @@ async def delete_report(slug: str, api_key: str = Depends(verify_admin_api_key))
 
 
 @router.patch("/admin/reports/{slug}/visibility")
-async def update_report_visibility(slug: str, api_key: str = Depends(verify_admin_api_key)) -> dict:
+async def update_report_visibility(slug: str, visibility_update: ReportVisibilityUpdate, api_key: str = Depends(verify_admin_api_key)) -> dict:
     try:
-        visibility = toggle_report_public_state(slug)
+        visibility = toggle_report_visibility_state(slug, visibility_update.visibility)
 
         return {"success": True, "visibility": visibility}
     except ValueError as e:

--- a/server/src/routers/report.py
+++ b/server/src/routers/report.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter, Depends, HTTPException, Security
 from fastapi.security.api_key import APIKeyHeader
 
 from src.config import settings
-from src.schemas.report import Report, ReportStatus
+from src.schemas.report import Report, ReportStatus, ReportVisibility
 from src.services.report_status import load_status_as_reports
 
 logger = logging.getLogger("uvicorn")
@@ -25,7 +25,7 @@ async def verify_public_api_key(api_key: str = Security(api_key_header)):
 async def reports() -> list[Report]:
     all_reports = load_status_as_reports()
     ready_reports = [
-        report for report in all_reports if report.status == ReportStatus.READY and getattr(report, "is_public", True)
+        report for report in all_reports if report.status == ReportStatus.READY and report.is_publicly_visible
     ]
     return ready_reports
 
@@ -40,8 +40,8 @@ async def report(slug: str, api_key: str = Depends(verify_public_api_key)) -> di
         raise HTTPException(status_code=404, detail="Report not found")
     if target_report_status.status != ReportStatus.READY:
         raise HTTPException(status_code=404, detail="Report is not ready")
-    if not getattr(target_report_status, "is_public", True):
-        raise HTTPException(status_code=404, detail="Report not found")
+    if target_report_status.visibility == ReportVisibility.PRIVATE:
+        raise HTTPException(status_code=404, detail="Report is private")
     if not report_path.exists():
         raise HTTPException(status_code=404, detail="Report not found")
 

--- a/server/src/schemas/admin_report.py
+++ b/server/src/schemas/admin_report.py
@@ -1,6 +1,7 @@
 from typing import Literal
 
 from src.schemas.base import SchemaBaseModel
+from src.schemas.report import ReportVisibility
 
 
 class Comment(SchemaBaseModel):
@@ -41,3 +42,9 @@ class ReportMetadataUpdate(SchemaBaseModel):
 
     title: str | None = None  # レポートのタイトル
     description: str | None = None  # レポートの調査概要
+
+
+class ReportVisibilityUpdate(SchemaBaseModel):
+    """レポートの可視性更新用スキーマ"""
+
+    visibility: ReportVisibility  # レポートの可視性

--- a/server/src/schemas/report.py
+++ b/server/src/schemas/report.py
@@ -10,11 +10,22 @@ class ReportStatus(Enum):
     DELETED = "deleted"
 
 
+class ReportVisibility(Enum):
+    PUBLIC = "public"
+    UNLISTED = "unlisted"
+    PRIVATE = "private"
+
+
 class Report(SchemaBaseModel):
     slug: str
     title: str
     description: str
     status: ReportStatus
+    visibility: ReportVisibility
     is_pubcom: bool = False
-    is_public: bool = True  # デフォルトは公開状態
     created_at: str | None = None  # 作成日時
+
+    @property
+    def is_publicly_visible(self) -> bool:
+        """レポートが一般ユーザーに公開表示可能かどうかを返す"""
+        return self.visibility == ReportVisibility.PUBLIC

--- a/server/src/services/report_status.py
+++ b/server/src/services/report_status.py
@@ -124,7 +124,7 @@ def invalidate_report_cache(slug: str) -> None:
         logger.error(f"Failed to call revalidate API for {slug}: {e}")
 
 
-def toggle_report_visibility_state(slug: str, new_visibility: ReportVisibility) -> str:
+def update_report_visibility_state(slug: str, new_visibility: ReportVisibility) -> str:
     with _lock:
         if slug not in _report_status:
             raise ValueError(f"slug {slug} not found in report status")
@@ -132,9 +132,8 @@ def toggle_report_visibility_state(slug: str, new_visibility: ReportVisibility) 
         _report_status[slug]["visibility"] = new_visibility.value
 
         save_status()
-        invalidate_report_cache(slug)
-
-        return _report_status[slug]["visibility"]
+    invalidate_report_cache(slug)
+    return _report_status[slug]["visibility"]
 
 
 def update_report_metadata(slug: str, title: str = None, description: str = None) -> dict:
@@ -188,5 +187,5 @@ def update_report_metadata(slug: str, title: str = None, description: str = None
                 # ただしログには残す
                 logger.error(f"Failed to update hierarchical_result.json for {slug}: {e}")
 
-        invalidate_report_cache(slug)
-        return _report_status[slug]
+    invalidate_report_cache(slug)
+    return _report_status[slug]

--- a/server/src/services/report_status.py
+++ b/server/src/services/report_status.py
@@ -17,7 +17,8 @@ _lock = threading.RLock()
 _report_status = {}
 
 
-# NOTE: 広聴AIをver3.0にした段階で削除する
+# FIXME: report_status.jsonのフォーマット変更に対応するためのコード。広聴AIをver3.0にした段階で削除する。
+# https://github.com/digitaldemocracy2030/kouchou-ai/issues/507
 def convert_old_format_status(status: dict) -> dict:
     """旧形式のレポートのステータスを新形式に変換する
     旧形式では公開/非公開をis_publicで管理していたが、新形式ではvisibilityで管理している

--- a/server/src/services/report_status.py
+++ b/server/src/services/report_status.py
@@ -127,15 +127,14 @@ def invalidate_report_cache(slug: str) -> None:
 def toggle_report_visibility_state(slug: str, new_visibility: ReportVisibility) -> str:
     with _lock:
         if slug not in _report_status:
-            raise ValueError(f"slug {slug} not found in report status")        
+            raise ValueError(f"slug {slug} not found in report status")
         # enumの値を文字列に変換して保存
         _report_status[slug]["visibility"] = new_visibility.value
-        
+
         save_status()
         invalidate_report_cache(slug)
 
         return _report_status[slug]["visibility"]
-    
 
 
 def update_report_metadata(slug: str, title: str = None, description: str = None) -> dict:

--- a/server/tests/routers/test_admin_report.py
+++ b/server/tests/routers/test_admin_report.py
@@ -71,8 +71,8 @@ class TestUpdateReportVisibility:
 
     def test_update_report_visibility_success(self, client):
         """正常系：有効なスラッグと可視性で更新が成功するケース"""
-        # toggle_report_visibility_stateをモック化
-        with patch("src.routers.admin_report.toggle_report_visibility_state") as mock_toggle:
+        # update_report_visibility_stateをモック化
+        with patch("src.routers.admin_report.update_report_visibility_state") as mock_toggle:
             # モック関数の戻り値を設定
             mock_toggle.return_value = ReportVisibility.PUBLIC.value
 
@@ -92,8 +92,8 @@ class TestUpdateReportVisibility:
 
     def test_update_report_visibility_not_found(self, client):
         """異常系：存在しないスラッグで404エラーが発生するケース"""
-        # toggle_report_visibility_stateをモック化してValueErrorを発生させる
-        with patch("src.routers.admin_report.toggle_report_visibility_state") as mock_toggle:
+        # update_report_visibility_stateをモック化してValueErrorを発生させる
+        with patch("src.routers.admin_report.update_report_visibility_state") as mock_toggle:
             mock_toggle.side_effect = ValueError("slug non-existent-slug not found in report status")
             # 存在しないスラッグでリクエストを送信
             response = client.patch(

--- a/server/tests/routers/test_admin_report.py
+++ b/server/tests/routers/test_admin_report.py
@@ -1,0 +1,123 @@
+import json
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.routers.admin_report import router, verify_admin_api_key
+from src.schemas.report import ReportVisibility
+
+
+@pytest.fixture
+def temp_status_file():
+    """テスト用の一時的なステータスファイルを作成するフィクスチャ"""
+    # 一時ディレクトリを作成
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # テスト用のステータスファイルパスを設定
+        temp_status_file = Path(temp_dir) / "test_report_status.json"
+
+        # テスト用のデータを作成
+        test_data = {
+            "test-slug": {
+                "slug": "test-slug",
+                "status": "ready",
+                "title": "テストタイトル",
+                "description": "テスト説明",
+                "is_pubcom": True,
+                "visibility": ReportVisibility.UNLISTED.value,
+                "created_at": "2025-05-13T07:56:58.405239+00:00",
+            }
+        }
+
+        # テスト用のデータをファイルに書き込む
+        with open(temp_status_file, "w") as f:
+            json.dump(test_data, f)
+
+        # テスト用のパッチを適用
+        with patch("src.services.report_status.STATE_FILE", temp_status_file):
+            yield temp_status_file
+
+            # テスト後にファイルを削除（tempfileが自動的に行うが念のため）
+            if temp_status_file.exists():
+                os.unlink(temp_status_file)
+
+
+@pytest.fixture
+def app():
+    """テスト用のFastAPIアプリケーションを作成するフィクスチャ"""
+    app = FastAPI()
+    app.include_router(router)
+
+    # 認証をバイパスするためのオーバーライド
+    async def override_verify_admin_api_key():
+        return "test-api-key"
+
+    app.dependency_overrides[verify_admin_api_key] = override_verify_admin_api_key
+    return app
+
+
+@pytest.fixture
+def client(app):
+    """テスト用のクライアントを作成するフィクスチャ"""
+    return TestClient(app)
+
+
+class TestUpdateReportVisibility:
+    """update_report_visibilityエンドポイントのテスト"""
+
+    def test_update_report_visibility_success(self, client):
+        """正常系：有効なスラッグと可視性で更新が成功するケース"""
+        # toggle_report_visibility_stateをモック化
+        with patch("src.routers.admin_report.toggle_report_visibility_state") as mock_toggle:
+            # モック関数の戻り値を設定
+            mock_toggle.return_value = ReportVisibility.PUBLIC.value
+
+            # エンドポイントにリクエストを送信
+            response = client.patch(
+                "/admin/reports/test-slug/visibility",
+                json={"visibility": ReportVisibility.PUBLIC.value},
+                headers={"x-api-key": "test-api-key"},
+            )
+
+            # レスポンスを検証
+            assert response.status_code == 200
+            assert response.json() == {"success": True, "visibility": ReportVisibility.PUBLIC.value}
+
+            # モック関数が正しく呼び出されたことを確認
+            mock_toggle.assert_called_once_with("test-slug", ReportVisibility.PUBLIC)
+
+    def test_update_report_visibility_not_found(self, client):
+        """異常系：存在しないスラッグで404エラーが発生するケース"""
+        # toggle_report_visibility_stateをモック化してValueErrorを発生させる
+        with patch("src.routers.admin_report.toggle_report_visibility_state") as mock_toggle:
+            mock_toggle.side_effect = ValueError("slug non-existent-slug not found in report status")
+            # 存在しないスラッグでリクエストを送信
+            response = client.patch(
+                "/admin/reports/non-existent-slug/visibility",
+                json={"visibility": ReportVisibility.PUBLIC.value},
+                headers={"x-api-key": "test-api-key"},
+            )
+
+            # レスポンスを検証
+            assert response.status_code == 404
+            assert "not found in report status" in response.json()["detail"]
+
+    def test_update_report_visibility_unauthorized(self, client, app):
+        """認証エラー：無効なAPIキーで401エラーが発生するケース"""
+        # 依存関係のオーバーライドを元に戻す
+        app.dependency_overrides = {}
+
+        # 無効なAPIキーでリクエストを送信
+        response = client.patch(
+            "/admin/reports/test-slug/visibility",
+            json={"visibility": ReportVisibility.PUBLIC.value},
+            headers={"x-api-key": "invalid-api-key"},
+        )
+
+        # レスポンスを検証
+        assert response.status_code == 401
+        assert response.json()["detail"] == "Invalid API key"

--- a/server/tests/services/test_report_status.py
+++ b/server/tests/services/test_report_status.py
@@ -6,6 +6,8 @@ from src.schemas.report import ReportVisibility
 from src.services.report_status import convert_old_format_status
 
 
+# FIXME: report_status.jsonのフォーマット変更に対応するための関数のテストコード。広聴AIをver3.0にした段階で削除する。
+# https://github.com/digitaldemocracy2030/kouchou-ai/issues/507
 class TestReportStatus:
     """レポートステータス関連のテスト"""
 

--- a/server/tests/services/test_report_status.py
+++ b/server/tests/services/test_report_status.py
@@ -1,0 +1,155 @@
+from copy import deepcopy
+
+import pytest
+
+from src.schemas.report import ReportVisibility
+from src.services.report_status import convert_old_format_status
+
+
+class TestReportStatus:
+    """レポートステータス関連のテスト"""
+
+    @pytest.fixture
+    def old_format_public_data(self):
+        """is_public: trueを持つ旧形式のデータ"""
+        return {
+            "test-slug": {
+                "slug": "test-slug",
+                "status": "ready",
+                "title": "テストタイトル",
+                "description": "テスト説明",
+                "is_pubcom": True,
+                "created_at": "2025-05-13T07:56:58.405239+00:00",
+                "is_public": True,
+            }
+        }
+
+    @pytest.fixture
+    def old_format_private_data(self):
+        """is_public: falseを持つ旧形式のデータ"""
+        return {
+            "test-slug": {
+                "slug": "test-slug",
+                "status": "ready",
+                "title": "テストタイトル",
+                "description": "テスト説明",
+                "is_pubcom": True,
+                "created_at": "2025-05-13T07:56:58.405239+00:00",
+                "is_public": False,
+            }
+        }
+
+    @pytest.fixture
+    def new_format_data(self):
+        """visibilityを持つ新形式のデータ"""
+        return {
+            "test-slug": {
+                "slug": "test-slug",
+                "status": "ready",
+                "title": "テストタイトル",
+                "description": "テスト説明",
+                "is_pubcom": True,
+                "visibility": "unlisted",
+                "created_at": "2025-05-13T07:56:58.405239+00:00",
+            }
+        }
+
+    @pytest.fixture
+    def mixed_format_data(self):
+        """旧形式と新形式が混在したデータ"""
+        return {
+            "old-slug": {
+                "slug": "old-slug",
+                "status": "ready",
+                "title": "旧形式タイトル",
+                "description": "旧形式説明",
+                "is_pubcom": True,
+                "created_at": "2025-05-13T07:56:58.405239+00:00",
+                "is_public": True,
+            },
+            "new-slug": {
+                "slug": "new-slug",
+                "status": "ready",
+                "title": "新形式タイトル",
+                "description": "新形式説明",
+                "is_pubcom": True,
+                "visibility": "unlisted",
+                "created_at": "2025-05-13T07:56:58.405239+00:00",
+            },
+        }
+
+    def test_convert_is_public_true_to_visibility_public(self, old_format_public_data):
+        """is_public: trueをvisibility: publicに変換するテスト"""
+        # 入力データのコピーを作成して元のデータが変更されないようにする
+        input_data = deepcopy(old_format_public_data)
+
+        # 関数を実行
+        result = convert_old_format_status(input_data)
+
+        # 結果を検証
+        assert "test-slug" in result
+        assert "visibility" in result["test-slug"]
+        assert result["test-slug"]["visibility"] == ReportVisibility.PUBLIC.value
+        assert "is_public" not in result["test-slug"]
+
+    def test_convert_is_public_false_to_visibility_private(self, old_format_private_data):
+        """is_public: falseをvisibility: privateに変換するテスト"""
+        # 入力データのコピーを作成して元のデータが変更されないようにする
+        input_data = deepcopy(old_format_private_data)
+
+        # 関数を実行
+        result = convert_old_format_status(input_data)
+
+        # 結果を検証
+        assert "test-slug" in result
+        assert "visibility" in result["test-slug"]
+        assert result["test-slug"]["visibility"] == ReportVisibility.PRIVATE.value
+        assert "is_public" not in result["test-slug"]
+
+    def test_new_format_data_unchanged(self, new_format_data):
+        """既に新形式になっているデータは変更されないことを確認するテスト"""
+        # 入力データのコピーを作成して元のデータが変更されないようにする
+        input_data = deepcopy(new_format_data)
+        original_visibility = input_data["test-slug"]["visibility"]
+
+        # 関数を実行
+        result = convert_old_format_status(input_data)
+
+        # 結果を検証
+        assert "test-slug" in result
+        assert "visibility" in result["test-slug"]
+        assert result["test-slug"]["visibility"] == original_visibility
+        assert "is_public" not in result["test-slug"]
+
+    def test_empty_dict(self):
+        """空の辞書を渡した場合のテスト"""
+        # 空の辞書を渡す
+        input_data = {}
+
+        # 関数を実行
+        result = convert_old_format_status(input_data)
+
+        # 結果を検証
+        assert result == {}
+
+    def test_mixed_format_data(self, mixed_format_data):
+        """旧形式と新形式が混在したデータのテスト"""
+        # 入力データのコピーを作成して元のデータが変更されないようにする
+        input_data = deepcopy(mixed_format_data)
+        original_new_visibility = input_data["new-slug"]["visibility"]
+
+        # 関数を実行
+        result = convert_old_format_status(input_data)
+
+        # 結果を検証
+        # 旧形式のデータが変換されていることを確認
+        assert "old-slug" in result
+        assert "visibility" in result["old-slug"]
+        assert result["old-slug"]["visibility"] == ReportVisibility.PUBLIC.value
+        assert "is_public" not in result["old-slug"]
+
+        # 新形式のデータが変更されていないことを確認
+        assert "new-slug" in result
+        assert "visibility" in result["new-slug"]
+        assert result["new-slug"]["visibility"] == original_new_visibility
+        assert "is_public" not in result["new-slug"]


### PR DESCRIPTION
# 変更の概要
* 従来の公開/非公開に加えて、限定公開（unlisted）を実装
* 「限定公開」にセットされたレポートは以下の挙動になる
  * adminの一覧画面では表示される
  * clientにおいて、
      * **一覧画面では表示されない**
      * レポートの詳細画面（ `/{slug}`） では閲覧できる
        * つまり、管理者などのURLを知っているユーザーのみが閲覧できる
* **作成直後のレポートは「限定公開」状態となる**
  * 実用上、作成されたレポートはすぐに公開したくないケースが多いと思われるため
    * 例えばAzure上で広聴AIをホスティングしている場合、作成したレポートを内部で確認し、問題なければ公開という手順を踏むことが多いと思われる

# スクリーンショット
公開方式の切り替えはドロップダウン方式で実装した（従来のラジオカードだと幅が足りなかったため）
![image](https://github.com/user-attachments/assets/2cc0ea37-a171-4474-84d2-6eb6dff28926)


# 変更の背景
前述したように、外部には広く公開したくないが、内部ではレポートを共有したいというニーズがあるため実装した

# 関連Issue
Close https://github.com/digitaldemocracy2030/kouchou-ai/issues/365
Close https://github.com/digitaldemocracy2030/kouchou-ai/issues/341

# 動作確認の結果
* 作成直後のレポートが限定公開状態になる
* 限定公開のレポートがadminの一覧画面に表示される
* 限定公開のレポートがclientの一覧画面に表示されない
* 限定公開のレポートの詳細画面にアクセスできる

# マージ前のチェックリスト（レビュアーがマージ前に確認してください）
- [ ] CIが全て通過している
- [ ] 単体テストが実装されているか
- [ ] 今回実装した機能および影響を受けると思われる機能について、適切な動作確認が行われているかを確認する。


動作確認の項目については、実装者による動作確認のケースが適切かを確認してください。
必要に応じてレビュアー自身による動作確認を行っても良いですが、動作確認は必須ではありません。

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - レポートの公開範囲設定が「公開」「限定公開」「非公開」の3種類から選択可能に拡張されました。
  - 管理画面の公開範囲切り替えUIがラジオボタンからドロップダウン形式に変更され、操作性が向上しました。

- **バグ修正**
  - レポートの公開範囲判定ロジックが厳密化され、非公開レポートの誤表示を防止します。

- **テスト**
  - 公開範囲変更APIの動作確認や旧フォーマットからのデータ変換処理に関するテストが追加され、品質が強化されました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->