### PR TITLE
biomeのlineWidthを120まで引き上げる

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -18,7 +18,8 @@
   "formatter": {
     "enabled": true,
     "indentStyle": "space",
-    "indentWidth": 2
+    "indentWidth": 2,
+    "lineWidth": 120
   },
   "organizeImports": {
     "enabled": true


### PR DESCRIPTION
# 変更の概要
* biomeのlineWidthをデフォルトの80 -> 120に引き上げた

# 変更の背景
80だと不自然な箇所で切れてしまうケースがあったので120まで引き上げた
参考: https://github.com/digitaldemocracy2030/kouchou-ai/pull/508#discussion_r2086898542

# 動作確認の結果
<!-- 実装者は動作確認の結果を記載してください（例: レポート作成を実行し、正常にレポートが作成されることを確認した） 複数の動作確認を行った場合は、それぞれの結果を記載してください -->

# マージ前のチェックリスト（レビュアーがマージ前に確認してください）
- [ ] CIが全て通過している
- [ ] 単体テストが実装されているか
- [ ] 今回実装した機能および影響を受けると思われる機能について、適切な動作確認が行われているかを確認する。


動作確認の項目については、実装者による動作確認のケースが適切かを確認してください。
必要に応じてレビュアー自身による動作確認を行っても良いですが、動作確認は必須ではありません。

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **スタイル**
  - フォーマッターの設定に最大行幅（120文字）が追加され、コードの整形方法が変更されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->