### PR TITLE
embeddingを使う際にproviderを適用する

### DIFF
--- a/server/broadlistening/pipeline/steps/embedding.py
+++ b/server/broadlistening/pipeline/steps/embedding.py
@@ -17,7 +17,7 @@ def embedding(config):
     batch_size = 1000
     for i in tqdm(range(0, len(arguments), batch_size)):
         args = arguments["argument"].tolist()[i : i + batch_size]
-        embeds = request_to_embed(args, model, is_embedded_at_local)
+        embeds = request_to_embed(args, model, is_embedded_at_local, config["provider"])
         embeddings.extend(embeds)
     df = pd.DataFrame([{"arg-id": arguments.iloc[i]["arg-id"], "embedding": e} for i, e in enumerate(embeddings)])
     df.to_pickle(path)

--- a/server/broadlistening/pipeline/steps/extraction.py
+++ b/server/broadlistening/pipeline/steps/extraction.py
@@ -32,7 +32,10 @@ def extraction(config):
     workers = config["extraction"]["workers"]
     limit = config["extraction"]["limit"]
     property_columns = config["extraction"]["properties"]
-    provider = config.get("provider", "openai")  # デフォルトはopenai
+
+    if "provider" not in config:
+        raise RuntimeError("provider is not set")
+    provider = config["provider"]
 
     # カラム名だけを読み込み、必要なカラムが含まれているか確認する
     comments = pd.read_csv(f"inputs/{config['input']}.csv", nrows=0)

--- a/server/broadlistening/pipeline/steps/hierarchical_initial_labelling.py
+++ b/server/broadlistening/pipeline/steps/hierarchical_initial_labelling.py
@@ -47,7 +47,7 @@ def hierarchical_initial_labelling(config: dict) -> None:
         sampling_num,
         model,
         workers,
-        config["provider"]
+        config["provider"],
         config.get("local_llm_address"),
     )
     print("start initial labelling")

--- a/server/broadlistening/pipeline/steps/hierarchical_initial_labelling.py
+++ b/server/broadlistening/pipeline/steps/hierarchical_initial_labelling.py
@@ -40,7 +40,6 @@ def hierarchical_initial_labelling(config: dict) -> None:
     initial_labelling_prompt = config["hierarchical_initial_labelling"]["prompt"]
     model = config["hierarchical_initial_labelling"]["model"]
     workers = config["hierarchical_initial_labelling"]["workers"]
-    provider = config.get("provider", "openai")  # デフォルトはopenai
 
     initial_label_df = initial_labelling(
         initial_labelling_prompt,
@@ -48,7 +47,7 @@ def hierarchical_initial_labelling(config: dict) -> None:
         sampling_num,
         model,
         workers,
-        provider,
+        config["provider"]
         config.get("local_llm_address"),
     )
     print("start initial labelling")

--- a/server/broadlistening/pipeline/steps/hierarchical_merge_labelling.py
+++ b/server/broadlistening/pipeline/steps/hierarchical_merge_labelling.py
@@ -274,7 +274,7 @@ def process_merge_labelling(
             messages=messages,
             model=config["hierarchical_merge_labelling"]["model"],
             json_schema=LabellingFromat,
-            provider=config.get("provider", "openai"),
+            provider=config["provider"],
             local_llm_address=config.get("local_llm_address"),
         )
         response_json = json.loads(response) if isinstance(response, str) else response

--- a/server/broadlistening/pipeline/steps/hierarchical_overview.py
+++ b/server/broadlistening/pipeline/steps/hierarchical_overview.py
@@ -21,7 +21,6 @@ def hierarchical_overview(config):
 
     prompt = config["hierarchical_overview"]["prompt"]
     model = config["hierarchical_overview"]["model"]
-    provider = config.get("provider", "openai")  # デフォルトはopenai
 
     # TODO: level1で固定にしているが、設定で変えられるようにする
     target_level = 1
@@ -40,7 +39,7 @@ def hierarchical_overview(config):
     response = request_to_chat_openai(
         messages=messages,
         model=model,
-        provider=provider,
+        provider=config["provider"],
         local_llm_address=config.get("local_llm_address"),
         json_schema=OverviewResponse,
     )


### PR DESCRIPTION
# 変更の概要
* embeddingを作成する際に、providerを考慮するように修正

# 変更の背景
* embedding作成時に、providerが考慮されておらず、デフォルトのOpenAIで作成されるようになっていた


# 動作確認の結果
![image](https://github.com/user-attachments/assets/aba89f39-ca1f-407e-8f26-055da6b019a5)

Azure OpenAIのembeddingが呼び出されていることを確認した

# マージ前のチェックリスト（レビュアーがマージ前に確認してください）
- [ ] CIが全て通過している
- [ ] 単体テストが実装されているか
- [ ] 今回実装した機能および影響を受けると思われる機能について、適切な動作確認が行われているかを確認する。


動作確認の項目については、実装者による動作確認のケースが適切かを確認してください。


# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **バグ修正**
  - 埋め込みリクエスト時にプロバイダー情報の指定が正しく反映されるようになりました。
  - プロバイダー設定が必須となり、未設定時にエラーが表示されるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->