### PR TITLE
windows直環境対応

### DIFF
--- a/experimental/direct_win/README.md
+++ b/experimental/direct_win/README.md
@@ -1,0 +1,90 @@
+
+# Windows環境でのユーザーガイド（開発用にWindowsでDockerを使わずに実行する場合,非推奨）
+
+本手順は、Windows環境で Docker を使用せずにローカル開発環境を構築するためのものです。簡易的な検証や開発用途を想定しており、本番環境や推奨構成ではありません。
+
+## 前提条件
+
+- Windows 10/11
+- インターネット接続
+- OpenAI APIキー（[取得方法](https://platform.openai.com/api-keys)）
+
+
+## セットアップ手順
+
+
+#### 1. リポジトリのクローン
+
+```
+git clone https://github.com/digitaldemocracy2030/kouchou-ai.git
+cd kouchou-ai
+```
+
+#### 2. .env ファイルの作成
+
+```
+copy .env.example .env
+```
+
+* `.env.example` をベースに `.env` を作成し、OpenAI APIキー他、各種環境変数を設定します。
+
+#### 3. Node.js の確認（client / client-admin用）
+
+```
+node -v
+npm -v
+```
+
+* 未インストールの場合は、[Node.js LTS](https://nodejs.org/ja) をインストールしてください。
+
+#### 4. Python の確認（server用）
+
+```
+python --version
+```
+
+* バージョンは 3.12 以上を推奨。
+* 未インストールの場合は、[Python公式サイト](https://www.python.org/downloads/windows/) よりインストールしてください。
+
+#### 5. client 側ライブラリのインストール
+
+```
+cd client
+npm install
+cd ..
+```
+
+#### 6. client-admin 側ライブラリのインストール
+
+```
+cd client-admin
+npm install
+cd ..
+```
+
+#### 7. server 側ライブラリのインストール（PDM + 仮想環境）
+
+```
+cd server
+pip install pdm
+pdm install
+cd ..
+```
+
+#### 8. direct\_start\_win.bat を実行
+
+* Windows用のバッチスクリプト `direct_start_win.bat` をkouchou-ai配下にコピーしダブルクリックまたはコマンドラインで実行
+
+```
+copy experimental\direct_win\direct_start_win.bat .\
+direct_start_win.bat
+```
+
+#### 9. アクセス確認
+
+* [http://localhost:3000](http://localhost:3000) : レポート一覧画面（client）
+* [http://localhost:4000](http://localhost:4000) : 管理画面（client-admin）
+
+---
+
+> ⚠️ 注意：この構成は動作確認・検証用であり、Dockerを用いた本番環境構築を推奨します。

--- a/experimental/direct_win/direct_start_win.bat
+++ b/experimental/direct_win/direct_start_win.bat
@@ -1,0 +1,105 @@
+@echo off
+setlocal
+
+@echo off
+setlocal enabledelayedexpansion
+
+rem === Check if .env exists ===
+if not exist ".env" (
+    echo [ERROR] .env file not found.
+    echo Please create it using the following steps:
+    echo   1. Copy .env.example to .env
+    echo   2. Edit environment variables - see .env.example for details
+    echo.
+    pause
+    exit /b 1
+)
+
+rem ----- Initialization -----
+set CLIENT_ENV=client\.env
+set ADMIN_ENV=client-admin\.env
+set SERVER_ENV=server\.env
+
+(del %CLIENT_ENV%) >nul 2>&1
+(del %ADMIN_ENV%) >nul 2>&1
+(del %SERVER_ENV%) >nul 2>&1
+
+rem ----- Parse .env and generate per-service env files -----
+echo [STEP 1] .env 分割バッチを実行中...
+for /f "usebackq tokens=1,* delims==" %%A in (".env") do (
+    set KEY=%%A
+    set VALUE=%%B
+
+    rem Skip empty lines and comments
+    echo !KEY! | findstr /b "#" >nul && (
+        rem skip comment
+    ) || if not "!KEY!"=="" (
+        rem server env
+        if /i "!KEY!"=="OPENAI_API_KEY" (
+            echo !KEY!=!VALUE!>>%SERVER_ENV%
+        ) else if /i "!KEY!"=="PUBLIC_API_KEY" (
+            echo !KEY!=!VALUE!>>%SERVER_ENV%
+        ) else if /i "!KEY!"=="ADMIN_API_KEY" (
+            echo !KEY!=!VALUE!>>%SERVER_ENV%
+        ) else if /i "!KEY!"=="ENVIRONMENT" (
+            echo !KEY!=!VALUE!>>%SERVER_ENV%
+        ) else if /i "!KEY!"=="STORAGE_TYPE" (
+            echo !KEY!=!VALUE!>>%SERVER_ENV%
+        )
+
+        rem client env
+        if /i "!KEY!"=="NEXT_PUBLIC_API_BASEPATH" (
+            echo !KEY!=!VALUE!>>%CLIENT_ENV%
+        ) else if /i "!KEY!"=="NEXT_PUBLIC_PUBLIC_API_KEY" (
+            echo !KEY!=!VALUE!>>%CLIENT_ENV%
+        ) else if /i "!KEY!"=="NEXT_PUBLIC_SITE_URL" (
+            echo !KEY!=!VALUE!>>%CLIENT_ENV%
+        ) else if /i "!KEY!"=="NEXT_PUBLIC_GA_MEASUREMENT_ID" (
+            echo !KEY!=!VALUE!>>%CLIENT_ENV%
+        )
+
+        rem client-admin env
+        if /i "!KEY!"=="NEXT_PUBLIC_CLIENT_BASEPATH" (
+            echo !KEY!=!VALUE!>>%ADMIN_ENV%
+        ) else if /i "!KEY!"=="NEXT_PUBLIC_API_BASEPATH" (
+            echo !KEY!=!VALUE!>>%ADMIN_ENV%
+        ) else if /i "!KEY!"=="NEXT_PUBLIC_ADMIN_API_KEY" (
+            echo !KEY!=!VALUE!>>%ADMIN_ENV%
+        ) else if /i "!KEY!"=="BASIC_AUTH_USERNAME" (
+            echo !KEY!=!VALUE!>>%ADMIN_ENV%
+        ) else if /i "!KEY!"=="BASIC_AUTH_PASSWORD" (
+            echo !KEY!=!VALUE!>>%ADMIN_ENV%
+        ) else if /i "!KEY!"=="NEXT_PUBLIC_ADMIN_GA_MEASUREMENT_ID" (
+            echo !KEY!=!VALUE!>>%ADMIN_ENV%
+        )
+    )
+)
+
+echo [INFO] .envからPYTHON_EXECUTABLEを読み込みます...
+
+rem --- 初期値：.venv を使う ---
+set "PYTHON_EXECUTABLE=.venv\Scripts\python.exe"
+
+rem --- .env ファイルから PYTHON_EXECUTABLE を探して上書き（あれば） ---
+for /f "tokens=1,* delims==" %%A in (.env) do (
+    if /i "%%A"=="PYTHON_EXECUTABLE" (
+        set "PYTHON_EXECUTABLE=%%B"
+    )
+)
+
+echo [INFO] 使用するPython: %PYTHON_EXECUTABLE%
+rem ----------- Launch all services ------------
+rem ----------- APIサーバ（FastAPI）起動 ------------
+echo [STEP 2] FastAPI サーバー起動中（別ウィンドウ）...
+start "server" cmd /k "cd server && %PYTHON_EXECUTABLE% -m uvicorn src.main:app --host 0.0.0.0 --port 8000 --reload --log-level debug"
+
+rem ----------- クライアント起動（client） ------------
+echo [STEP 3] client を起動中（別ウィンドウ）...
+start "client" cmd /k "cd client && npm run dev"
+
+rem ----------- 管理画面（client-admin）起動 ------------
+echo [STEP 4] client-admin を起動中（別ウィンドウ）...
+start "client-admin" cmd /k "cd client-admin && npm run dev"
+
+echo [DONE] すべてのサービスを起動しました。終了する場合は各ウインドウを閉じてください。
+pause


### PR DESCRIPTION
ドラフト
# 変更の概要
Windows 環境で Docker を使用せずに開発環境を構築・起動する手順をまとめた Markdown ファイルを新たに追加しました。
起動用のdirect_start_win.batを追加しました
検証・開発用途を想定しており、非推奨構成として experimental 配下に配置しています。
pdm を利用しつつ pyproject.toml に準拠したセットアップ手順を記載しています。
.env の分割処理や各サービスの依存ライブラリインストール方法を明記しました。


当初はご提案いただいたとおり、rye + make を使った構成に合わせようと検討しましたが、以下の理由から今回は断念し、代替手段として pdm ベースでの手順を採用しました。

rye の実行ファイルは、インストール時にセキュリティ警告を無視する必要があり、加えて Windows 環境での実行にはセキュリティ設定の調整が必要となる場面がありました。
make も別途 exe をダウンロードし、Path に追加する必要がありますが、最終的には rye に依存するため、初心者や非エンジニアにとっては敷居が高い構成になってしまうと判断しました。
.env の分割処理などもバッチスクリプトで補完する必要があり、結果的に純粋な make ベースの恩恵が限定的である点も考慮しました。
そのため、server 側では pyproject.toml を活かしつつも、pdm を使ったセットアップに調整しています。
また、report_launcher.pyの変更は起動時の仮想環境を引き継げていたため取り下げました。
なお、この手順は「非推奨手順」として kouchou-ai/experimental/direct_win に配置し、軽量な検証や個人開発向けの補助的な位置づけとして取り扱っています。


# スクリーンショット
- UIなし

# 変更の背景
- issu対応

# 関連Issue
https://github.com/digitaldemocracy2030/kouchou-ai/issues/509
https://github.com/digitaldemocracy2030/kouchou-ai/pull/499

# 動作確認の結果
pdm で作った仮想環境を使いつつ起動、レポート作成の完了。

# マージ前のチェックリスト（レビュアーがマージ前に確認してください）
- [ ] CIが全て通過している
- [x ] 単体テストが実装されているか
- [x ] 今回実装した機能および影響を受けると思われる機能について、適切な動作確認が行われているかを確認する。




- [x ] CLAの内容を読み、同意しました