### PR TITLE
利用規約のリンクのデフォルト値をnullに変更

### DIFF
--- a/server/public/meta/default/metadata.json
+++ b/server/public/meta/default/metadata.json
@@ -3,6 +3,6 @@
   "message": "これは動作確認のためのテスト用のメタデータです。レポートの作成者に関する情報等を、public/meta/custom/metadata.jsonに記載することで、レポート上で情報を表示することができます。",
   "webLink": "/",
   "privacyLink": "/",
-  "termsLink": "/",
+  "termsLink": null,
   "brandColor": "#2577B1"
 }


### PR DESCRIPTION
# 変更の概要
* 利用規約のリンクのデフォルト値をnullに変更

# 変更の背景
利用規約については（実装的にもサービスとしても）必須ではないが、現状のデフォルト値が `/` になっており、optionalでないことがユーザーにとってわかりにくいのでデフォルト値をnullに変更した

# 関連Issue
Close https://github.com/digitaldemocracy2030/kouchou-ai/issues/539

# 動作確認の結果
利用規約がnullの場合はフッターに利用規約が含まれないことを確認した
![image](https://github.com/user-attachments/assets/2db1651f-039f-4009-b932-61220b53103b)


# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

# マージ前のチェックリスト（レビュアーがマージ前に確認してください）
- [ ] CIが全て通過している
- [ ] 単体テストが実装されているか
- [ ] 今回実装した機能および影響を受けると思われる機能について、適切な動作確認が行われているかを確認する。


動作確認の項目については、実装者による動作確認のケースが適切かを確認してください。
必要に応じてレビュアー自身による動作確認も歓迎します（必須ではありません）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - 利用規約リンクが正しく表示されない問題を修正しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->