### PR TITLE
dd2030に関する説明を修正

### DIFF
--- a/client/components/Footer.tsx
+++ b/client/components/Footer.tsx
@@ -62,6 +62,8 @@ export function Footer({ meta }: Props) {
                   <Text>
                     広聴AIは、デジタル民主主義2030プロジェクトから生まれたオープンソース（OSS）アプリケーションです。本ページは、そのOSS成果物を活用して構築されています。
                   </Text>
+                </Box>
+                <Box mb={8} maxW={"700px"} mx={"auto"}>
                   <Heading size={"lg"} mb={2} textAlign={"center"}>
                     デジタル民主主義2030プロジェクトについて
                   </Heading>

--- a/client/components/Footer.tsx
+++ b/client/components/Footer.tsx
@@ -57,7 +57,13 @@ export function Footer({ meta }: Props) {
               <DrawerBody textAlign={"center"}>
                 <Box mb={8} maxW={"700px"} mx={"auto"}>
                   <Heading size={"lg"} mb={2} textAlign={"center"}>
-                    プロジェクトについて
+                    広聴AIについて
+                  </Heading>
+                  <Text>
+                    広聴AIは、デジタル民主主義2030プロジェクトから生まれたオープンソース（OSS）アプリケーションです。本ページは、そのOSS成果物を活用して構築されています。
+                  </Text>
+                  <Heading size={"lg"} mb={2} textAlign={"center"}>
+                    デジタル民主主義2030プロジェクトについて
                   </Heading>
                   <Text>
                     2030年には、情報技術により民主主義のあり方はアップデートされており、一人ひとりの声が政治・行政に届き、適切に合意形成・政策反映されていくような社会が当たり前になる──そんな未来を目指して立ち上げられたのがデジタル民主主義2030プロジェクトです。

--- a/server/public/meta/default/metadata.json
+++ b/server/public/meta/default/metadata.json
@@ -3,6 +3,6 @@
   "message": "これは動作確認のためのテスト用のメタデータです。レポートの作成者に関する情報等を、public/meta/custom/metadata.jsonに記載することで、レポート上で情報を表示することができます。",
   "webLink": "/",
   "privacyLink": "/",
-  "termsLink": "/",
+  "termsLink": null,
   "brandColor": "#2577B1"
 }


### PR DESCRIPTION
# 変更の概要
フッター中のdd2030の説明において以下の追記を実施

* 広聴AIに関する説明を追記
* このレポートが広聴AIによって出力されたものである旨を追記


# スクリーンショット
`広聴AIについて` を追記

![image](https://github.com/user-attachments/assets/9bdb2274-88ff-4d5a-8a07-0e2404ede495)


変更前の内容は以下

![image](https://github.com/user-attachments/assets/3c5955e2-e929-461c-802d-4e5ffd998e5d)


# 変更の背景
* 元々の記述だと、デジタル民主主義2030プロジェクトに関する説明はなされているが、それとこのレポートとの関係性がわからなかった
* また、レポート出力者とdd2030との関係性も読み取りにくい構造になっていた

-> 当該レポートが、dd2030の成果物によって出力されたものであることを明示するように修正


# 動作確認の結果
前述のスクショの通り

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

# マージ前のチェックリスト（レビュアーがマージ前に確認してください）
- [ ] CIが全て通過している
- [ ] 単体テストが実装されているか
- [ ] 今回実装した機能および影響を受けると思われる機能について、適切な動作確認が行われているかを確認する。


動作確認の項目については、実装者による動作確認のケースが適切かを確認してください。
必要に応じてレビュアー自身による動作確認も歓迎します（必須ではありません）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - フッタードロワーに「広聴AIについて」と「デジタル民主主義2030プロジェクトについて」の2つのセクションを追加し、説明文を拡充しました。

- **その他**
  - 利用規約リンクが一時的に非表示になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->