### PR TITLE
fix github actions error, add setup doc md

### DIFF
--- a/.github/scripts/status_update_common.py
+++ b/.github/scripts/status_update_common.py
@@ -45,6 +45,7 @@ class GithubHandler:
     def __init__(self, config: Config):
         self.config = config
         try:
+          self.action = config.action
           self.github = Github(config.github_token)
           self.repo = self.github.get_repo(config.github_repo)
           self.issue_number = config.issue_number

--- a/docs/github-actions-status-update.md
+++ b/docs/github-actions-status-update.md
@@ -1,0 +1,57 @@
+# Issueのstatus自動更新の設定手順
+
+このドキュメントでは、GitHub AppsとGitHub Actionsを用いてProjectsのstatusフィールドを自動更新するためのセットアップ手順を説明します。
+
+### OrganizationのGitHub Apps を作成する
+- 手順：https://docs.github.com/ja/apps/creating-github-apps/registering-a-github-app/registering-a-github-app
+- WebhookはOFF
+- Permissions > Organization permissions > Projects > Read and write を指定
+- Permissions > Repository permissions > Metadata > Read only を指定
+- Permissions > Repository permissions > Actions > Read only を指定
+    - 確認メールが届いたら、リンク先でリポジトリを指定して許可
+- Install only on this account
+
+### Private Key の発行
+- 作成完了画面の指示に従い、続けてGitHub Apps のインストール準備としてprivate keyを発行する
+- 手順：https://docs.github.com/ja/apps/creating-github-apps/authenticating-with-a-github-app/managing-private-keys-for-github-apps
+- 発行すると、ローカルに秘密鍵（pemファイル）がダウンロードされる
+
+### OrganizationのGitHub Apps をインストールする
+- 手順：https://docs.github.com/ja/apps/using-github-apps/installing-your-own-github-app
+- General > Generate a new client secret
+- Install App > Install (to organization)
+
+### Organization secrets の設定
+- Organization の設定ページを開く
+- Repository > Settings > General > Security > Secrets and variables > Actions > Organization secrets
+- PJ_APP_ID : AppのGeneralタブのApp ID
+- PJ_APP_PEM : private key を発行した際にローカルにダウンロードされたpemファイルの内容（テキスト全体）
+    - Repository を指定する
+
+# 補足：
+
+- `.github/scripts/repo_config.py` について
+    - `digitaldemocracy2030/kouchou-ai` に特化したID等になっている
+    - 機密情報ではない
+    - 本来は環境設定に持たせるかscript内で取得する方が綺麗だが、どうせ後続処理もこのリポジトリ独自のルールに則った処理なので、このままにしている
+    - `project_id` (PVT_xxxx) と `status_field_id` (PVTSSF_xxxx) の確認方法：
+        - https://docs.github.com/ja/graphql/overview/explorer にアクセス
+        - Githubアカウントでログイン ※ `digitaldemocracy2030` のメンバーである必要がある
+        - 以下のクエリを実行:
+```
+{
+  organization(login: "digitaldemocracy2030") {
+    projectV2(number: 3) {
+      id
+      fields(first: 20) {
+        nodes {
+          ... on ProjectV2SingleSelectField {
+            id
+            name
+          }
+        }
+      }
+    }
+  }
+}
+```


### PR DESCRIPTION
# 変更の概要
以下の2点です。
- PR #512 の修正もれのfix
- 設定手順のmdを作成（PR 512に記載されていた内容）

# 変更の背景
- PR 512の作成後にcoderabbitaiの指摘事項に対応した際にデグレードが発生していました
- 設定手順が資料化されていませんでした

# 関連Issue
https://github.com/digitaldemocracy2030/kouchou-ai/issues/425
(後続Issue: https://github.com/digitaldemocracy2030/kouchou-ai/issues/454 , https://github.com/digitaldemocracy2030/kouchou-ai/issues/459 )

# 動作確認の結果
[Assign](https://github.com/sasa-test-org/kouchou-ai-copy/actions/runs/15229149314/job/42834885229)、[unassign](https://github.com/sasa-test-org/kouchou-ai-copy/actions/runs/15229154820/job/42834895404) ともに期待通りに動作しました。

# CLAへの同意
- [x] CLAの内容を読み、同意しました

# マージ前のチェックリスト（レビュアーがマージ前に確認してください）
- [ ] CIが全て通過している
- [ ] 単体テストが実装されているか
- [ ] 今回実装した機能および影響を受けると思われる機能について、適切な動作確認が行われているかを確認する。

動作確認の項目については、実装者による動作確認のケースが適切かを確認してください。
必要に応じてレビュアー自身による動作確認も歓迎します（必須ではありません）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **ドキュメント**
  - GitHub Projectsのステータスフィールドを自動更新するためのセットアップ手順を新たに追加しました。
  - GitHub Appの作成や必要な権限、シークレットの設定方法などを詳細に説明しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->