### PR TITLE
[client] Dialog を開いた際の Initial Focus を変更する

### DIFF
--- a/client/components/Footer.tsx
+++ b/client/components/Footer.tsx
@@ -1,8 +1,10 @@
+"use client";
+
 import type { Meta } from "@/type";
 import { Box, type ButtonProps as ChakraButtonProps, Flex, Link, Text, Button as _Button } from "@chakra-ui/react";
 import { ArrowUpRight } from "lucide-react";
 import Image from "next/image";
-import type { ReactNode } from "react";
+import { forwardRef, useRef, type ReactNode } from "react";
 import { GitHubIcon, NoteIcon, SlackIcon, XIcon } from "./icons/MediaIcons";
 import {
   DialogActionTrigger,
@@ -21,8 +23,9 @@ type Props = {
 };
 
 const Dialog = ({ title, trigger, children }: { title: string; trigger: ReactNode; children: ReactNode }) => {
+  const ref = useRef<HTMLButtonElement>(null);
   return (
-    <DialogRoot size="sm">
+    <DialogRoot size="sm" initialFocusEl={() => ref.current}>
       <DialogTrigger asChild>{trigger}</DialogTrigger>
       <DialogContent
         mx="4"
@@ -41,7 +44,7 @@ const Dialog = ({ title, trigger, children }: { title: string; trigger: ReactNod
         <DialogCloseTrigger />
         <DialogFooter pb={{ base: "6", md: "8" }} justifyContent="center">
           <DialogActionTrigger asChild>
-            <Button size="md" borderColor="gray.300">
+            <Button ref={ref} size="md" borderColor="gray.300">
               閉じる
             </Button>
           </DialogActionTrigger>
@@ -51,7 +54,7 @@ const Dialog = ({ title, trigger, children }: { title: string; trigger: ReactNod
   );
 };
 
-const Button = ({ children, ...props }: ChakraButtonProps) => {
+const Button = forwardRef<HTMLButtonElement, ChakraButtonProps>(({ children, ...props }, ref) => {
   return (
     <_Button
       variant="outline"
@@ -65,12 +68,13 @@ const Button = ({ children, ...props }: ChakraButtonProps) => {
         width: "16px",
         height: "16px",
       }}
+      ref={ref}
       {...props}
     >
       {children}
     </_Button>
   );
-};
+});
 
 export function Footer({ meta }: Props) {
   return (


### PR DESCRIPTION
# 変更の概要
- client の Footer 内にある「謝辞」と「免責」の Dialog を開いた際に、閉じるボタンに foucs が当たるようにしました

# スクリーンショット
## 謝辞

![image](https://github.com/user-attachments/assets/e6184ccb-7b74-48d5-93bf-bcd62dfd45ec)

## 免責

![image](https://github.com/user-attachments/assets/dfcb1398-8d3c-4139-a3bb-016c58784d9b)

# 変更の背景
- 元の実装は Chakra UI のデフォルトの挙動で、Dialog 内に出現する Initial Focusable Element にフォーカスが当たるようになっていました
  - おそらくこちらの挙動を実施しているものと思われます
  > ダイアログを実装する際には、ユーザーのフォーカスを設定する場所として最も適切な場所を検討することが重要です。HTMLDialogElement.showModal() を用いて <dialog> を開いたとき、フォーカスは内部で最初のフォーカス可能な要素に設定されます。
ref: [<dialog>: ダイアログ要素 - HTML: ハイパーテキストマークアップ言語 | MDN](https://developer.mozilla.org/ja/docs/Web/HTML/Reference/Elements/dialog#%E3%82%A2%E3%82%AF%E3%82%BB%E3%82%B7%E3%83%93%E3%83%AA%E3%83%86%E3%82%A3)
- この挙動によって、「謝辞」の Dialog を開いた際に「[AI Objectives Institute](https://ai.objectives.institute/)」の Link に対して初期フォーカスが当たっていました
- 上記のリンクは参考情報を掲載したもので、ユーザーに MUST で閲覧してもらうことを期待した Link ではないので、Initail Focus が当たることは違和感がある
- W3C の Accecibiliy のガイドラインでは追加的な情報を表示する Dialog について最も頻繁に使われそうな要素に focus するのが望ましいという記述があるので、今回は「閉じる」ボタンに Initial Focus を当てるように変更しました
  > If a dialog is limited to interactions that either provide additional information or continue processing, it may be advisable to set focus to the element that is likely to be most frequently used, such as an OK or Continue button.
ref: https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/
- Chakra UI で Initial Foucs を設定する方法: https://www.chakra-ui.com/docs/components/dialog#initial-focus

# 関連Issue
- https://github.com/digitaldemocracy2030/kouchou-ai/pull/589#issuecomment-2948651314

# 動作確認の結果
<!-- 実装者は動作確認の結果を記載してください（例: レポート作成を実行し、正常にレポートが作成されることを確認した） 複数の動作確認を行った場合は、それぞれの結果を記載してください -->

- client で謝辞と免責の Dialog を開いて、閉じるボタンにフォーカスが当たっている

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

# マージ前のチェックリスト（レビュアーがマージ前に確認してください）
- [ ] CIが全て通過している
- [ ] 単体テストが実装されているか
- [ ] 今回実装した機能および影響を受けると思われる機能について、適切な動作確認が行われているかを確認する。


動作確認の項目については、実装者による動作確認のケースが適切かを確認してください。
必要に応じてレビュアー自身による動作確認も歓迎します（必須ではありません）。