### PR TITLE
[client] レポーター画像が Docker 環境で取得できないエラーを修正

### DIFF
--- a/client/components/Footer.tsx
+++ b/client/components/Footer.tsx
@@ -4,7 +4,7 @@ import type { Meta } from "@/type";
 import { Box, type ButtonProps as ChakraButtonProps, Flex, Link, Text, Button as _Button } from "@chakra-ui/react";
 import { ArrowUpRight } from "lucide-react";
 import Image from "next/image";
-import { forwardRef, useRef, type ReactNode } from "react";
+import { type ReactNode, forwardRef, useRef } from "react";
 import { GitHubIcon, NoteIcon, SlackIcon, XIcon } from "./icons/MediaIcons";
 import {
   DialogActionTrigger,

--- a/client/components/charts/ScatterChart.tsx
+++ b/client/components/charts/ScatterChart.tsx
@@ -217,9 +217,10 @@ export function ScatterChart({
             hoverinfo: "skip", // ホバー表示を無効化
             showlegend: false,
             // argumentのメタデータを埋め込み
-            customdata: notMatching.length > 0 
-              ? notMatching.map((arg) => ({ arg_id: arg.arg_id, url: arg.url }))
-              : allClusterArguments.map((arg) => ({ arg_id: arg.arg_id, url: arg.url })),
+            customdata:
+              notMatching.length > 0
+                ? notMatching.map((arg) => ({ arg_id: arg.arg_id, url: arg.url }))
+                : allClusterArguments.map((arg) => ({ arg_id: arg.arg_id, url: arg.url })),
           }
         : null;
 
@@ -234,10 +235,12 @@ export function ScatterChart({
               size: 10, // 統一サイズでシンプルに
               color: Array(matching.length).fill(clusterColorMap[cluster.id]),
               opacity: Array(matching.length).fill(1), // 不透明
-              line: config?.enable_source_link ? {
-                width: 2,
-                color: '#ffffff',
-              } : undefined,
+              line: config?.enable_source_link
+                ? {
+                    width: 2,
+                    color: "#ffffff",
+                  }
+                : undefined,
             },
             text: matching.map((arg) => {
               const argumentText = arg.argument.replace(/(.{30})/g, "$1<br />");
@@ -387,22 +390,22 @@ export function ScatterChart({
           onUpdate={onUpdate}
           onClick={(data: any) => {
             if (!config?.enable_source_link) return;
-            
+
             try {
               if (data.points && data.points.length > 0) {
                 const point = data.points[0];
-                
+
                 // customdataから直接argumentの情報を取得
                 if (point.customdata) {
                   const customData = point.customdata as { arg_id: string; url?: string };
-                  
+
                   if (customData.url) {
-                    window.open(customData.url, '_blank', 'noopener,noreferrer');
+                    window.open(customData.url, "_blank", "noopener,noreferrer");
                   } else {
                     // customdataにURLがない場合、argumentListから検索
-                    const matchedArgument = argumentList.find(arg => arg.arg_id === customData.arg_id);
+                    const matchedArgument = argumentList.find((arg) => arg.arg_id === customData.arg_id);
                     if (matchedArgument?.url) {
-                      window.open(matchedArgument.url, '_blank', 'noopener,noreferrer');
+                      window.open(matchedArgument.url, "_blank", "noopener,noreferrer");
                     } else {
                       console.log("No URL found for argument:", customData.arg_id);
                     }

--- a/client/components/reporter/Reporter.tsx
+++ b/client/components/reporter/Reporter.tsx
@@ -1,6 +1,3 @@
-"use server";
-
-import { getImageFromServerSrc } from "@/app/utils/image-src";
 import type { Meta } from "@/type";
 import { Image } from "@chakra-ui/react";
 import { ReporterContent } from "./ReporterContent";
@@ -10,13 +7,15 @@ async function ReporterImage({
 }: {
   reporterName: string;
 }) {
-  const src: string = getImageFromServerSrc("/meta/reporter.png");
+  const imagePath = "/meta/reporter.png";
   try {
-    const res = await fetch(src, {
-      method: "GET",
-    });
+    // リポータ画像の有無はserver側で確認する
+    const url = new URL(imagePath, process.env.API_BASEPATH).toString();
+    const res = await fetch(url);
 
     if (res.status === 200) {
+      // 画像が存在する場合は、clientから取得できる画像のパスを返す
+      const src = new URL(imagePath, process.env.NEXT_PUBLIC_API_BASEPATH).toString();
       return <Image src={src} alt={reporterName} maxW="150px" />;
     }
   } catch (error) {


### PR DESCRIPTION
# 変更の概要
- #581 で追加した Reporter コンポーネントで、レポーターの画像が  Docker Compose 起動時に取得できないエラーが出ていたので修正しました
```
Failed to fetch reporter image: TypeError: fetch failed
client-1               |     at async a (.next/server/chunks/296.js:1:399) {
client-1               |   [cause]: [AggregateError: ] { code: 'ECONNREFUSED' }
client-1               | }
```

# スクリーンショット
赤枠で囲った画像が今回の修正対象です

![スクリーンショット 2025-06-09 17 26 38](https://github.com/user-attachments/assets/e53c43c6-9981-4fd3-8b4e-cd47c9c14821)

# 変更の背景
- レポーターの画像オプショナルなので、server 側で画像があるかどうかを判定しています
  - client 側で判定すると、画像の有無によってレイアウトがガタつくので、client でレンダリングする前に判定できる server で処理をしています
  - 画像があれば client から取得できる URL を設定した Image コンポーネントを返すようにしました
  - 元の実装で使っていた `getImageFromServerSrc` は[サーバーサイドレンダリング時に `NEXT_PUBLIC_API_BASEPATH` を使っていて](https://github.com/shgtkshruch/kouchou-ai/blob/e9b403e844ddc4a7f33562f681149f28b6379c21/client/app/utils/image-src.ts#L56-L57)、こちらは [cilent rendering 用の `API_BASEPATH`](https://github.com/digitaldemocracy2030/kouchou-ai/blob/e9b403e844ddc4a7f33562f681149f28b6379c21/.env.example#L39-L40) で実装とコメントに差異があるので、一旦使用するのを避けました
- Biome のフォーマット漏れのコードがあったので、合わせて修正しました

# 関連Issue
- #581

# 動作確認の結果
<!-- 実装者は動作確認の結果を記載してください（例: レポート作成を実行し、正常にレポートが作成されることを確認した） 複数の動作確認を行った場合は、それぞれの結果を記載してください -->

- Docker Comopse 環境でレポータの画像を設定したら表示 されること

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

# マージ前のチェックリスト（レビュアーがマージ前に確認してください）
- [ ] CIが全て通過している
- [ ] 単体テストが実装されているか
- [ ] 今回実装した機能および影響を受けると思われる機能について、適切な動作確認が行われているかを確認する。


動作確認の項目については、実装者による動作確認のケースが適切かを確認してください。
必要に応じてレビュアー自身による動作確認も歓迎します（必須ではありません）。