### PR TITLE
[client] デザインシステムの Typography を適用する

### DIFF
--- a/client/app/layout.tsx
+++ b/client/app/layout.tsx
@@ -11,7 +11,15 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
   return (
     <html suppressHydrationWarning lang={"ja"}>
       <head>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+        <link
+          href="https://fonts.googleapis.com/css2?family=BIZ+UDPGothic&display=swap"
+          rel="stylesheet"
+        />
+
         <link rel={"icon"} href={getImageFromServerSrc("/meta/icon.png")} sizes={"any"} />
+
         {enableGA && <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID || ""} />}
       </head>
       <body>

--- a/client/components/Footer.tsx
+++ b/client/components/Footer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { Meta } from "@/type";
-import { Box, type ButtonProps as ChakraButtonProps, Flex, Link, Text, Button as _Button } from "@chakra-ui/react";
+import { Box, type ButtonProps as ChakraButtonProps, Flex, Text, Button as _Button } from "@chakra-ui/react";
 import { ArrowUpRight } from "lucide-react";
 import Image from "next/image";
 import { type ReactNode, forwardRef, useRef } from "react";
@@ -17,6 +17,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "./ui/dialog";
+import { Link } from "./ui/link";
 
 type Props = {
   meta: Meta;
@@ -37,9 +38,7 @@ const Dialog = ({ title, trigger, children }: { title: string; trigger: ReactNod
           <DialogTitle>{title}</DialogTitle>
         </DialogHeader>
         <DialogBody px={{ base: "6", md: "8" }}>
-          <Text textStyle="body/md">
-            {children}
-          </Text>
+          <Text textStyle="body/md">{children}</Text>
         </DialogBody>
         <DialogCloseTrigger />
         <DialogFooter pb={{ base: "6", md: "8" }} justifyContent="center">
@@ -117,12 +116,7 @@ export function Footer({ meta }: Props) {
               </Button>
               <Dialog title="謝辞" trigger={<Button textStyle="body/sm/bold">謝辞</Button>}>
                 広聴AIは{" "}
-                <Link
-                  href="https://ai.objectives.institute/"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  color="blue.500"
-                >
+                <Link href="https://ai.objectives.institute/" target="_blank" rel="noopener noreferrer">
                   AI Objectives Institute
                 </Link>{" "}
                 が開発した{" "}
@@ -130,7 +124,6 @@ export function Footer({ meta }: Props) {
                   href="https://github.com/AIObjectives/talk-to-the-city-reports"
                   target="_blank"
                   rel="noopener noreferrer"
-                  color="blue.500"
                 >
                   Talk to the City
                 </Link>{" "}

--- a/client/components/Footer.tsx
+++ b/client/components/Footer.tsx
@@ -37,14 +37,14 @@ const Dialog = ({ title, trigger, children }: { title: string; trigger: ReactNod
           <DialogTitle>{title}</DialogTitle>
         </DialogHeader>
         <DialogBody px={{ base: "6", md: "8" }}>
-          <Text fontSize="sm" lineHeight="2">
+          <Text textStyle="body/md">
             {children}
           </Text>
         </DialogBody>
         <DialogCloseTrigger />
         <DialogFooter pb={{ base: "6", md: "8" }} justifyContent="center">
           <DialogActionTrigger asChild>
-            <Button ref={ref} size="md" borderColor="gray.300">
+            <Button ref={ref} size="md" borderColor="gray.300" textStyle="body/md/bold">
               閉じる
             </Button>
           </DialogActionTrigger>
@@ -60,7 +60,6 @@ const Button = forwardRef<HTMLButtonElement, ChakraButtonProps>(({ children, ...
       variant="outline"
       rounded="full"
       size="xs"
-      fontWeight="bold"
       px="5"
       borderColor="gray.800"
       gap="2"
@@ -78,7 +77,7 @@ const Button = forwardRef<HTMLButtonElement, ChakraButtonProps>(({ children, ...
 
 export function Footer({ meta }: Props) {
   return (
-    <Box as="footer" fontSize="xs" color="gray.800" lineHeight="2">
+    <Box as="footer" color="gray.800">
       <Box
         bg="url('/images/footer-bg.webp')"
         bgSize="cover"
@@ -104,19 +103,19 @@ export function Footer({ meta }: Props) {
             height={102}
           />
           <Flex flexDirection="column" gap={{ base: "4" }}>
-            <Text>
+            <Text textStyle="body/sm">
               広聴AIは、デジタル民主主義2030プロジェクトから生まれたオープンソース（OSS）アプリケーションです。
               <Box as="br" display={{ base: "none", lg: "inline" }} />
               本ページは、そのOSS成果物を活用して構築されています。
             </Text>
             <Flex gap="3">
-              <Button asChild>
+              <Button textStyle="body/sm/bold" asChild>
                 <a href="https://dd2030.org/kouchou-ai" target="_blank" rel="noopener noreferrer">
                   広聴AIについて
                   <ArrowUpRight />
                 </a>
               </Button>
-              <Dialog title="謝辞" trigger={<Button>謝辞</Button>}>
+              <Dialog title="謝辞" trigger={<Button textStyle="body/sm/bold">謝辞</Button>}>
                 広聴AIは{" "}
                 <Link
                   href="https://ai.objectives.institute/"
@@ -155,11 +154,11 @@ export function Footer({ meta }: Props) {
         >
           <Image src="/images/dd2030-logo-full.svg" alt="デジタル民主主義2030" width={256} height={80} />
           <Flex flexDirection="column" gap="4">
-            <Text>
+            <Text textStyle="body/sm">
               2030年には、情報技術により民主主義のあり方はアップデートされており、一人ひとりの声が政治・行政に届き、適切に合意形成・政策反映されていくような社会が当たり前になる、──そんな未来を目指して立ち上げられたのがデジタル民主主義2030プロジェクトです。
             </Text>
             <Flex gap="3" flexWrap="wrap">
-              <Button asChild>
+              <Button textStyle="body/sm/bold" asChild>
                 <a href="https://dd2030.org" rel="noopener noreferrer" target="_blank">
                   プロジェクトサイト
                   <ArrowUpRight />
@@ -175,13 +174,13 @@ export function Footer({ meta }: Props) {
                   <NoteIcon />
                 </a>
               </Button>
-              <Button asChild>
+              <Button textStyle="body/sm/bold" asChild>
                 <a href="https://dd2030.slack.com" rel="noopener noreferrer" target="_blank">
                   <SlackIcon />
-                  Slack
+                  slack
                 </a>
               </Button>
-              <Button asChild>
+              <Button textStyle="body/sm/bold" asChild>
                 <a href="https://github.com/digitaldemocracy2030" rel="noopener noreferrer" target="_blank">
                   <GitHubIcon />
                   GitHub
@@ -200,7 +199,7 @@ export function Footer({ meta }: Props) {
           flexDirection={{ base: "column-reverse", lg: "row" }}
           gap={{ base: "4" }}
         >
-          <Text display="flex" color="gray.500" fontSize="xs">
+          <Text display="flex" color="gray.500" textStyle="body/sm">
             © 2025 デジタル民主主義2030
             <Box as="span" mx="0.4em" display={{ base: "none", lg: "inline" }}>
               |
@@ -210,18 +209,16 @@ export function Footer({ meta }: Props) {
           </Text>
           <Flex gap="0" alignItems="center" color="gray.800">
             {meta.termsLink && (
-              <Button variant="ghost" border="none" asChild>
+              <Button variant="ghost" border="none" textStyle="body/sm/bold" asChild>
                 <a href={meta.termsLink} target="_blank" rel="noopener noreferrer">
-                  <Text fontWeight="bold" fontSize="xs">
-                    利用規約
-                  </Text>
+                  利用規約
                 </a>
               </Button>
             )}
             <Dialog
               title="免責"
               trigger={
-                <Button variant="ghost" border="none">
+                <Button variant="ghost" border="none" textStyle="body/sm/bold">
                   免責
                 </Button>
               }

--- a/client/components/reporter/ReporterContent.tsx
+++ b/client/components/reporter/ReporterContent.tsx
@@ -30,21 +30,21 @@ function EmptyText() {
 function ReadMore({ setIsExpanded }: { setIsExpanded: (isExpanded: boolean) => void }) {
   return (
     <Flex display="inline-flex">
-      <Text w="1rem">...</Text>
+      <Text textStyle="body/md" mr="0.2rem">...</Text>
       <Button
         variant="plain"
         w="fit-content"
         h="fit-content"
         p="0"
-        mt="2px"
+        mt="-2px"
         color="blue.500"
-        fontWeight="normal"
         textDecoration="underline"
         textUnderlineOffset="2px"
         _hover={{
           opacity: 0.75,
           textDecoration: "none",
         }}
+        textStyle="body/md"
         onClick={() => setIsExpanded(true)}
       >
         全文表示
@@ -67,8 +67,7 @@ function MessageText({ isDefault, message }: { isDefault: boolean; message: stri
   return (
     <Text
       as="div"
-      fontSize="sm"
-      lineHeight={2}
+      textStyle="body/md"
       color="gray.600"
       textAlign="left"
       whiteSpace={isExpanded ? "pre-line" : "normal"}
@@ -83,18 +82,14 @@ function MessageText({ isDefault, message }: { isDefault: boolean; message: stri
 export function ReporterContent({ meta, children }: { meta: Meta; children: ReactNode }) {
   return (
     <Flex flexDirection="column" gap="4" color="gray.600">
-      <Flex flexDirection={{ base: "column", md: "row" }} alignItems="flex-start">
+      <Flex flexDirection={{ base: "column", md: "row" }} alignItems={{ base: "flex-start", md: "center" }}>
         <Box mb={{ base: "4", md: "0" }} mr={{ base: "0", md: "4" }} _empty={{ display: "none" }}>
           {children}
         </Box>
-        <Flex flexDirection="column" justifyContent="space-between" color="gray.600" gap="2">
-          <Text fontSize="xs">レポーター</Text>
+        <Flex flexDirection="column" justifyContent="space-between" color="gray.600">
+          <Text textStyle="body/sm">レポーター</Text>
           {/* metadataが未設定の場合は、レポーター名は非表示 */}
-          {!meta.isDefault && (
-            <Text fontSize="md" fontWeight="bold">
-              {meta.reporter}
-            </Text>
-          )}
+          {!meta.isDefault && <Text textStyle="body/md/bold">{meta.reporter}</Text>}
         </Flex>
       </Flex>
       <MessageText isDefault={meta.isDefault} message={meta.message} />
@@ -110,6 +105,7 @@ export function ReporterContent({ meta, children }: { meta: Meta; children: Reac
               width: "14px",
               height: "14px",
             }}
+            textStyle="body/sm/bold"
             asChild
           >
             <a href={meta.webLink} target="_blank" rel="noopener noreferrer">
@@ -121,14 +117,30 @@ export function ReporterContent({ meta, children }: { meta: Meta; children: Reac
           </Button>
         )}
         {!meta.isDefault && meta.privacyLink && (
-          <Button variant="outline" size="xs" rounded="full" px="5" color="currentcolor" asChild>
+          <Button
+            variant="outline"
+            size="xs"
+            rounded="full"
+            px="5"
+            color="currentcolor"
+            textStyle="body/sm/bold"
+            asChild
+          >
             <a href={meta.privacyLink} target="_blank" rel="noopener noreferrer">
               プライバシーポリシー
             </a>
           </Button>
         )}
         {!meta.isDefault && meta.termsLink && (
-          <Button variant="outline" size="xs" rounded="full" px="5" color="currentcolor" asChild>
+          <Button
+            variant="outline"
+            size="xs"
+            rounded="full"
+            px="5"
+            color="currentcolor"
+            textStyle="body/sm/bold"
+            asChild
+          >
             <a href={meta.termsLink} target="_blank" rel="noopener noreferrer">
               利用規約
             </a>

--- a/client/components/reporter/ReporterContent.tsx
+++ b/client/components/reporter/ReporterContent.tsx
@@ -1,24 +1,19 @@
 "use client";
 
 import type { Meta } from "@/type";
-import { Box, Button, Flex, Link, Text } from "@chakra-ui/react";
+import { Box, Button, Flex, Text } from "@chakra-ui/react";
 import { Globe } from "lucide-react";
 import { type ReactNode, useState } from "react";
+import { Link } from "../ui/link";
 
 function EmptyText() {
   return (
-    <Text fontSize="sm" color="gray.500">
+    <Text textStyle="body/md" color="gray.500">
       レポーター情報が未設定です。レポート作成者が
       <Link
         href="https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/README.md#%E3%83%A1%E3%82%BF%E3%83%87%E3%83%BC%E3%82%BF%E3%83%95%E3%82%A1%E3%82%A4%E3%83%AB%E3%81%AE%E3%82%BB%E3%83%83%E3%83%88%E3%82%A2%E3%83%83%E3%83%97"
         target="_blank"
         rel="noopener noreferrer"
-        variant="underline"
-        color="blue.500"
-        _hover={{
-          opacity: 0.75,
-          textDecoration: "none",
-        }}
       >
         メタデータをセットアップ
       </Link>
@@ -29,26 +24,9 @@ function EmptyText() {
 
 function ReadMore({ setIsExpanded }: { setIsExpanded: (isExpanded: boolean) => void }) {
   return (
-    <Flex display="inline-flex">
-      <Text textStyle="body/md" mr="0.2rem">...</Text>
-      <Button
-        variant="plain"
-        w="fit-content"
-        h="fit-content"
-        p="0"
-        mt="-2px"
-        color="blue.500"
-        textDecoration="underline"
-        textUnderlineOffset="2px"
-        _hover={{
-          opacity: 0.75,
-          textDecoration: "none",
-        }}
-        textStyle="body/md"
-        onClick={() => setIsExpanded(true)}
-      >
-        全文表示
-      </Button>
+    <Flex textStyle="body/md" display="inline-flex">
+      <Text mr="0.4rem">...</Text>
+      <Link onClick={() => setIsExpanded(true)}>全文表示</Link>
     </Flex>
   );
 }

--- a/client/components/theme/fonts.ts
+++ b/client/components/theme/fonts.ts
@@ -1,6 +1,5 @@
 const fontFamily = '"BIZ UDPGothic", "Hiragino Kaku Gothic ProN", Meiryo, sans-serif'
 
 export const fonts = {
-  body: { value: fontFamily},
-  heading: { value: fontFamily },
+  main: { value: fontFamily },
 }

--- a/client/components/theme/fonts.ts
+++ b/client/components/theme/fonts.ts
@@ -1,0 +1,6 @@
+const fontFamily = '"BIZ UDPGothic", "Hiragino Kaku Gothic ProN", Meiryo, sans-serif'
+
+export const fonts = {
+  body: { value: fontFamily},
+  heading: { value: fontFamily },
+}

--- a/client/components/theme/recipe/link.ts
+++ b/client/components/theme/recipe/link.ts
@@ -1,0 +1,34 @@
+import { defineRecipe } from "@chakra-ui/react";
+
+// https://github.com/chakra-ui/chakra-ui/blob/3df43bab4e98af6cabc4f7e199e38c4b8ec11bbe/packages/react/src/theme/recipes/link.ts
+export const linkRecipe = defineRecipe({
+  className: "chakra-link",
+  base: {
+    display: "inline-flex",
+    alignItems: "center",
+    outline: "none",
+    gap: "1.5",
+    cursor: "pointer",
+    borderRadius: "l1",
+    focusRing: "outside",
+  },
+
+  variants: {
+    variant: {
+      underline: {
+        color: "font.link",
+        textDecoration: "underline",
+        textUnderlineOffset: "3px",
+        textDecorationColor: "currentColor/20",
+        _hover: {
+          opacity: 0.75,
+          textDecoration: "none",
+        }
+      },
+    },
+  },
+
+  defaultVariants: {
+    variant: "underline",
+  },
+})

--- a/client/components/theme/semanticTokens.ts
+++ b/client/components/theme/semanticTokens.ts
@@ -1,0 +1,14 @@
+export const semanticTokens = {
+  colors: {
+    font: {
+      primary: { value: "{colors.gray.800}" },
+      secondary: { value: "{colors.gray.500}" },
+      disable: { value: "{colors.gray.400}" },
+      white: { value: "{colors.white}" },
+      link: { value: "{colors.blue.500}" },
+      visited: { value: "{colors.purple.700}" },
+      error: { value: "{colors.error.500}" },
+      aiTalking: { value: "{colors.purple.600}" },
+    },
+  },
+};

--- a/client/components/theme/system.ts
+++ b/client/components/theme/system.ts
@@ -1,8 +1,12 @@
 import { createSystem, defaultConfig } from "@chakra-ui/react";
 import { textStyles } from "./textStyle";
+import { fonts } from "./fonts";
 
 export const system = createSystem(defaultConfig, {
   theme: {
+    tokens: {
+      fonts,
+    },
     textStyles,
   },
 });

--- a/client/components/theme/system.ts
+++ b/client/components/theme/system.ts
@@ -1,12 +1,14 @@
 import { createSystem, defaultConfig } from "@chakra-ui/react";
-import { textStyles } from "./textStyle";
 import { fonts } from "./fonts";
+import { semanticTokens } from "./semanticTokens";
+import { textStyles } from "./textStyle";
 
 export const system = createSystem(defaultConfig, {
   theme: {
     tokens: {
       fonts,
     },
+    semanticTokens,
     textStyles,
   },
 });

--- a/client/components/theme/system.ts
+++ b/client/components/theme/system.ts
@@ -1,0 +1,8 @@
+import { createSystem, defaultConfig } from "@chakra-ui/react";
+import { textStyles } from "./textStyle";
+
+export const system = createSystem(defaultConfig, {
+  theme: {
+    textStyles,
+  },
+});

--- a/client/components/theme/textStyle.ts
+++ b/client/components/theme/textStyle.ts
@@ -1,55 +1,59 @@
-import { defineTextStyles } from "@chakra-ui/react"
-
-export const textStyles = defineTextStyles({
-  'heading/3xl': {
+export const textStyles = {
+  "heading/3xl": {
     value: {
+      fontFamily: "heading",
       fontSize: "3xl",
       fontWeight: "bold",
       lineHeight: "tall",
       letterSpacing: "0.9px",
     },
   },
-  'heading/2xl': {
+  "heading/2xl": {
     value: {
+      fontFamily: "heading",
       fontSize: "2xl",
       fontWeight: "bold",
       lineHeight: "tall",
       letterSpacing: "0.75px",
     },
   },
-  'heading/xl': {
+  "heading/xl": {
     value: {
+      fontFamily: "heading",
       fontSize: "xl",
       fontWeight: "bold",
       lineHeight: "tall",
       letterSpacing: "0.6px",
     },
   },
-  'body/lg': {
+  "body/lg": {
     value: {
+      fontFamily: "body",
       fontSize: "lg",
       fontWeight: "normal",
       lineHeight: "taller",
       letterSpacing: "0.5px",
     },
   },
-  'body/md': {
+  "body/md": {
     value: {
+      fontFamily: "body",
       fontSize: "md",
       fontWeight: "normal",
       lineHeight: "taller",
       letterSpacing: "0.4px",
     },
   },
-  'body/sm': {
+  "body/sm": {
     value: {
+      fontFamily: "body",
       fontSize: "xs",
       fontWeight: "normal",
       lineHeight: "taller",
       letterSpacing: "0.3px",
     },
   },
-  'body/lg/bold': {
+  "body/lg/bold": {
     value: {
       fontFamily: "body",
       fontSize: "lg",
@@ -58,7 +62,7 @@ export const textStyles = defineTextStyles({
       letterSpacing: "0.5px",
     },
   },
-  'body/md/bold': {
+  "body/md/bold": {
     value: {
       fontFamily: "body",
       fontSize: "md",
@@ -67,7 +71,7 @@ export const textStyles = defineTextStyles({
       letterSpacing: "0.4px",
     },
   },
-  'body/sm/bold': {
+  "body/sm/bold": {
     value: {
       fontFamily: "body",
       fontSize: "xs",
@@ -76,4 +80,4 @@ export const textStyles = defineTextStyles({
       letterSpacing: "0.3px",
     },
   },
-})
+};

--- a/client/components/theme/textStyle.ts
+++ b/client/components/theme/textStyle.ts
@@ -2,7 +2,7 @@ export const textStyles = {
   "heading/3xl": {
     value: {
       fontFamily: "main",
-      fontSize: "3xl",
+      fontSize: "4xl",
       fontWeight: "bold",
       lineHeight: "tall",
       letterSpacing: "0.9px",
@@ -11,7 +11,7 @@ export const textStyles = {
   "heading/2xl": {
     value: {
       fontFamily: "main",
-      fontSize: "2xl",
+      fontSize: "3xl",
       fontWeight: "bold",
       lineHeight: "tall",
       letterSpacing: "0.75px",
@@ -20,7 +20,7 @@ export const textStyles = {
   "heading/xl": {
     value: {
       fontFamily: "main",
-      fontSize: "xl",
+      fontSize: "2xl",
       fontWeight: "bold",
       lineHeight: "tall",
       letterSpacing: "0.6px",
@@ -29,7 +29,7 @@ export const textStyles = {
   "body/lg": {
     value: {
       fontFamily: "main",
-      fontSize: "lg",
+      fontSize: "xl",
       fontWeight: "normal",
       lineHeight: "taller",
       letterSpacing: "0.5px",
@@ -56,7 +56,7 @@ export const textStyles = {
   "body/lg/bold": {
     value: {
       fontFamily: "main",
-      fontSize: "lg",
+      fontSize: "xl",
       fontWeight: "bold",
       lineHeight: "taller",
       letterSpacing: "0.5px",

--- a/client/components/theme/textStyle.ts
+++ b/client/components/theme/textStyle.ts
@@ -1,0 +1,79 @@
+import { defineTextStyles } from "@chakra-ui/react"
+
+export const textStyles = defineTextStyles({
+  'heading/3xl': {
+    value: {
+      fontSize: "3xl",
+      fontWeight: "bold",
+      lineHeight: "tall",
+      letterSpacing: "0.9px",
+    },
+  },
+  'heading/2xl': {
+    value: {
+      fontSize: "2xl",
+      fontWeight: "bold",
+      lineHeight: "tall",
+      letterSpacing: "0.75px",
+    },
+  },
+  'heading/xl': {
+    value: {
+      fontSize: "xl",
+      fontWeight: "bold",
+      lineHeight: "tall",
+      letterSpacing: "0.6px",
+    },
+  },
+  'body/lg': {
+    value: {
+      fontSize: "lg",
+      fontWeight: "normal",
+      lineHeight: "taller",
+      letterSpacing: "0.5px",
+    },
+  },
+  'body/md': {
+    value: {
+      fontSize: "md",
+      fontWeight: "normal",
+      lineHeight: "taller",
+      letterSpacing: "0.4px",
+    },
+  },
+  'body/sm': {
+    value: {
+      fontSize: "xs",
+      fontWeight: "normal",
+      lineHeight: "taller",
+      letterSpacing: "0.3px",
+    },
+  },
+  'body/lg/bold': {
+    value: {
+      fontFamily: "body",
+      fontSize: "lg",
+      fontWeight: "bold",
+      lineHeight: "taller",
+      letterSpacing: "0.5px",
+    },
+  },
+  'body/md/bold': {
+    value: {
+      fontFamily: "body",
+      fontSize: "md",
+      fontWeight: "bold",
+      lineHeight: "taller",
+      letterSpacing: "0.4px",
+    },
+  },
+  'body/sm/bold': {
+    value: {
+      fontFamily: "body",
+      fontSize: "xs",
+      fontWeight: "bold",
+      lineHeight: "taller",
+      letterSpacing: "0.3px",
+    },
+  },
+})

--- a/client/components/theme/textStyle.ts
+++ b/client/components/theme/textStyle.ts
@@ -1,7 +1,7 @@
 export const textStyles = {
   "heading/3xl": {
     value: {
-      fontFamily: "heading",
+      fontFamily: "main",
       fontSize: "3xl",
       fontWeight: "bold",
       lineHeight: "tall",
@@ -10,7 +10,7 @@ export const textStyles = {
   },
   "heading/2xl": {
     value: {
-      fontFamily: "heading",
+      fontFamily: "main",
       fontSize: "2xl",
       fontWeight: "bold",
       lineHeight: "tall",
@@ -19,7 +19,7 @@ export const textStyles = {
   },
   "heading/xl": {
     value: {
-      fontFamily: "heading",
+      fontFamily: "main",
       fontSize: "xl",
       fontWeight: "bold",
       lineHeight: "tall",
@@ -28,7 +28,7 @@ export const textStyles = {
   },
   "body/lg": {
     value: {
-      fontFamily: "body",
+      fontFamily: "main",
       fontSize: "lg",
       fontWeight: "normal",
       lineHeight: "taller",
@@ -37,7 +37,7 @@ export const textStyles = {
   },
   "body/md": {
     value: {
-      fontFamily: "body",
+      fontFamily: "main",
       fontSize: "md",
       fontWeight: "normal",
       lineHeight: "taller",
@@ -46,7 +46,7 @@ export const textStyles = {
   },
   "body/sm": {
     value: {
-      fontFamily: "body",
+      fontFamily: "main",
       fontSize: "xs",
       fontWeight: "normal",
       lineHeight: "taller",
@@ -55,7 +55,7 @@ export const textStyles = {
   },
   "body/lg/bold": {
     value: {
-      fontFamily: "body",
+      fontFamily: "main",
       fontSize: "lg",
       fontWeight: "bold",
       lineHeight: "taller",
@@ -64,7 +64,7 @@ export const textStyles = {
   },
   "body/md/bold": {
     value: {
-      fontFamily: "body",
+      fontFamily: "main",
       fontSize: "md",
       fontWeight: "bold",
       lineHeight: "taller",
@@ -73,7 +73,7 @@ export const textStyles = {
   },
   "body/sm/bold": {
     value: {
-      fontFamily: "body",
+      fontFamily: "main",
       fontSize: "xs",
       fontWeight: "bold",
       lineHeight: "taller",

--- a/client/components/ui/link.tsx
+++ b/client/components/ui/link.tsx
@@ -1,0 +1,18 @@
+import {
+  Link as ChakraLink,
+  type LinkProps as ChakraLinkProps,
+  type RecipeVariantProps,
+  useRecipe,
+} from "@chakra-ui/react";
+import { forwardRef } from "react";
+import { linkRecipe } from "../theme/recipe/link";
+
+type LinkVariantProps = RecipeVariantProps<typeof linkRecipe>;
+type LinkProps = LinkVariantProps & Omit<ChakraLinkProps, keyof LinkVariantProps>;
+
+export const Link = forwardRef<HTMLAnchorElement, LinkProps>(({ variant, ...rest }, ref) => {
+  const recipe = useRecipe({ recipe: linkRecipe });
+  const styles = recipe({ variant });
+
+  return <ChakraLink ref={ref} css={styles} {...rest} />;
+});

--- a/client/components/ui/provider.tsx
+++ b/client/components/ui/provider.tsx
@@ -1,16 +1,6 @@
 "use client";
-import { ChakraProvider, createSystem, defaultConfig } from "@chakra-ui/react";
-
-const system = createSystem(defaultConfig, {
-  theme: {
-    tokens: {
-      fonts: {
-        heading: { value: "var(--font-mplus1)" },
-        body: { value: "var(--font-mplus1)" },
-      },
-    },
-  },
-});
+import { ChakraProvider } from "@chakra-ui/react";
+import { system } from "../theme/system";
 
 export function Provider({ children }: { children: React.ReactNode }) {
   return <ChakraProvider value={system}>{children}</ChakraProvider>;

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -22,6 +22,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
+        "@chakra-ui/cli": "^3.21.0",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
         "@types/jest": "^29.5.14",
@@ -820,6 +821,74 @@
         "node": ">=14.21.3"
       }
     },
+    "node_modules/@chakra-ui/cli": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/cli/-/cli-3.21.0.tgz",
+      "integrity": "sha512-wZwv4OpMivxVFbYgEUYuy4LRVrRiQlp3v0YPzAq5xXRctpWhlsIFFqJMKCBtM/+s55+R1pnnwLKeuucZDml/SA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@clack/prompts": "0.10.1",
+        "@pandacss/is-valid-prop": "0.53.6",
+        "@types/cli-table": "^0.3.4",
+        "@types/debug": "^4.1.12",
+        "@visulima/boxen": "^1.0.30",
+        "bundle-n-require": "1.1.2",
+        "chokidar": "3.6.0",
+        "cli-table": "^0.3.11",
+        "commander": "12.1.0",
+        "debug": "^4.4.0",
+        "globby": "14.1.0",
+        "https-proxy-agent": "^7.0.6",
+        "look-it-up": "2.1.0",
+        "node-fetch": "3.3.2",
+        "package-manager-detector": "1.2.0",
+        "prettier": "3.5.3",
+        "scule": "1.3.0",
+        "sucrase": "^3.35.0",
+        "zod": "^3.24.3"
+      },
+      "bin": {
+        "chakra": "bin/index.js"
+      },
+      "peerDependencies": {
+        "@chakra-ui/react": ">=3.0.0-next.0"
+      }
+    },
+    "node_modules/@chakra-ui/cli/node_modules/agent-base": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@chakra-ui/cli/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/cli/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/@chakra-ui/react": {
       "version": "3.19.1",
       "resolved": "https://registry.npmjs.org/@chakra-ui/react/-/react-3.19.1.tgz",
@@ -851,6 +920,29 @@
       },
       "bin": {
         "findup": "bin/findup.js"
+      }
+    },
+    "node_modules/@clack/core": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@clack/core/-/core-0.4.2.tgz",
+      "integrity": "sha512-NYQfcEy8MWIxrT5Fj8nIVchfRFA26yYKJcvBS7WlUIlw2OmQOY9DhGGXMovyI5J5PpxrCPGkgUi207EBrjpBvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picocolors": "^1.0.0",
+        "sisteransi": "^1.0.5"
+      }
+    },
+    "node_modules/@clack/prompts": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-0.10.1.tgz",
+      "integrity": "sha512-Q0T02vx8ZM9XSv9/Yde0jTmmBQufZhPJfYAg2XrrrxWWaZgq1rr8nU8Hv710BQ1dhoP8rtY7YUdpGej2Qza/cw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@clack/core": "0.4.2",
+        "picocolors": "^1.0.0",
+        "sisteransi": "^1.0.5"
       }
     },
     "node_modules/@emotion/babel-plugin": {
@@ -975,6 +1067,431 @@
       "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
       "license": "MIT"
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.5.tgz",
+      "integrity": "sha512-9o3TMmpmftaCMepOdA5k/yDw8SfInyzWWTjYTFCX3kPSDJMROQTb8jg+h9Cnwnmm1vOzvxN7gIfB5V2ewpjtGA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.5.tgz",
+      "integrity": "sha512-AdJKSPeEHgi7/ZhuIPtcQKr5RQdo6OO2IL87JkianiMYMPbCtot9fxPbrMiBADOWWm3T2si9stAiVsGbTQFkbA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.5.tgz",
+      "integrity": "sha512-VGzGhj4lJO+TVGV1v8ntCZWJktV7SGCs3Pn1GRWI1SBFtRALoomm8k5E9Pmwg3HOAal2VDc2F9+PM/rEY6oIDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.5.tgz",
+      "integrity": "sha512-D2GyJT1kjvO//drbRT3Hib9XPwQeWd9vZoBJn+bu/lVsOZ13cqNdDeqIF/xQ5/VmWvMduP6AmXvylO/PIc2isw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.5.tgz",
+      "integrity": "sha512-GtaBgammVvdF7aPIgH2jxMDdivezgFu6iKpmT+48+F8Hhg5J/sfnDieg0aeG/jfSvkYQU2/pceFPDKlqZzwnfQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.5.tgz",
+      "integrity": "sha512-1iT4FVL0dJ76/q1wd7XDsXrSW+oLoquptvh4CLR4kITDtqi2e/xwXwdCVH8hVHU43wgJdsq7Gxuzcs6Iq/7bxQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.5.tgz",
+      "integrity": "sha512-nk4tGP3JThz4La38Uy/gzyXtpkPW8zSAmoUhK9xKKXdBCzKODMc2adkB2+8om9BDYugz+uGV7sLmpTYzvmz6Sw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.5.tgz",
+      "integrity": "sha512-PrikaNjiXdR2laW6OIjlbeuCPrPaAl0IwPIaRv+SMV8CiM8i2LqVUHFC1+8eORgWyY7yhQY+2U2fA55mBzReaw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.5.tgz",
+      "integrity": "sha512-cPzojwW2okgh7ZlRpcBEtsX7WBuqbLrNXqLU89GxWbNt6uIg78ET82qifUy3W6OVww6ZWobWub5oqZOVtwolfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.5.tgz",
+      "integrity": "sha512-Z9kfb1v6ZlGbWj8EJk9T6czVEjjq2ntSYLY2cw6pAZl4oKtfgQuS4HOq41M/BcoLPzrUbNd+R4BXFyH//nHxVg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.5.tgz",
+      "integrity": "sha512-sQ7l00M8bSv36GLV95BVAdhJ2QsIbCuCjh/uYrWiMQSUuV+LpXwIqhgJDcvMTj+VsQmqAHL2yYaasENvJ7CDKA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.5.tgz",
+      "integrity": "sha512-0ur7ae16hDUC4OL5iEnDb0tZHDxYmuQyhKhsPBV8f99f6Z9KQM02g33f93rNH5A30agMS46u2HP6qTdEt6Q1kg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.5.tgz",
+      "integrity": "sha512-kB/66P1OsHO5zLz0i6X0RxlQ+3cu0mkxS3TKFvkb5lin6uwZ/ttOkP3Z8lfR9mJOBk14ZwZ9182SIIWFGNmqmg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.5.tgz",
+      "integrity": "sha512-UZCmJ7r9X2fe2D6jBmkLBMQetXPXIsZjQJCjgwpVDz+YMcS6oFR27alkgGv3Oqkv07bxdvw7fyB71/olceJhkQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.5.tgz",
+      "integrity": "sha512-kTxwu4mLyeOlsVIFPfQo+fQJAV9mh24xL+y+Bm6ej067sYANjyEw1dNHmvoqxJUCMnkBdKpvOn0Ahql6+4VyeA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.5.tgz",
+      "integrity": "sha512-K2dSKTKfmdh78uJ3NcWFiqyRrimfdinS5ErLSn3vluHNeHVnBAFWC8a4X5N+7FgVE1EjXS1QDZbpqZBjfrqMTQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.5.tgz",
+      "integrity": "sha512-uhj8N2obKTE6pSZ+aMUbqq+1nXxNjZIIjCjGLfsWvVpy7gKCOL6rsY1MhRh9zLtUtAI7vpgLMK6DxjO8Qm9lJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.5.tgz",
+      "integrity": "sha512-pwHtMP9viAy1oHPvgxtOv+OkduK5ugofNTVDilIzBLpoWAM16r7b/mxBvfpuQDpRQFMfuVr5aLcn4yveGvBZvw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.5.tgz",
+      "integrity": "sha512-WOb5fKrvVTRMfWFNCroYWWklbnXH0Q5rZppjq0vQIdlsQKuw6mdSihwSo4RV/YdQ5UCKKvBy7/0ZZYLBZKIbwQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.5.tgz",
+      "integrity": "sha512-7A208+uQKgTxHd0G0uqZO8UjK2R0DDb4fDmERtARjSHWxqMTye4Erz4zZafx7Di9Cv+lNHYuncAkiGFySoD+Mw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.5.tgz",
+      "integrity": "sha512-G4hE405ErTWraiZ8UiSoesH8DaCsMm0Cay4fsFWOOUcz8b8rC6uCvnagr+gnioEjWn0wC+o1/TAHt+It+MpIMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.5.tgz",
+      "integrity": "sha512-l+azKShMy7FxzY0Rj4RCt5VD/q8mG/e+mDivgspo+yL8zW7qEwctQ6YqKX34DTEleFAvCIUviCFX1SDZRSyMQA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.5.tgz",
+      "integrity": "sha512-O2S7SNZzdcFG7eFKgvwUEZ2VG9D/sn/eIiz8XRZ1Q/DO5a3s76Xv0mdBzVM5j5R639lXQmPmSo0iRpHqUUrsxw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.5.tgz",
+      "integrity": "sha512-onOJ02pqs9h1iMJ1PQphR+VZv8qBMQ77Klcsqv9CNW2w6yLqoURLcgERAIurY6QE63bbLuqgP9ATqajFLK5AMQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.5.tgz",
+      "integrity": "sha512-TXv6YnJ8ZMVdX+SXWVBo/0p8LTcrUYngpWjvm91TMjjBQii7Oz11Lw5lbDV5Y0TzuhSJHwiH4hEtC1I42mMS0g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@floating-ui/core": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.0.tgz",
@@ -1094,7 +1611,6 @@
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "string-width": "^5.1.2",
         "string-width-cjs": "npm:string-width@^4.2.0",
@@ -1974,6 +2490,44 @@
         "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0"
       }
     },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/@pandacss/is-valid-prop": {
       "version": "0.53.6",
       "resolved": "https://registry.npmjs.org/@pandacss/is-valid-prop/-/is-valid-prop-0.53.6.tgz",
@@ -1985,7 +2539,6 @@
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -2081,6 +2634,19 @@
       "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
+      "integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",
@@ -2358,6 +2924,23 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/cli-table": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@types/cli-table/-/cli-table-0.3.4.tgz",
+      "integrity": "sha512-GsALrTL69mlwbAw/MHF1IPTadSLZQnsxe7a80G8l4inN/iEXCOcVeT/S7aRc6hbhqzL9qZ314kHPDQnQ3ev+HA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/debug": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/eslint": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
@@ -2532,6 +3115,13 @@
         "@types/pbf": "*"
       }
     },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "20.17.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.19.tgz",
@@ -2660,6 +3250,31 @@
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@visulima/boxen": {
+      "version": "1.0.31",
+      "resolved": "https://registry.npmjs.org/@visulima/boxen/-/boxen-1.0.31.tgz",
+      "integrity": "sha512-h4l4XCxXGaj1zoKa9DuX7ULLpWsc/tvzAFbQ2bs4gpS0ePtFOpV0Sqp8SqtGuI1U9pU+FSyCpUWXll7J209pdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/prisis"
+        },
+        {
+          "type": "consulting",
+          "url": "https://anolilab.com/support"
+        }
+      ],
+      "license": "MIT",
+      "os": [
+        "darwin",
+        "linux",
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18.0.0 <=23.x"
+      }
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.14.1",
@@ -3725,7 +4340,6 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
       "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3747,6 +4361,13 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
@@ -4004,6 +4625,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/binary-search-bounds": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-2.0.5.tgz",
@@ -4107,6 +4741,17 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "license": "MIT"
+    },
+    "node_modules/bundle-n-require": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/bundle-n-require/-/bundle-n-require-1.1.2.tgz",
+      "integrity": "sha512-bEk2jakVK1ytnZ9R2AAiZEeK/GxPUM8jvcRxHZXifZDMcjkI4EG/GlsJ2YGSVYT9y/p/gA9/0yDY8rCGsSU6Tg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.1",
+        "node-eval": "^2.0.0"
+      }
     },
     "node_modules/busboy": {
       "version": "1.6.0",
@@ -4226,6 +4871,31 @@
         "node": ">=10"
       }
     },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/chrome-trace-event": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
@@ -4265,6 +4935,18 @@
       "integrity": "sha512-kgMuFyE78OC6Dyu3Dy7vcx4uy97EIbVxJB/B0eJ3bUNAkwdNcxYzgKltnyADiYwsR7SEqkkUPsEUT//OVS6XMA==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/cli-table": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.11.tgz",
+      "integrity": "sha512-IqLQi4lO0nIB4tcdTpN4LCB9FI3uqrJZK7RC515EnhZ6qBaglkIgICb1wjeAqpdoOabm1+SuQtkXIPdYC93jhQ==",
+      "dev": true,
+      "dependencies": {
+        "colors": "1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.2.0"
+      }
     },
     "node_modules/client-only": {
       "version": "0.0.1",
@@ -4494,6 +5176,16 @@
       "dependencies": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/colors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+      "integrity": "sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
       }
     },
     "node_modules/combined-stream": {
@@ -4969,6 +5661,16 @@
       "license": "BSD-3-Clause",
       "peer": true
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/data-urls": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
@@ -5190,8 +5892,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.102",
@@ -5233,8 +5934,7 @@
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
@@ -5392,6 +6092,47 @@
         "es5-ext": "^0.10.46",
         "es6-iterator": "^2.0.3",
         "es6-symbol": "^3.1.1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.5.tgz",
+      "integrity": "sha512-P8OtKZRv/5J5hhz0cUAdu/cLuPIKXpQl1R9pZtvmHWQvrAUVd0UNIPT4IB4W3rNOqVO0rlqHmCIbSwxh/c9yUQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.5",
+        "@esbuild/android-arm": "0.25.5",
+        "@esbuild/android-arm64": "0.25.5",
+        "@esbuild/android-x64": "0.25.5",
+        "@esbuild/darwin-arm64": "0.25.5",
+        "@esbuild/darwin-x64": "0.25.5",
+        "@esbuild/freebsd-arm64": "0.25.5",
+        "@esbuild/freebsd-x64": "0.25.5",
+        "@esbuild/linux-arm": "0.25.5",
+        "@esbuild/linux-arm64": "0.25.5",
+        "@esbuild/linux-ia32": "0.25.5",
+        "@esbuild/linux-loong64": "0.25.5",
+        "@esbuild/linux-mips64el": "0.25.5",
+        "@esbuild/linux-ppc64": "0.25.5",
+        "@esbuild/linux-riscv64": "0.25.5",
+        "@esbuild/linux-s390x": "0.25.5",
+        "@esbuild/linux-x64": "0.25.5",
+        "@esbuild/netbsd-arm64": "0.25.5",
+        "@esbuild/netbsd-x64": "0.25.5",
+        "@esbuild/openbsd-arm64": "0.25.5",
+        "@esbuild/openbsd-x64": "0.25.5",
+        "@esbuild/sunos-x64": "0.25.5",
+        "@esbuild/win32-arm64": "0.25.5",
+        "@esbuild/win32-ia32": "0.25.5",
+        "@esbuild/win32-x64": "0.25.5"
       }
     },
     "node_modules/esbuild-style-plugin": {
@@ -5650,6 +6391,23 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
     "node_modules/fast-isnumeric": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/fast-isnumeric/-/fast-isnumeric-1.1.4.tgz",
@@ -5690,6 +6448,16 @@
       "license": "BSD-3-Clause",
       "peer": true
     },
+    "node_modules/fastq": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
+      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
@@ -5698,6 +6466,30 @@
       "license": "Apache-2.0",
       "dependencies": {
         "bser": "2.1.1"
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
       }
     },
     "node_modules/fill-range": {
@@ -5775,7 +6567,6 @@
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
       "integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "cross-spawn": "^7.0.0",
         "signal-exit": "^4.0.1"
@@ -5803,6 +6594,19 @@
         "node": ">= 6"
       }
     },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/from2": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
@@ -5820,6 +6624,21 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -5996,7 +6815,6 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
       "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^3.1.2",
@@ -6012,6 +6830,19 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/glob-to-regexp": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
@@ -6024,7 +6855,6 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -6034,7 +6864,6 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
       "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -6093,6 +6922,53 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/globby": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-14.1.0.tgz",
+      "integrity": "sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^2.1.0",
+        "fast-glob": "^3.3.3",
+        "ignore": "^7.0.3",
+        "path-type": "^6.0.0",
+        "slash": "^5.1.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globby/node_modules/path-type": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-6.0.0.tgz",
+      "integrity": "sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globby/node_modules/slash": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/glsl-inject-defines": {
@@ -6588,6 +7464,16 @@
       "license": "BSD-3-Clause",
       "peer": true
     },
+    "node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -6678,6 +7564,19 @@
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "license": "MIT"
     },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-browser": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-browser/-/is-browser-2.1.0.tgz",
@@ -6698,6 +7597,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-finite": {
@@ -6740,6 +7649,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-iexplorer": {
@@ -6922,7 +7844,6 @@
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
       "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
       "license": "BlueOak-1.0.0",
-      "peer": true,
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
       },
@@ -8158,6 +9079,13 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/look-it-up": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/look-it-up/-/look-it-up-2.1.0.tgz",
+      "integrity": "sha512-nMoGWW2HurtuJf6XAL56FWTDCWLOTSsanrgwOyaR5Y4e3zfG5N/0cU5xWZSEU3tBxhQugRbV1xL9jb+ug7yZww==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -8174,8 +9102,7 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/lucide-react": {
       "version": "0.474.0",
@@ -8409,6 +9336,16 @@
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "license": "MIT"
     },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/micromatch": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -8504,7 +9441,6 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -8568,6 +9504,18 @@
       "integrity": "sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.8",
@@ -8706,6 +9654,59 @@
       "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
       "license": "ISC",
       "peer": true
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-eval": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/node-eval/-/node-eval-2.0.0.tgz",
+      "integrity": "sha512-Ap+L9HznXAVeJj3TJ1op6M6bg5xtTq8L5CU/PJxtkhea/DrIxdTknGKIECKd/v/Lgql95iuMAYvIzBNd0pmcMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-is-absolute": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
@@ -8857,8 +9858,14 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-      "license": "BlueOak-1.0.0",
-      "peer": true
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/package-manager-detector": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.2.0.tgz",
+      "integrity": "sha512-PutJepsOtsqVfUsxCzgTTpyXmiAgvKptIgY4th5eq5UXXFhj5PxfQ9hnGkypMeovpAvVshFRItoFHYO18TCOqA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -8974,7 +9981,6 @@
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
       "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
       "license": "BlueOak-1.0.0",
-      "peer": true,
       "dependencies": {
         "lru-cache": "^10.2.0",
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
@@ -9358,6 +10364,22 @@
       "license": "ISC",
       "peer": true
     },
+    "node_modules/prettier": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/pretty-format": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
@@ -9534,6 +10556,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/quickselect": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
@@ -9655,6 +10698,19 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
     },
     "node_modules/redent": {
       "version": "3.0.0",
@@ -9860,12 +10916,47 @@
         "node": ">=10"
       }
     },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/right-now": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/right-now/-/right-now-1.0.0.tgz",
       "integrity": "sha512-DA8+YS+sMIVpbsuKgy+Z67L9Lxb1p05mNxRpDPNksPDEFir4vmBlUtuN9jkTGn9YMMdlBuK7XQgFiz6ws+yhSg==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
     },
     "node_modules/rw": {
       "version": "1.3.3",
@@ -9983,6 +11074,13 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/scule": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/scule/-/scule-1.3.0.tgz",
+      "integrity": "sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/secure-compare": {
       "version": "3.0.1",
@@ -10162,7 +11260,6 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -10417,7 +11514,6 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "eastasianwidth": "^0.2.0",
         "emoji-regex": "^9.2.2",
@@ -10436,7 +11532,6 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -10451,7 +11546,6 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -10460,15 +11554,13 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/string-width-cjs/node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -10481,7 +11573,6 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
       "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -10498,7 +11589,6 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -10511,7 +11601,6 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -10604,6 +11693,39 @@
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
       "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
       "license": "MIT"
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.0",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
+      "integrity": "sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "glob": "^10.3.10",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/sucrase/node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/supercluster": {
       "version": "7.1.5",
@@ -10806,6 +11928,29 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/third-party-capital": {
       "version": "1.0.20",
       "resolved": "https://registry.npmjs.org/third-party-capital/-/third-party-capital-1.0.20.tgz",
@@ -10918,6 +12063,13 @@
         "node": ">=12"
       }
     },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -10991,6 +12143,19 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
       "license": "MIT"
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/union": {
       "version": "0.5.0",
@@ -11165,6 +12330,16 @@
       "integrity": "sha512-lNR9aAefbGPpHO7AEnY0hCFjz1eTkWCXYvkTRrTHs9qv8zJp+SkVYpzfLIFXQQiG3tVvbNFQgVg2bQS8YGgxyw==",
       "license": "Apache-2.0",
       "peer": true
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/webgl-context": {
       "version": "2.2.0",
@@ -11347,7 +12522,6 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^6.1.0",
         "string-width": "^5.0.1",
@@ -11366,7 +12540,6 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -11384,7 +12557,6 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -11393,15 +12565,13 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/wrap-ansi-cjs/node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -11416,7 +12586,6 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -11429,7 +12598,6 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
       "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11624,6 +12792,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.63",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.63.tgz",
+      "integrity": "sha512-3ttCkqhtpncYXfP0f6dsyabbYV/nEUW+Xlu89jiXbTBifUfjaSqXOG6JnQPLtqt87n7KAmnMqcjay6c0Wq0Vbw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/client/package.json
+++ b/client/package.json
@@ -17,7 +17,8 @@
     "start:static": "http-server out -p 3000",
     "lint": "biome check .",
     "format": "biome check --write .",
-    "test": "jest"
+    "test": "jest",
+    "typegen:chakra": "npx @chakra-ui/cli typegen ./components/theme/system.ts"
   },
   "dependencies": {
     "@chakra-ui/react": "^3.5.1",
@@ -34,6 +35,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
+    "@chakra-ui/cli": "^3.21.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@types/jest": "^29.5.14",


### PR DESCRIPTION
# 変更の概要
- デザインシステムで Typography の定義がされたので、client の画面に適用します
    - Figma: https://www.figma.com/design/ZImSumdtUme9loVY5CejWX/%E5%BA%83%E8%81%B4AI%EF%BC%88%E3%83%87%E3%82%B8%E6%B0%912030%EF%BC%89?node-id=893-2217&t=RD5Ds3wDIpwS4Hfo-4

![image](https://github.com/user-attachments/assets/ee8636ff-bb36-4470-a320-d71f4fa62386)


# スクリーンショット

## Before

![localhost_3000_](https://github.com/user-attachments/assets/a3ae3a07-84e7-4e75-93fb-edb7a3b17460)

## After

![localhost_3000_](https://github.com/user-attachments/assets/3cdfea78-801f-4b6b-955d-09f0623006fc)


# 変更の背景
- Typography は Figma で client の一部の要素にしか適用されていないため、以下の部分が適用対象です
  - レポーターの情報を表示するコンポーネント
  - Footert
- font-family に BIZ UDPGothic を適用
  - 一部の heading, body の文字列に適用するために、layout.tsx で Goole Fonts を読み込む形にしています
  - [Next.js に Web Font を最適化する機能](https://nextjs.org/docs/app/getting-started/fonts)がありますが、こちらを利用すると全ての要素に適用されて Figma の状態と差異が出るため、こちらの方法は選択しませんでした
  - Figma でもすべての要素に Typograohy が適用されたら上記の機能を使うのが良いと思っています
- TextStyle とそれに関連した  Semantic Token を定義
  - https://chakra-ui.com/docs/styling/text-styles
  - https://chakra-ui.com/docs/theming/semantic-tokens
- デザインシステムに則った Link コンポーネントを追加
  - https://chakra-ui.com/docs/components/link
- textStyle など独自に定義した token が VS Code で補完できるようにするために typegen:chakra コマンドを追加
  - https://chakra-ui.com/docs/get-started/cli#chakra-typegen

# 関連Issue
- fix: #598 

# 動作確認の結果
<!-- 実装者は動作確認の結果を記載してください（例: レポート作成を実行し、正常にレポートが作成されることを確認した） 複数の動作確認を行った場合は、それぞれの結果を記載してください -->

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

# マージ前のチェックリスト（レビュアーがマージ前に確認してください）
- [ ] CIが全て通過している
- [ ] 単体テストが実装されているか
- [ ] 今回実装した機能および影響を受けると思われる機能について、適切な動作確認が行われているかを確認する。


動作確認の項目については、実装者による動作確認のケースが適切かを確認してください。
必要に応じてレビュアー自身による動作確認も歓迎します（必須ではありません）。