### PR TITLE
[BUG] OpenAI API以外のLLMを使っても、OpenAI APIを利用したと表示される

### DIFF
--- a/server/broadlistening/pipeline/steps/hierarchical_aggregation.py
+++ b/server/broadlistening/pipeline/steps/hierarchical_aggregation.py
@@ -143,7 +143,7 @@ def create_custom_intro(config):
             "openrouter": "OpenRouter API",
             "local": "Local LLM",
         }
-        
+
         provider_name = provider_names.get(provider, f"{provider} API")
         return f"{provider_name} ({model})"
 


### PR DESCRIPTION
# 変更の概要
- `server/broadlistening/pipeline/steps/hierarchical_aggregation.py`にて、
`分析対象となったデータの件数は{processed_num}件で、これらのデータに対してOpenAI APIを用いて{args_count}件の意見（議論）を抽出し、クラスタリングを行った。`
このようにOpenAI APIが固定の文字列になっていたため、configのJSONに記載されているプロバイダ名およびモデル名を取得し、動的に表示するようにしました。

# スクリーンショット
OpenAIによる分析のときは、これまでの文言通りであること
<img width="1451" alt="OpenAI" src="https://github.com/user-attachments/assets/d99feb90-a216-41e5-a7d0-958ae17e0dbe" />


<img width="1010" alt="OpenAIテスト結果" src="https://github.com/user-attachments/assets/db2c8160-1090-4549-b663-33243578c9ab" />


プロバイダを動的に取得できていること

<img width="1160" alt="OpenRouter" src="https://github.com/user-attachments/assets/74e80fb1-7a89-48ef-b66d-20b26e08f13c" />

<img width="1088" alt="OpenRouterテスト結果" src="https://github.com/user-attachments/assets/b94115dd-c882-46b5-9936-d9a7e0f8727d" />



# 変更の背景
- 関連ISSUEにも記載の通りのバグ修正のためのPRになります

# 関連Issue
https://github.com/digitaldemocracy2030/kouchou-ai/issues/494

# 動作確認の結果
<!-- 実装者は動作確認の結果を記載してください（例: レポート作成を実行し、正常にレポートが作成されることを確認した） 複数の動作確認を行った場合は、それぞれの結果を記載してください -->

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

# マージ前のチェックリスト（レビュアーがマージ前に確認してください）
- [ ] CIが全て通過している
- [ ] 単体テストが実装されているか
- [ ] 今回実装した機能および影響を受けると思われる機能について、適切な動作確認が行われているかを確認する。


動作確認の項目については、実装者による動作確認のケースが適切かを確認してください。
必要に応じてレビュアー自身による動作確認も歓迎します（必須ではありません）。
動作確認については、上にUIのスクリーンショットを添付していますので、そちらとさせてください


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - カスタム紹介文に実際に利用されているLLMプロバイダー名とモデル名が動的に表示されるようになりました。複数プロバイダーや環境変数による切り替えにも対応しています。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->