### PR TITLE
Revert "[FEATURE] admin のレポートについて、CSV ダウンロードを一律で可能にする"

### DIFF
--- a/client-admin/app/create/components/AISettingsSection.tsx
+++ b/client-admin/app/create/components/AISettingsSection.tsx
@@ -8,12 +8,14 @@ export function AISettingsSection({
   provider,
   model,
   workers,
+  isPubcomMode,
   enableSourceLink,
   onProviderChange,
   onModelChange,
   onWorkersChange,
   onIncreaseWorkers,
   onDecreaseWorkers,
+  onPubcomModeChange,
   onEnableSourceLinkChange,
   getModelDescription,
   getProviderDescription,
@@ -30,12 +32,14 @@ export function AISettingsSection({
   provider: string;
   model: string;
   workers: number;
+  isPubcomMode: boolean;
   enableSourceLink: boolean;
   onProviderChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
   onModelChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
   onWorkersChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onIncreaseWorkers: () => void;
   onDecreaseWorkers: () => void;
+  onPubcomModeChange: (checked: boolean | "indeterminate") => void;
   onEnableSourceLinkChange: (checked: boolean | "indeterminate") => void;
   getModelDescription: () => string;
   getProviderDescription: () => string;
@@ -62,6 +66,21 @@ export function AISettingsSection({
 
   return (
     <VStack gap={10}>
+      <Field.Root>
+        <Checkbox
+          checked={isPubcomMode}
+          onCheckedChange={(details) => {
+            const { checked } = details;
+            onPubcomModeChange(checked);
+          }}
+        >
+          csv出力モード
+        </Checkbox>
+        <Field.HelperText>
+          元のコメントと要約された意見をCSV形式で出力します。完成したCSVファイルはレポート一覧ページからダウンロードできます。
+        </Field.HelperText>
+      </Field.Root>
+
       <Field.Root>
         <Field.Label>AIプロバイダー</Field.Label>
         <NativeSelect.Root w={"40%"}>

--- a/client-admin/app/create/hooks/useAISettings.ts
+++ b/client-admin/app/create/hooks/useAISettings.ts
@@ -110,6 +110,7 @@ export function useAISettings() {
   const [provider, setProvider] = useState<Provider>(() => getFromStorage<Provider>(STORAGE_KEYS.PROVIDER, "openai"));
   const [model, setModel] = useState<string>(() => getFromStorage<string>(STORAGE_KEYS.MODEL, "gpt-4o-mini"));
   const [workers, setWorkers] = useState<number>(() => getFromStorage<number>(STORAGE_KEYS.WORKERS, 30));
+  const [isPubcomMode, setIsPubcomMode] = useState<boolean>(true);
   const [isEmbeddedAtLocal, setIsEmbeddedAtLocal] = useState<boolean>(() =>
     getFromStorage<boolean>(STORAGE_KEYS.IS_EMBEDDED_AT_LOCAL, false),
   );
@@ -257,6 +258,13 @@ export function useAISettings() {
     setModel(e.target.value);
   };
 
+  /**
+   * パブコムモード変更時のハンドラー
+   */
+  const handlePubcomModeChange = (checked: boolean | "indeterminate") => {
+    if (checked === "indeterminate") return;
+    setIsPubcomMode(checked);
+  };
 
   /**
    * ソースリンク設定変更時のハンドラー
@@ -320,6 +328,7 @@ export function useAISettings() {
     setProvider("openai");
     setModel("gpt-4o-mini");
     setWorkers(30);
+    setIsPubcomMode(true);
     setIsEmbeddedAtLocal(false);
     setEnableSourceLink(false);
     setLocalLLMAddress(DEFAULT_LOCAL_LLM_ADDRESS);
@@ -338,6 +347,7 @@ export function useAISettings() {
     provider,
     model,
     workers,
+    isPubcomMode,
     isEmbeddedAtLocal,
     enableSourceLink,
     localLLMAddress,
@@ -346,6 +356,7 @@ export function useAISettings() {
     handleWorkersChange,
     increaseWorkers,
     decreaseWorkers,
+    handlePubcomModeChange,
     handleEnableSourceLinkChange,
     setLocalLLMAddress,
     getModelDescription,

--- a/client-admin/app/create/page.tsx
+++ b/client-admin/app/create/page.tsx
@@ -162,7 +162,7 @@ export default function Page() {
         model: aiSettings.model,
         workers: aiSettings.workers,
         prompt: promptData,
-        is_pubcom: true,
+        is_pubcom: aiSettings.isPubcomMode,
         inputType: inputData.inputType,
         is_embedded_at_local: aiSettings.isEmbeddedAtLocal,
         enable_source_link: aiSettings.enableSourceLink,
@@ -268,6 +268,7 @@ export default function Page() {
               provider={aiSettings.provider}
               model={aiSettings.model}
               workers={aiSettings.workers}
+              isPubcomMode={aiSettings.isPubcomMode}
               enableSourceLink={aiSettings.enableSourceLink}
               isEmbeddedAtLocal={aiSettings.isEmbeddedAtLocal}
               localLLMAddress={aiSettings.localLLMAddress}
@@ -282,6 +283,7 @@ export default function Page() {
               }}
               onIncreaseWorkers={aiSettings.increaseWorkers}
               onDecreaseWorkers={aiSettings.decreaseWorkers}
+              onPubcomModeChange={aiSettings.handlePubcomModeChange}
               onEnableSourceLinkChange={aiSettings.handleEnableSourceLinkChange}
               onEmbeddedAtLocalChange={(checked) => {
                 if (checked === "indeterminate") return;

--- a/client-admin/app/page.tsx
+++ b/client-admin/app/page.tsx
@@ -511,7 +511,7 @@ function ReportCard({
             </Box>
           )}
           <HStack position="relative" zIndex="20">
-            {report.status === "ready" && (report.isPubcom === true || report.isPubcom === undefined) && (
+            {report.status === "ready" && report.isPubcom && (
               <Popover.Root>
                 <Popover.Trigger asChild>
                   <Button
@@ -560,11 +560,6 @@ function ReportCard({
                                 window.URL.revokeObjectURL(url);
                               } catch (error) {
                                 console.error(error);
-                                toaster.create({
-                                  type: "error",
-                                  title: "CSVダウンロードエラー",
-                                  description: error instanceof Error ? error.message : "CSVファイルのダウンロードに失敗しました",
-                                });
                               }
                             }}
                           >
@@ -603,11 +598,6 @@ function ReportCard({
                                 window.URL.revokeObjectURL(url);
                               } catch (error) {
                                 console.error(error);
-                                toaster.create({
-                                  type: "error",
-                                  title: "CSVダウンロードエラー",
-                                  description: error instanceof Error ? error.message : "CSVファイルのダウンロードに失敗しました",
-                                });
                               }
                             }}
                           >

--- a/client-admin/type.d.ts
+++ b/client-admin/type.d.ts
@@ -19,7 +19,7 @@ export type Report = {
   status: string;
   title: string;
   description: string;
-  isPubcom?: boolean; // 既存レポートとの互換性のため残す（新規は常にtrue）
+  isPubcom: boolean;
   visibility: ReportVisibility;
   createdAt?: string; // 作成日時（ISO形式の文字列）
   tokenUsage?: number; // トークン使用量（合計）

--- a/server/src/schemas/admin_report.py
+++ b/server/src/schemas/admin_report.py
@@ -30,7 +30,7 @@ class ReportInput(SchemaBaseModel):
     workers: int  # LLM APIの並列実行数
     prompt: Prompt  # プロンプト
     comments: list[Comment]  # コメントのリスト
-    is_pubcom: Literal[True] = True  # CSV出力モード出力フラグ（常にCSV出力する）
+    is_pubcom: bool = False  # CSV出力モード出力フラグ
     inputType: Literal["file", "spreadsheet"] = "file"  # 入力タイプ
     is_embedded_at_local: bool = False  # エンベデッド処理をローカルで行うかどうか
     provider: str = "openai"  # LLMプロバイダー（openai, azure, openrouter, local）

--- a/server/src/schemas/report.py
+++ b/server/src/schemas/report.py
@@ -1,5 +1,4 @@
 from enum import Enum
-from typing import Literal
 
 from src.schemas.base import SchemaBaseModel
 
@@ -23,7 +22,7 @@ class Report(SchemaBaseModel):
     description: str
     status: ReportStatus
     visibility: ReportVisibility
-    is_pubcom: Literal[True] = True  # 常にCSV出力する（変更不可）
+    is_pubcom: bool = False
     created_at: str | None = None  # 作成日時
     token_usage: int | None = None  # トークン使用量（合計）
     token_usage_input: int | None = None  # 入力トークン使用量


### PR DESCRIPTION
Reverts digitaldemocracy2030/kouchou-ai#603

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 設定セクションに「CSV出力モード」のチェックボックスを追加し、ユーザーがCSV出力機能の有効・無効を切り替え可能になりました。

- **改善**
  - レポート作成時にCSV出力モードの設定を反映できるようになりました。
  - レポート一覧でCSVダウンロードボタンの表示条件を簡素化しました。

- **変更**
  - レポートのCSV出力モード設定の初期値が「無効」になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->