### PR TITLE
[client] meta タグやレポーター情報の初期値を変更する

### DIFF
--- a/client/app/page.tsx
+++ b/client/app/page.tsx
@@ -17,7 +17,7 @@ export async function generateMetadata(): Promise<Metadata> {
     const { getBasePath, getRelativeUrl } = await import("@/app/utils/image-src");
 
     const metadata: Metadata = {
-      title: `${meta.reporter} - 広聴AI(デジタル民主主義2030ブロードリスニング)`,
+      title: `${meta.reporter}のレポート一覧 - 広聴AI`,
       description: meta.message || "",
       openGraph: {
         images: [getRelativeUrl("/meta/ogp.png")],
@@ -35,7 +35,7 @@ export async function generateMetadata(): Promise<Metadata> {
   } catch (_e) {
     console.error("Failed to fetch metadata for generateMetadata:", _e);
     return {
-      title: "広聴AI(デジタル民主主義2030ブロードリスニング)",
+      title: "広聴AI",
     };
   }
 }

--- a/client/components/reporter/ReporterContent.tsx
+++ b/client/components/reporter/ReporterContent.tsx
@@ -68,7 +68,7 @@ export function ReporterContent({ meta, children }: { meta: Meta; children: Reac
         <Flex flexDirection="column" justifyContent="space-between" color="gray.600">
           <Text textStyle="body/sm">レポーター</Text>
           {/* metadataが未設定の場合は、レポーター名は非表示 */}
-          {!meta.isDefault && <Text textStyle="body/md/bold">{meta.reporter}</Text>}
+          {<Text textStyle="body/md/bold">{meta.reporter}</Text>}
         </Flex>
       </Flex>
       <MessageText isDefault={meta.isDefault} message={meta.message} />

--- a/server/public/meta/default/metadata.json
+++ b/server/public/meta/default/metadata.json
@@ -1,6 +1,6 @@
 {
-  "reporter": "テスト環境",
-  "message": "これは動作確認のためのテスト用のメタデータです。レポートの作成者に関する情報等を、public/meta/custom/metadata.jsonに記載することで、レポート上で情報を表示することができます。",
+  "reporter": "名前未設定ユーザー",
+  "message": "レポーター情報が未設定です。レポート作成者がメタデータをセットアップすることでレポーター情報が表示されます。",
   "webLink": "/",
   "privacyLink": "/",
   "termsLink": null,


### PR DESCRIPTION
# 変更の概要
- デフォルトの metadata の内容を検索エンジンで表示されて違和感のないものに変更
- カスタムの metadata がない場合は、レポーター名に「名前未設定ユーザー」と表示する

# スクリーンショット

## client トップページの meta タグ
![image](https://github.com/user-attachments/assets/96241178-5419-481d-8b4d-991758f09e08)

## レポーター表示
![image](https://github.com/user-attachments/assets/600844bf-3fa8-4242-bac2-d2483bc5b23d)


# 変更の背景
- reporter の初期値をテスト環境 -> 名称未設定ユーザーに変更
  - 実際に起きているのはメタデータが未設定で、環境の問題ではないため
- レポーター情報を表示するコンポーネントでも、metadata がない場合にユーザー名として「名前未設定ユーザー」と表示する
  - 上記の変更と合わせて client に表示される情報と meta タグ内の情報を揃える
- titile から「デジタル民主主義2030」の文言を削除
  - 複数のページで同じ内容が載ってることで、検索エンジンに忌避されるリスクがあるため
  - 現状でも client のレポート個別ページでは「デジタル民主主義2030」の文言はないので、そちらとも揃う

# 関連Issue
- fix: #590 

# 動作確認の結果
<!-- 実装者は動作確認の結果を記載してください（例: レポート作成を実行し、正常にレポートが作成されることを確認した） 複数の動作確認を行った場合は、それぞれの結果を記載してください -->

- metadata を未設定の状態で、client の meta タグが適切に表示され、レポーター情報に「名前未設定ユーザー」と表示されること
- metadata を設定した状態で、その情報をもとに meta タグが設定されて、レポーター情報にも表示されること

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

# マージ前のチェックリスト（レビュアーがマージ前に確認してください）
- [x] CIが全て通過している
- [ ] 単体テストが実装されているか
- [x] 今回実装した機能および影響を受けると思われる機能について、適切な動作確認が行われているかを確認する。


動作確認の項目については、実装者による動作確認のケースが適切かを確認してください。
必要に応じてレビュアー自身による動作確認も歓迎します（必須ではありません）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - デフォルトのレポーター名が「名前未設定ユーザー」に変更されました。
- **改善**
  - メタデータのタイトル表示がより分かりやすい形式になりました。
  - レポーター名が常に表示されるようになりました。
- **ドキュメント**
  - メタデータの説明文が、レポーター情報未設定時の案内に更新されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->