### PR TITLE
[client] レポートのタイトルと本文に行数制限を追加

### DIFF
--- a/client/app/page.tsx
+++ b/client/app/page.tsx
@@ -80,7 +80,7 @@ export default async function Page() {
                       <HStack>
                         <Box>
                           <Card.Title>
-                            <Text fontSize={"lg"} color={"#2577b1"} mb={1}>
+                            <Text fontSize={"lg"} color={"#2577b1"} mb={1} lineClamp="2">
                               {report.title}
                             </Text>
                           </Card.Title>
@@ -89,7 +89,7 @@ export default async function Page() {
                               作成日時: {new Date(report.createdAt).toLocaleString("ja-JP", { timeZone: "Asia/Tokyo" })}
                             </Text>
                           )}
-                          <Card.Description>{report.description || ""}</Card.Description>
+                          <Card.Description lineClamp={{ base: 3, md: 2 }}>{report.description || ""}</Card.Description>
                         </Box>
                       </HStack>
                     </Card.Body>


### PR DESCRIPTION
# 変更の概要
- client のレポート一覧画面で、レポートの一覧性を向上させるために、デバイスサイズに応じて適切な行数でレポートのタイトルと説明文を省略表示するようにしました

# スクリーンショット
## SP
タイトルは2行、説明文は3行以上になったら省略表示にします。

![localhost_3000_ (4)](https://github.com/user-attachments/assets/5bc619fc-18e1-4bf5-ab09-b3d0ac66bc82)

## タブレット以上
タイトル・説明文共に2行以上になったら省略表示にします。

![localhost_3000_ (3)](https://github.com/user-attachments/assets/fb46f912-8dae-42e5-8f01-5e7fa5d1b446)


# 変更の背景
- Chakra UI にテキストを特定の行数以上の場合に省略表示にする props があるので、そちらを利用して実装しました
  - https://chakra-ui.com/docs/components/text#line-clamp

# 関連Issue
- fix: #427

# 動作確認の結果
<!-- 実装者は動作確認の結果を記載してください（例: レポート作成を実行し、正常にレポートが作成されることを確認した） 複数の動作確認を行った場合は、それぞれの結果を記載してください -->

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

# マージ前のチェックリスト（レビュアーがマージ前に確認してください）
- [x] CIが全て通過している
- [ ] 単体テストが実装されているか
- [x] 今回実装した機能および影響を受けると思われる機能について、適切な動作確認が行われているかを確認する。


動作確認の項目については、実装者による動作確認のケースが適切かを確認してください。
必要に応じてレビュアー自身による動作確認も歓迎します（必須ではありません）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **スタイル**
  - レポートリストカードのタイトルと説明文に行数制限を追加し、テキストの表示が2～3行で切り取られるようになりました。これにより、レイアウトの一貫性が向上し、テキストのはみ出しが防止されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->