### PR TITLE
レポートのバックアップスクリプトを docker 環境で実行する

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -476,7 +476,13 @@ azure-update-deployment:
 	@echo ">>> レポートのバックアップを取得..."
 	$(eval API_DOMAIN=$(shell docker run --rm -v $(HOME)/.azure:/root/.azure mcr.microsoft.com/azure-cli /bin/bash -c "az containerapp show --name api --resource-group $(AZURE_RESOURCE_GROUP) --query properties.configuration.ingress.fqdn -o tsv 2>/dev/null | tail -n 1"))
 	@echo ">>> API_DOMAIN: $(API_DOMAIN)"
-	@cd $(shell pwd) && python3 scripts/fetch_reports.py --api-url https://$(API_DOMAIN)
+	@docker run --rm \
+		--env-file .env \
+		-v $(shell pwd):/workspace \
+		-w /workspace \
+		python:3.11-slim /bin/bash -c "\
+		pip install requests python-dotenv > /dev/null 2>&1 && \
+		python scripts/fetch_reports.py --api-url https://$(API_DOMAIN)"
 
 	@echo ">>> コンテナイメージのビルド..."
 	@$(MAKE) azure-build


### PR DESCRIPTION
# 変更の概要
- `make azure-update-deployment` 実行時に実行環境を整える必要がないように、docker 環境で実行するように修正しました

# 変更の背景
- #622 の作業時に、そのままではローカル環境を整える必要があることに気がつきました

# 動作確認の結果
<!-- 実装者は動作確認の結果を記載してください（例: レポート作成を実行し、正常にレポートが作成されることを確認した） 複数の動作確認を行った場合は、それぞれの結果を記載してください -->

修正後の Makefile で、`make azure-update-deployment` を実行した際に適切にレポートのバックアップスクリプトが動作することを確認しました。

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

# マージ前のチェックリスト（レビュアーがマージ前に確認してください）
- [ ] CIが全て通過している
- [ ] 単体テストが実装されているか
- [ ] 今回実装した機能および影響を受けると思われる機能について、適切な動作確認が行われているかを確認する。


動作確認の項目については、実装者による動作確認のケースが適切かを確認してください。
必要に応じてレビュアー自身による動作確認も歓迎します（必須ではありません）。