### PR TITLE
[api] 管理画面のレポート一覧のレスポンスにコメント数などを含める

### DIFF
--- a/client-admin/type.d.ts
+++ b/client-admin/type.d.ts
@@ -28,6 +28,11 @@ export type Report = {
   estimatedCost?: number; // 推定コスト（USD）
   provider?: string; // LLMプロバイダー
   model?: string; // LLMモデル
+  analysis: {
+    commentNum: number
+    argumentsNum: number
+    clusterNum: number
+  }
 };
 
 export type Result = {

--- a/client-admin/type.d.ts
+++ b/client-admin/type.d.ts
@@ -28,7 +28,7 @@ export type Report = {
   estimatedCost?: number; // 推定コスト（USD）
   provider?: string; // LLMプロバイダー
   model?: string; // LLMモデル
-  analysis: {
+  analysis?: {
     commentNum: number
     argumentsNum: number
     clusterNum: number

--- a/server/src/routers/admin_report.py
+++ b/server/src/routers/admin_report.py
@@ -1,5 +1,7 @@
+from collections import defaultdict
 import json
 import os
+from typing import Any, Dict
 
 import openai
 from fastapi import APIRouter, Depends, HTTPException, Query, Security
@@ -40,7 +42,30 @@ async def verify_admin_api_key(api_key: str = Security(api_key_header)):
 
 @router.get("/admin/reports")
 async def get_reports(api_key: str = Depends(verify_admin_api_key)) -> list[Report]:
-    return load_status_as_reports()
+    def add_analysis_data(report: Report):
+        if (report.status == ReportStatus.READY):
+            new_report_dict = report.__dict__.copy()
+            report_path = settings.REPORT_DIR / report.slug / "hierarchical_result.json"
+            with open(report_path) as f:
+                report_result = json.load(f)
+                new_report_dict["analysis"] = {
+                    "comment_num": report_result["comment_num"],
+                    "arguments_num": len(report_result["arguments"]),
+                    "cluster_num": get_cluster_num(report_result)
+                }
+            return new_report_dict
+        else:
+            return report
+
+    def get_cluster_num(result: dict) -> Dict[int, int]:
+        array = [c["level"] for c in result["clusters"]]
+        acc = defaultdict(int)
+        for num in array:
+            acc[num] += 1
+        return dict(acc)[2]
+
+    all_reports = load_status_as_reports()
+    return list(map(add_analysis_data, all_reports))
 
 
 @router.post("/admin/reports", status_code=202)

--- a/server/src/routers/admin_report.py
+++ b/server/src/routers/admin_report.py
@@ -41,8 +41,7 @@ async def verify_admin_api_key(api_key: str = Security(api_key_header)):
 
 @router.get("/admin/reports")
 async def get_reports(api_key: str = Depends(verify_admin_api_key)) -> list[Report]:
-    all_reports = load_status_as_reports()
-    return list(map(add_analysis_data, all_reports))
+    return list(map(add_analysis_data, load_status_as_reports()))
 
 
 @router.post("/admin/reports", status_code=202)

--- a/server/src/schemas/report.py
+++ b/server/src/schemas/report.py
@@ -15,6 +15,10 @@ class ReportVisibility(Enum):
     UNLISTED = "unlisted"
     PRIVATE = "private"
 
+class AnalysisData(SchemaBaseModel):
+    comment_num: int
+    arguments_num: int
+    cluster_num: int
 
 class Report(SchemaBaseModel):
     slug: str
@@ -30,6 +34,8 @@ class Report(SchemaBaseModel):
     estimated_cost: float | None = None  # 推定コスト（USD）
     provider: str | None = None  # LLMプロバイダー
     model: str | None = None  # LLMモデル
+    analysis: AnalysisData | None = None
+
 
     @property
     def is_publicly_visible(self) -> bool:

--- a/server/src/schemas/report.py
+++ b/server/src/schemas/report.py
@@ -15,10 +15,12 @@ class ReportVisibility(Enum):
     UNLISTED = "unlisted"
     PRIVATE = "private"
 
+
 class AnalysisData(SchemaBaseModel):
     comment_num: int
     arguments_num: int
     cluster_num: int
+
 
 class Report(SchemaBaseModel):
     slug: str
@@ -35,7 +37,6 @@ class Report(SchemaBaseModel):
     provider: str | None = None  # LLMプロバイダー
     model: str | None = None  # LLMモデル
     analysis: AnalysisData | None = None
-
 
     @property
     def is_publicly_visible(self) -> bool:

--- a/server/src/services/report_status.py
+++ b/server/src/services/report_status.py
@@ -1,14 +1,13 @@
 import json
 import logging
 import threading
-from collections import defaultdict
 from datetime import UTC, datetime
 
 import requests
 
 from src.config import settings
 from src.schemas.admin_report import ReportInput
-from src.schemas.report import Report, ReportStatus, ReportVisibility
+from src.schemas.report import AnalysisData, Report, ReportStatus, ReportVisibility
 from src.schemas.report_config import ReportConfigUpdate
 from src.services.llm_pricing import LLMPricing
 
@@ -236,25 +235,32 @@ def update_report_config(slug: str, updated_config: ReportConfigUpdate) -> dict:
     return _report_status[slug]
 
 
-def add_analysis_data(report: Report):
-    if report.status == ReportStatus.READY:
-        new_report_dict = report.__dict__.copy()
-        report_path = settings.REPORT_DIR / report.slug / "hierarchical_result.json"
-        with open(report_path) as f:
-            report_result = json.load(f)
-            new_report_dict["analysis"] = {
-                "comment_num": report_result["comment_num"],
-                "arguments_num": len(report_result["arguments"]),
-                "cluster_num": get_cluster_num(report_result),
-            }
-        return new_report_dict
-    else:
+def add_analysis_data(report: Report) -> Report:
+    if report.status != ReportStatus.READY:
         return report
 
+    report_path = settings.REPORT_DIR / report.slug / "hierarchical_result.json"
+    try:
+        with open(report_path) as f:
+            report_result = json.load(f)
 
-def get_cluster_num(result: dict) -> dict[int, int]:
-    array = [c["level"] for c in result["clusters"]]
-    acc = defaultdict(int)
-    for num in array:
-        acc[num] += 1
-    return dict(acc)[2]
+        analysis_data = AnalysisData(
+            comment_num=report_result.get("comment_num", 0),
+            arguments_num=len(report_result.get("arguments", [])),
+            cluster_num=get_cluster_num(report_result),
+        )
+
+        return report.model_copy(update={"analysis": analysis_data})
+
+    except FileNotFoundError:
+        logger.warning(f"[add_analysis_data] File not found: {report_path}")
+    except json.JSONDecodeError as e:
+        logger.error(f"[add_analysis_data] JSON decode error for {report_path}: {e}")
+    except Exception as e:
+        logger.exception(f"[add_analysis_data] Unexpected error for {report_path}: {e}")
+
+    return report
+
+
+def get_cluster_num(result: dict) -> int:
+    return sum(1 for c in result.get("clusters", []) if c.get("level") == 2)

--- a/server/src/services/report_status.py
+++ b/server/src/services/report_status.py
@@ -1,9 +1,8 @@
-from collections import defaultdict
 import json
 import logging
 import threading
+from collections import defaultdict
 from datetime import UTC, datetime
-from typing import Dict
 
 import requests
 
@@ -238,7 +237,7 @@ def update_report_config(slug: str, updated_config: ReportConfigUpdate) -> dict:
 
 
 def add_analysis_data(report: Report):
-    if (report.status == ReportStatus.READY):
+    if report.status == ReportStatus.READY:
         new_report_dict = report.__dict__.copy()
         report_path = settings.REPORT_DIR / report.slug / "hierarchical_result.json"
         with open(report_path) as f:
@@ -246,13 +245,14 @@ def add_analysis_data(report: Report):
             new_report_dict["analysis"] = {
                 "comment_num": report_result["comment_num"],
                 "arguments_num": len(report_result["arguments"]),
-                "cluster_num": get_cluster_num(report_result)
+                "cluster_num": get_cluster_num(report_result),
             }
         return new_report_dict
     else:
         return report
 
-def get_cluster_num(result: dict) -> Dict[int, int]:
+
+def get_cluster_num(result: dict) -> dict[int, int]:
     array = [c["level"] for c in result["clusters"]]
     acc = defaultdict(int)
     for num in array:

--- a/server/tests/services/test_report_status.py
+++ b/server/tests/services/test_report_status.py
@@ -1,9 +1,12 @@
+import json
 from copy import deepcopy
+from pathlib import Path
+from unittest.mock import mock_open, patch
 
 import pytest
 
-from src.schemas.report import ReportVisibility
-from src.services.report_status import convert_old_format_status
+from src.schemas.report import Report, ReportStatus, ReportVisibility
+from src.services.report_status import add_analysis_data, convert_old_format_status
 
 
 # FIXME: report_status.jsonのフォーマット変更に対応するための関数のテストコード。広聴AIをver3.0にした段階で削除する。
@@ -155,3 +158,126 @@ class TestReportStatus:
         assert "visibility" in result["new-slug"]
         assert result["new-slug"]["visibility"] == original_new_visibility
         assert "is_public" not in result["new-slug"]
+
+
+class TestAddAnalysisData:
+    """add_analysis_data関数のテスト"""
+
+    @pytest.fixture
+    def ready_report(self):
+        """READYステータスのレポート"""
+        return Report(
+            slug="test-report",
+            status=ReportStatus.READY,
+            title="テストレポート",
+            description="テスト説明",
+            is_pubcom=True,
+            visibility=ReportVisibility.PUBLIC,
+            created_at="2025-01-01T00:00:00+00:00",
+            token_usage=1000,
+            token_usage_input=500,
+            token_usage_output=500,
+            estimated_cost=0.01,
+            provider="openai",
+            model="gpt-4",
+        )
+
+    @pytest.fixture
+    def processing_report(self):
+        """PROCESSINGステータスのレポート"""
+        return Report(
+            slug="processing-report",
+            status=ReportStatus.PROCESSING,
+            title="処理中レポート",
+            description="処理中説明",
+            is_pubcom=True,
+            visibility=ReportVisibility.PRIVATE,
+            created_at="2025-01-01T00:00:00+00:00",
+            token_usage=0,
+            token_usage_input=0,
+            token_usage_output=0,
+            estimated_cost=0.0,
+            provider=None,
+            model=None,
+        )
+
+    @pytest.fixture
+    def mock_hierarchical_result(self):
+        """モックのhierarchical_result.json"""
+        return {
+            "comment_num": 150,
+            "arguments": [
+                {"id": 1, "text": "引数1"},
+                {"id": 2, "text": "引数2"},
+                {"id": 3, "text": "引数3"},
+            ],
+            "clusters": [
+                {"id": 1, "level": 1, "name": "クラスター1"},
+                {"id": 2, "level": 2, "name": "クラスター2"},
+                {"id": 3, "level": 2, "name": "クラスター3"},
+                {"id": 4, "level": 2, "name": "クラスター4"},
+            ],
+        }
+
+    @patch("src.services.report_status.settings")
+    def test_add_analysis_data_ready_report(self, mock_settings, ready_report, mock_hierarchical_result):
+        """READYステータスのレポートに分析データを追加するテスト"""
+        # モックの設定
+        mock_settings.REPORT_DIR = Path("/test/reports")
+
+        with patch("builtins.open", mock_open(read_data=json.dumps(mock_hierarchical_result))):
+            result = add_analysis_data(ready_report)
+
+        # 結果の検証
+        assert isinstance(result, dict)
+        assert result["slug"] == "test-report"
+        assert result["status"] == ReportStatus.READY
+        assert "analysis" in result
+
+        # 分析データの内容を検証
+        analysis = result["analysis"]
+        assert analysis["comment_num"] == 150
+        assert analysis["arguments_num"] == 3
+        assert analysis["cluster_num"] == 3  # level 2のクラスター数
+
+    def test_add_analysis_data_processing_report(self, processing_report):
+        """PROCESSINGステータスのレポートはそのまま返すテスト"""
+        result = add_analysis_data(processing_report)
+
+        # 結果の検証
+        assert result == processing_report
+        assert result.analysis is None
+
+    @patch("src.services.report_status.settings")
+    def test_add_analysis_data_file_not_found(self, mock_settings, ready_report):
+        """hierarchical_result.jsonが存在しない場合のテスト"""
+        mock_settings.REPORT_DIR = Path("/test/reports")
+
+        with patch("builtins.open", side_effect=FileNotFoundError("File not found")):
+            with pytest.raises(FileNotFoundError):
+                add_analysis_data(ready_report)
+
+    @patch("src.services.report_status.settings")
+    def test_add_analysis_data_invalid_json(self, mock_settings, ready_report):
+        """hierarchical_result.jsonが無効なJSONの場合のテスト"""
+        mock_settings.REPORT_DIR = Path("/test/reports")
+
+        with patch("builtins.open", mock_open(read_data="invalid json")):
+            with pytest.raises(json.JSONDecodeError):
+                add_analysis_data(ready_report)
+
+    @patch("src.services.report_status.settings")
+    def test_add_analysis_data_empty_clusters(self, mock_settings, ready_report):
+        """クラスターが空の場合のテスト"""
+        mock_settings.REPORT_DIR = Path("/test/reports")
+        empty_result = {"comment_num": 100, "arguments": [], "clusters": []}
+
+        with patch("builtins.open", mock_open(read_data=json.dumps(empty_result))):
+            with patch("src.services.report_status.get_cluster_num", return_value=0):
+                result = add_analysis_data(ready_report)
+
+        # 結果の検証
+        analysis = result["analysis"]
+        assert analysis["comment_num"] == 100
+        assert analysis["arguments_num"] == 0
+        assert analysis["cluster_num"] == 0


### PR DESCRIPTION
# 変更の概要
- 管理画面のレポート一覧のレスポンスに、コメント数・意見数・意見グループ数を含めるようにしました
- フロントエンドでは、以下のようなデータ構造で取得できます。

```js
{
    "slug": "9d282108-75f7-4575-8125-df714c7e9c28",
    "title": "誰もが等しく行政サービスを使えるよう、デジタル化と人への配慮の両立をめざした行政手続きの整備を求めます。",
    "description": "デジタル化の名のもとに、紙の申請や窓口対応が急激に減り、高齢者や障がいを持つ方にとって行政手続きが「わからない」「できない」ものになりつつあります。手続きがデジタルで簡素になることは歓迎ですが、それに置き去りになる人が増えてはいけません。マイナポータルやLINEでの申請支援のような工夫を全国の自治体で共通化し、誰もが等しく使える行政サービスに整備すべきだと考えます。",
    "status": "ready",
    "visibility": "public",
    "isPubcom": false,
    "createdAt": null,
    "tokenUsage": 0,
    "tokenUsageInput": 0,
    "tokenUsageOutput": 0,
    "estimatedCost": null,
    "provider": null,
    "model": "gpt-4o-mini",
    "analysis": {
        "commentNum": 50,
        "argumentsNum": 50,
        "clusterNum": 50
    }
}
```

# スクリーンショット
- なし

# 変更の背景
- 管理画面のリデザインで、各レポートごとに以下の情報を表示したいため

# 関連Issue
- close: https://github.com/digitaldemocracy2030/kouchou-ai/issues/635

# 動作確認の結果
<!-- 実装者は動作確認の結果を記載してください（例: レポート作成を実行し、正常にレポートが作成されることを確認した） 複数の動作確認を行った場合は、それぞれの結果を記載してください -->

- 管理画面のレポート一覧で、フロントエンドからコメント数・意見数・意見グループ数が取得できること

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

# マージ前のチェックリスト（レビュアーがマージ前に確認してください）
- [ ] CIが全て通過している
- [ ] 単体テストが実装されているか
- [ ] 今回実装した機能および影響を受けると思われる機能について、適切な動作確認が行われているかを確認する。


動作確認の項目については、実装者による動作確認のケースが適切かを確認してください。
必要に応じてレビュアー自身による動作確認も歓迎します（必須ではありません）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * レポート一覧に「分析」データ（コメント数、議論数、クラスタ数）が表示されるようになりました。

* **バグ修正**
  * レポートの分析データ取得時のエラーが適切に処理されるようになりました。

* **テスト**
  * レポート分析データ追加機能に関するテストが追加されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->