### PR TITLE
main ブランチにマージされたコードを Azure に deploy する

### DIFF
--- a/.github/workflows/azure-deploy.yml
+++ b/.github/workflows/azure-deploy.yml
@@ -1,0 +1,186 @@
+name: Azure Deployment
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+env:
+  AZURE_ACR_NAME: ${{ vars.AZURE_ACR_NAME }}
+  AZURE_RESOURCE_GROUP: ${{ vars.AZURE_RESOURCE_GROUP }}
+  AZURE_LOCATION: ${{ vars.AZURE_LOCATION }}
+  AZURE_CONTAINER_ENV: ${{ vars.AZURE_CONTAINER_ENV }}
+  AZURE_BLOB_STORAGE_ACCOUNT_NAME: ${{ vars.AZURE_BLOB_STORAGE_ACCOUNT_NAME }}
+  AZURE_BLOB_STORAGE_CONTAINER_NAME: ${{ vars.AZURE_BLOB_STORAGE_CONTAINER_NAME }}
+  ENVIRONMENT: ${{ vars.ENVIRONMENT }}
+  BASIC_AUTH_USERNAME: ${{ vars.BASIC_AUTH_USERNAME }}
+  PUBLIC_API_KEY: ${{ secrets.PUBLIC_API_KEY }}
+  ADMIN_API_KEY: ${{ secrets.ADMIN_API_KEY }}
+  BASIC_AUTH_PASSWORD: ${{ secrets.BASIC_AUTH_PASSWORD }}
+  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+  REVALIDATE_SECRET: ${{ secrets.REVALIDATE_SECRET }}
+
+jobs:
+  deploy:
+    if: github.repository == 'digitaldemocracy2030/kouchou-ai'
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Azure CLI ログイン
+        uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Docker ログイン (ACR)
+        run: |
+          az acr login --name ${{ env.AZURE_ACR_NAME }}
+
+      - name: Python環境のセットアップ
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Python依存関係のインストール
+        run: |
+          python -m pip install --upgrade pip
+          pip install requests python-dotenv
+
+      - name: 環境変数ファイルの準備
+        run: |
+          # .env.azureファイルの作成（Makefileで使用）
+          cat > .env.azure << EOF
+          AZURE_RESOURCE_GROUP=${{ env.AZURE_RESOURCE_GROUP }}
+          AZURE_LOCATION=${{ env.AZURE_LOCATION }}
+          AZURE_ACR_NAME=${{ env.AZURE_ACR_NAME }}
+          AZURE_CONTAINER_ENV=${{ env.AZURE_CONTAINER_ENV }}
+          AZURE_BLOB_STORAGE_ACCOUNT_NAME=${{ env.AZURE_BLOB_STORAGE_ACCOUNT_NAME }}
+          AZURE_BLOB_STORAGE_CONTAINER_NAME=${{ env.AZURE_BLOB_STORAGE_CONTAINER_NAME }}
+          EOF
+
+      - name: ドメイン情報の準備
+        run: |
+          # ドメイン情報を直接環境変数に設定
+          echo "API_DOMAIN=$(az containerapp show --name api \
+            --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
+            --query properties.configuration.ingress.fqdn -o tsv)" >> $GITHUB_ENV
+          echo "CLIENT_DOMAIN=$(az containerapp show --name client \
+            --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
+            --query properties.configuration.ingress.fqdn -o tsv)" >> $GITHUB_ENV
+          echo "CLIENT_ADMIN_DOMAIN=$(az containerapp show --name client-admin \
+            --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
+            --query properties.configuration.ingress.fqdn -o tsv)" >> $GITHUB_ENV
+          echo "CLIENT_STATIC_BUILD_DOMAIN=$(az containerapp show --name client-static-build \
+            --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
+            --query properties.configuration.ingress.fqdn -o tsv)" >> $GITHUB_ENV
+
+      - name: Azure環境のデプロイ
+        run: |
+          # レポートのバックアップを取得
+          if [ -n "$API_DOMAIN" ]; then
+            echo "レポートのバックアップを取得中..."
+            python3 scripts/fetch_reports.py --api-url https://$API_DOMAIN
+          else
+            echo "❌ レポートのバックアップが取得できませんでした"
+            exit 1
+          fi
+
+          # 全イメージを並列ビルド
+          docker build --platform linux/amd64 \
+            -t ${AZURE_ACR_NAME}.azurecr.io/api:latest \
+            ./server &
+
+          docker build --platform linux/amd64 \
+            --build-arg NEXT_PUBLIC_API_BASEPATH="https://${API_DOMAIN}" \
+            --build-arg NEXT_PUBLIC_PUBLIC_API_KEY="${PUBLIC_API_KEY}" \
+            --build-arg API_BASEPATH="https://${API_DOMAIN}" \
+            -t ${AZURE_ACR_NAME}.azurecr.io/client:latest \
+            ./client &
+
+          docker build --platform linux/amd64 \
+            --build-arg NEXT_PUBLIC_CLIENT_BASEPATH="https://${CLIENT_DOMAIN}" \
+            --build-arg NEXT_PUBLIC_ADMIN_API_KEY="${ADMIN_API_KEY}" \
+            --build-arg NEXT_PUBLIC_API_BASEPATH="https://${API_DOMAIN}" \
+            --build-arg CLIENT_STATIC_BUILD_BASEPATH="https://${CLIENT_STATIC_BUILD_DOMAIN}" \
+            --build-arg BASIC_AUTH_USERNAME="${BASIC_AUTH_USERNAME}" \
+            --build-arg BASIC_AUTH_PASSWORD="${BASIC_AUTH_PASSWORD}" \
+            --build-arg API_BASEPATH="https://${API_DOMAIN}" \
+            -t ${AZURE_ACR_NAME}.azurecr.io/client-admin:latest \
+            ./client-admin &
+
+          docker build --platform linux/amd64 \
+            --build-arg NEXT_PUBLIC_API_BASEPATH="https://${API_DOMAIN}" \
+            --build-arg NEXT_PUBLIC_PUBLIC_API_KEY="${PUBLIC_API_KEY}" \
+            --build-arg API_BASEPATH="https://${API_DOMAIN}" \
+            -f ./client-static-build/Dockerfile \
+            -t ${AZURE_ACR_NAME}.azurecr.io/client-static-build:latest \
+            . &
+
+          # 全ビルドの完了を待機
+          wait
+
+          # イメージを並列プッシュ
+          docker push ${AZURE_ACR_NAME}.azurecr.io/api:latest &
+          docker push ${AZURE_ACR_NAME}.azurecr.io/client:latest &
+          docker push ${AZURE_ACR_NAME}.azurecr.io/client-admin:latest &
+          docker push ${AZURE_ACR_NAME}.azurecr.io/client-static-build:latest &
+
+          # 全プッシュの完了を待機
+          wait
+
+          # ヘルスプローブとポリシーの適用
+          make azure-apply-policies || echo "ポリシー適用をスキップ"
+
+      - name: コンテナ更新
+        run: |
+          # 全コンテナのイメージを更新
+          az containerapp update --name api --resource-group ${AZURE_RESOURCE_GROUP} \
+            --image ${AZURE_ACR_NAME}.azurecr.io/api:latest \
+            --cpu 1.0 --memory 2.0Gi &
+          az containerapp update --name client --resource-group ${AZURE_RESOURCE_GROUP} \
+            --image ${AZURE_ACR_NAME}.azurecr.io/client:latest &
+          az containerapp update --name client-admin --resource-group ${AZURE_RESOURCE_GROUP} \
+            --image ${AZURE_ACR_NAME}.azurecr.io/client-admin:latest &
+          az containerapp update --name client-static-build --resource-group ${AZURE_RESOURCE_GROUP} \
+            --image ${AZURE_ACR_NAME}.azurecr.io/client-static-build:latest &
+          wait
+
+          # APIコンテナの環境変数設定
+          az containerapp update --name api --resource-group ${AZURE_RESOURCE_GROUP} \
+            --set-env-vars \
+              "OPENAI_API_KEY=${OPENAI_API_KEY}" \
+              "PUBLIC_API_KEY=${PUBLIC_API_KEY}" \
+              "ADMIN_API_KEY=${ADMIN_API_KEY}" \
+              "LOG_LEVEL=info" \
+              "AZURE_BLOB_STORAGE_ACCOUNT_NAME=${AZURE_BLOB_STORAGE_ACCOUNT_NAME}" \
+              "AZURE_BLOB_STORAGE_CONTAINER_NAME=${AZURE_BLOB_STORAGE_CONTAINER_NAME}" \
+              "STORAGE_TYPE=azure_blob" \
+              "REVALIDATE_URL=https://${CLIENT_DOMAIN}/api/revalidate" \
+              "REVALIDATE_SECRET=${REVALIDATE_SECRET}" \
+              "ENVIRONMENT=${ENVIRONMENT}"
+
+      - name: デプロイ確認
+        run: |
+          if [ -z "$API_DOMAIN" ]; then
+            echo "❌ APIドメインが取得できませんでした"
+            exit 1
+          fi
+          
+          # リトライ付きヘルスチェック
+          RETRY_COUNT=6
+          RETRY_INTERVAL=20
+          
+          for i in $(seq 1 $RETRY_COUNT); do
+            echo "ヘルスチェック試行 $i/$RETRY_COUNT..."
+            if curl -f "https://$API_DOMAIN/" --max-time 10 > /dev/null 2>&1; then
+              echo "✅ デプロイ成功: https://$API_DOMAIN"
+              exit 0
+            fi
+            [ $i -lt $RETRY_COUNT ] && sleep $RETRY_INTERVAL
+          done
+          
+          echo "❌ ヘルスチェック失敗"
+          exit 1


### PR DESCRIPTION
# 変更の概要
- digitaldemocracy2030/kouchou-ai の main ブランチにマージされると、自動的に別途用意した DD2030 が持つ azure 環境に最新のコードが deploy されるようにする

# 変更の背景
以下のような状況から DD2030 で Azure に広聴AIの環境を構築中だが、この環境の更新は現状は手動でやる必要がある
- 動作確認する環境が、開発者の手元の環境のみのため開発者以外が動作確認するすべがない
- ユーザーが広聴AIを利用するには環境構築をする必要があり、利用までに技術的なハードルがあるためデモ環境を用意したい

# 関連Issue
#622 

# 動作確認の結果
<!-- 実装者は動作確認の結果を記載してください（例: レポート作成を実行し、正常にレポートが作成されることを確認した） 複数の動作確認を行った場合は、それぞれの結果を記載してください -->

deploy 処理部分は、フォークしたリポジトリから deploy できることを確認しました。
https://github.com/shingo-ohki/kouchou-ai/actions/runs/16157340778

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

# マージ前のチェックリスト（レビュアーがマージ前に確認してください）
- [ ] CIが全て通過している
- [ ] 単体テストが実装されているか
- [ ] 今回実装した機能および影響を受けると思われる機能について、適切な動作確認が行われているかを確認する。


動作確認の項目については、実装者による動作確認のケースが適切かを確認してください。
必要に応じてレビュアー自身による動作確認も歓迎します（必須ではありません）。