### PR TITLE
[client-admin] レポートの公開状態の総数を表示する UI を追加

### DIFF
--- a/client-admin/app/_components/PageContent.tsx
+++ b/client-admin/app/_components/PageContent.tsx
@@ -1,6 +1,7 @@
+import { Button } from "@/components/ui/button";
 import type { Report } from "@/type";
-import { Button, Flex, HStack, Heading, Icon, Link, Text, VStack } from "@chakra-ui/react";
-import { Eye, EyeClosedIcon, LockKeyhole } from "lucide-react";
+import { Box, Flex, HStack, Heading, Icon, Text, VStack } from "@chakra-ui/react";
+import { Eye, EyeClosedIcon, LockKeyhole, Plus } from "lucide-react";
 import { BuildDownloadButton } from "./BuildDownloadButton/BuildDownloadButton";
 import { Empty } from "./Empty";
 import { ReportCardList } from "./ReportCardList";
@@ -12,34 +13,44 @@ type Props = {
 export function PageContent({ reports }: Props) {
   return (
     <>
-      <Flex justifyContent="space-between">
-        <Heading textStyle="heading/xl">レポート管理</Heading>
-        <Flex gap="3">
-          <VStack gap="2" w="88px" h="80px" bg="white" justifyContent="center">
-            <Icon color="font.public">
-              <Eye />
-            </Icon>
-            <Text textStyle="body/lg/bold" lineHeight="1.38">
-              0
-            </Text>
-          </VStack>
-          <VStack gap="2" w="88px" h="80px" bg="white" justifyContent="center">
-            <Icon color="font.limitedPublic">
-              <LockKeyhole />
-            </Icon>
-            <Text textStyle="body/lg/bold" lineHeight="1.38">
-              0
-            </Text>
-          </VStack>
-          <VStack gap="2" w="88px" h="80px" bg="white" justifyContent="center">
-            <Icon color="font.error">
-              <EyeClosedIcon />
-            </Icon>
-            <Text textStyle="body/lg/bold" lineHeight="1.38">
-              0
-            </Text>
-          </VStack>
+      <Box mb="12">
+        <Flex justifyContent="space-between">
+          <Heading textStyle="heading/xl">レポート管理</Heading>
+          <Flex gap="3">
+            <VStack gap="2" w="88px" h="80px" bg="white" justifyContent="center">
+              <Icon color="font.public">
+                <Eye />
+              </Icon>
+              <Text textStyle="body/lg/bold" lineHeight="1.38">
+                0
+              </Text>
+            </VStack>
+            <VStack gap="2" w="88px" h="80px" bg="white" justifyContent="center">
+              <Icon color="font.limitedPublic">
+                <LockKeyhole />
+              </Icon>
+              <Text textStyle="body/lg/bold" lineHeight="1.38">
+                0
+              </Text>
+            </VStack>
+            <VStack gap="2" w="88px" h="80px" bg="white" justifyContent="center">
+              <Icon color="font.error">
+                <EyeClosedIcon />
+              </Icon>
+              <Text textStyle="body/lg/bold" lineHeight="1.38">
+                0
+              </Text>
+            </VStack>
+          </Flex>
         </Flex>
+      </Box>
+      <Flex justifyContent="flex-end" mb="4">
+        <Button size="md" asChild>
+          <a href="/create">
+            <Plus />
+            新規作成
+          </a>
+        </Button>
       </Flex>
       {reports.length === 0 ? (
         <Empty />
@@ -47,9 +58,6 @@ export function PageContent({ reports }: Props) {
         <>
           <ReportCardList reports={reports} />
           <HStack justify="center" mt={10}>
-            <Link href="/create">
-              <Button size="xl">新しいレポートを作成する</Button>
-            </Link>
             <BuildDownloadButton />
           </HStack>
         </>

--- a/client-admin/app/_components/PageContent.tsx
+++ b/client-admin/app/_components/PageContent.tsx
@@ -4,7 +4,8 @@ import { Button } from "@/components/ui/button";
 import type { Report } from "@/type";
 import { Box, Flex, HStack, Heading, Icon, Text, VStack } from "@chakra-ui/react";
 import { Eye, EyeClosedIcon, LockKeyhole, Plus } from "lucide-react";
-import { useState } from "react";
+import Link from "next/link";
+import { useMemo, useState } from "react";
 import { BuildDownloadButton } from "./BuildDownloadButton/BuildDownloadButton";
 import { Empty } from "./Empty";
 import { ReportCardList } from "./ReportCardList";
@@ -16,9 +17,14 @@ type Props = {
 export function PageContent({ reports: _reports }: Props) {
   const [reports, setReports] = useState<Report[]>(_reports);
 
-  const publicCount = reports.filter((report) => report.visibility === "public").length;
-  const unlistedCount = reports.filter((report) => report.visibility === "unlisted").length;
-  const privateCount = reports.filter((report) => report.visibility === "private").length;
+  const counts = useMemo(
+    () => ({
+      public: reports.filter((report) => report.visibility === "public").length,
+      unlisted: reports.filter((report) => report.visibility === "unlisted").length,
+      private: reports.filter((report) => report.visibility === "private").length,
+    }),
+    [reports],
+  );
 
   return (
     <>
@@ -31,7 +37,7 @@ export function PageContent({ reports: _reports }: Props) {
                 <Eye />
               </Icon>
               <Text textStyle="body/lg/bold" lineHeight="1.38">
-                {publicCount}
+                {counts.public}
               </Text>
             </VStack>
             <VStack gap="2" w="88px" h="80px" bg="white" justifyContent="center">
@@ -39,7 +45,7 @@ export function PageContent({ reports: _reports }: Props) {
                 <LockKeyhole />
               </Icon>
               <Text textStyle="body/lg/bold" lineHeight="1.38">
-                {unlistedCount}
+                {counts.unlisted}
               </Text>
             </VStack>
             <VStack gap="2" w="88px" h="80px" bg="white" justifyContent="center">
@@ -47,7 +53,7 @@ export function PageContent({ reports: _reports }: Props) {
                 <EyeClosedIcon />
               </Icon>
               <Text textStyle="body/lg/bold" lineHeight="1.38">
-                {privateCount}
+                {counts.private}
               </Text>
             </VStack>
           </Flex>
@@ -55,10 +61,10 @@ export function PageContent({ reports: _reports }: Props) {
       </Box>
       <Flex justifyContent="flex-end" mb="4">
         <Button size="md" asChild>
-          <a href="/create">
+          <Link href="/create">
             <Plus />
             新規作成
-          </a>
+          </Link>
         </Button>
       </Flex>
       {reports.length === 0 ? (

--- a/client-admin/app/_components/PageContent.tsx
+++ b/client-admin/app/_components/PageContent.tsx
@@ -1,0 +1,32 @@
+import type { Report } from "@/type";
+import { Button, HStack, Heading, Link } from "@chakra-ui/react";
+import { BuildDownloadButton } from "./BuildDownloadButton/BuildDownloadButton";
+import { Empty } from "./Empty";
+import { ReportCardList } from "./ReportCardList";
+
+type Props = {
+  reports: Report[];
+};
+
+export function PageContent({ reports }: Props) {
+  return (
+    <>
+      <Heading textAlign="left" fontSize="xl" mb={8}>
+        レポート一覧
+      </Heading>
+      {reports.length === 0 ? (
+        <Empty />
+      ) : (
+        <>
+          <ReportCardList reports={reports} />
+          <HStack justify="center" mt={10}>
+            <Link href="/create">
+              <Button size="xl">新しいレポートを作成する</Button>
+            </Link>
+            <BuildDownloadButton />
+          </HStack>
+        </>
+      )}
+    </>
+  );
+}

--- a/client-admin/app/_components/PageContent.tsx
+++ b/client-admin/app/_components/PageContent.tsx
@@ -11,8 +11,8 @@ type Props = {
 export function PageContent({ reports }: Props) {
   return (
     <>
-      <Heading textAlign="left" fontSize="xl" mb={8}>
-        レポート一覧
+      <Heading textStyle="heading/xl">
+        レポート管理
       </Heading>
       {reports.length === 0 ? (
         <Empty />

--- a/client-admin/app/_components/PageContent.tsx
+++ b/client-admin/app/_components/PageContent.tsx
@@ -1,5 +1,6 @@
 import type { Report } from "@/type";
-import { Button, HStack, Heading, Link } from "@chakra-ui/react";
+import { Button, Flex, HStack, Heading, Icon, Link, Text, VStack } from "@chakra-ui/react";
+import { Eye, EyeClosedIcon, LockKeyhole } from "lucide-react";
 import { BuildDownloadButton } from "./BuildDownloadButton/BuildDownloadButton";
 import { Empty } from "./Empty";
 import { ReportCardList } from "./ReportCardList";
@@ -11,9 +12,35 @@ type Props = {
 export function PageContent({ reports }: Props) {
   return (
     <>
-      <Heading textStyle="heading/xl">
-        レポート管理
-      </Heading>
+      <Flex justifyContent="space-between">
+        <Heading textStyle="heading/xl">レポート管理</Heading>
+        <Flex gap="3">
+          <VStack gap="2" w="88px" h="80px" bg="white" justifyContent="center">
+            <Icon color="font.public">
+              <Eye />
+            </Icon>
+            <Text textStyle="body/lg/bold" lineHeight="1.38">
+              0
+            </Text>
+          </VStack>
+          <VStack gap="2" w="88px" h="80px" bg="white" justifyContent="center">
+            <Icon color="font.limitedPublic">
+              <LockKeyhole />
+            </Icon>
+            <Text textStyle="body/lg/bold" lineHeight="1.38">
+              0
+            </Text>
+          </VStack>
+          <VStack gap="2" w="88px" h="80px" bg="white" justifyContent="center">
+            <Icon color="font.error">
+              <EyeClosedIcon />
+            </Icon>
+            <Text textStyle="body/lg/bold" lineHeight="1.38">
+              0
+            </Text>
+          </VStack>
+        </Flex>
+      </Flex>
       {reports.length === 0 ? (
         <Empty />
       ) : (

--- a/client-admin/app/_components/PageContent.tsx
+++ b/client-admin/app/_components/PageContent.tsx
@@ -1,7 +1,10 @@
+"use client";
+
 import { Button } from "@/components/ui/button";
 import type { Report } from "@/type";
 import { Box, Flex, HStack, Heading, Icon, Text, VStack } from "@chakra-ui/react";
 import { Eye, EyeClosedIcon, LockKeyhole, Plus } from "lucide-react";
+import { useState } from "react";
 import { BuildDownloadButton } from "./BuildDownloadButton/BuildDownloadButton";
 import { Empty } from "./Empty";
 import { ReportCardList } from "./ReportCardList";
@@ -10,7 +13,13 @@ type Props = {
   reports: Report[];
 };
 
-export function PageContent({ reports }: Props) {
+export function PageContent({ reports: _reports }: Props) {
+  const [reports, setReports] = useState<Report[]>(_reports);
+
+  const publicCount = reports.filter((report) => report.visibility === "public").length;
+  const unlistedCount = reports.filter((report) => report.visibility === "unlisted").length;
+  const privateCount = reports.filter((report) => report.visibility === "private").length;
+
   return (
     <>
       <Box mb="12">
@@ -22,7 +31,7 @@ export function PageContent({ reports }: Props) {
                 <Eye />
               </Icon>
               <Text textStyle="body/lg/bold" lineHeight="1.38">
-                0
+                {publicCount}
               </Text>
             </VStack>
             <VStack gap="2" w="88px" h="80px" bg="white" justifyContent="center">
@@ -30,7 +39,7 @@ export function PageContent({ reports }: Props) {
                 <LockKeyhole />
               </Icon>
               <Text textStyle="body/lg/bold" lineHeight="1.38">
-                0
+                {unlistedCount}
               </Text>
             </VStack>
             <VStack gap="2" w="88px" h="80px" bg="white" justifyContent="center">
@@ -38,7 +47,7 @@ export function PageContent({ reports }: Props) {
                 <EyeClosedIcon />
               </Icon>
               <Text textStyle="body/lg/bold" lineHeight="1.38">
-                0
+                {privateCount}
               </Text>
             </VStack>
           </Flex>
@@ -56,7 +65,7 @@ export function PageContent({ reports }: Props) {
         <Empty />
       ) : (
         <>
-          <ReportCardList reports={reports} />
+          <ReportCardList reports={reports} setReports={setReports} />
           <HStack justify="center" mt={10}>
             <BuildDownloadButton />
           </HStack>

--- a/client-admin/app/_components/ReportCardList.tsx
+++ b/client-admin/app/_components/ReportCardList.tsx
@@ -1,17 +1,13 @@
-"use client";
-
 import type { Report } from "@/type";
 import { Grid, GridItem } from "@chakra-ui/react";
-import { useState } from "react";
 import { ReportCard } from "./ReportCard/ReportCard";
 
 type Props = {
   reports: Report[];
+  setReports: React.Dispatch<React.SetStateAction<Report[]>>;
 };
 
-export function ReportCardList({ reports: _reports }: Props) {
-  const [reports, setReports] = useState<Report[]>(_reports);
-
+export function ReportCardList({ reports, setReports }: Props) {
   return (
     <Grid gridTemplateColumns="170px minmax(300px, 1fr) 52px repeat(3, 83px) repeat(3, min-content)" rowGap="2">
       <Grid gridTemplateColumns="subgrid" gridColumn="span 9" textStyle="body/sm">

--- a/client-admin/app/page.tsx
+++ b/client-admin/app/page.tsx
@@ -1,10 +1,7 @@
 import { Header } from "@/components/Header";
 import type { Report } from "@/type";
-import { Box, Button, HStack, Heading } from "@chakra-ui/react";
-import Link from "next/link";
-import { BuildDownloadButton } from "./_components/BuildDownloadButton/BuildDownloadButton";
-import { Empty } from "./_components/Empty";
-import { ReportCardList } from "./_components/ReportCardList";
+import { Box, Heading } from "@chakra-ui/react";
+import { PageContent } from "./_components/PageContent";
 import { getApiBaseUrl } from "./utils/api";
 
 export default async function Page() {
@@ -37,22 +34,7 @@ export default async function Page() {
       <Box className="container" bgColor="bg.secondary">
         <Header />
         <Box mx="auto" maxW="1024px" boxSizing="content-box" px="6" py="12">
-          <Heading textAlign="left" fontSize="xl" mb={8}>
-            レポート一覧
-          </Heading>
-          {reports.length === 0 ? (
-            <Empty />
-          ) : (
-            <>
-              <ReportCardList reports={reports} />
-              <HStack justify="center" mt={10}>
-                <Link href="/create">
-                  <Button size="xl">新しいレポートを作成する</Button>
-                </Link>
-                <BuildDownloadButton />
-              </HStack>
-            </>
-          )}
+          <PageContent reports={reports} />
         </Box>
       </Box>
     );


### PR DESCRIPTION
# 変更の概要
- 管理画面のレポート一覧に公開状態の総数を表示する UI を追加しました
- レポート新規作成画面へのボタンを、テーブルの上部に移動しました

# スクリーンショット
<img width="1124" height="1050" alt="image" src="https://github.com/user-attachments/assets/a61bc36f-af01-4af3-968c-ab47be47817c" />

https://github.com/user-attachments/assets/0782ecac-aca1-4f0c-a3de-3d700a4c34aa

# 変更の背景
- 管理画面の UI を使いやすくしたい

# 関連Issue
- fix: https://github.com/digitaldemocracy2030/kouchou-ai/issues/644

# 動作確認の結果
<!-- 実装者は動作確認の結果を記載してください（例: レポート作成を実行し、正常にレポートが作成されることを確認した） 複数の動作確認を行った場合は、それぞれの結果を記載してください -->

- 管理画面のレポートの公開状態を変更すると、その総数も更新されること

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

# マージ前のチェックリスト（レビュアーがマージ前に確認してください）
- [ ] CIが全て通過している
- [ ] 単体テストが実装されているか
- [ ] 今回実装した機能および影響を受けると思われる機能について、適切な動作確認が行われているかを確認する。


動作確認の項目については、実装者による動作確認のケースが適切かを確認してください。
必要に応じてレビュアー自身による動作確認も歓迎します（必須ではありません）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * レポート一覧を管理・表示する新しい「PageContent」コンポーネントを追加しました。
  * レポートの公開範囲ごとの件数をアイコン付きで表示します。
  * 「新規作成」ボタンやダウンロードボタンを配置しました。

* **リファクタリング**
  * レポート一覧の表示・管理ロジックを「PageContent」コンポーネントへ集約しました。
  * レポートリストの状態管理を親コンポーネントに移譲しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->