### PR TITLE
[client-admin] format, type エラーを修正する

### DIFF
--- a/client-admin/app/_components/ReportCard/ClusterEditDialog/ClusterEditDialog.test.tsx
+++ b/client-admin/app/_components/ReportCard/ClusterEditDialog/ClusterEditDialog.test.tsx
@@ -22,7 +22,7 @@ process.env.NEXT_PUBLIC_ADMIN_API_KEY = "test-api-key";
 
 const mockReport: Report = {
   slug: "test-report",
-  status: "completed",
+  status: "processing",
   title: "Test Report",
   description: "Test Description",
   isPubcom: false,

--- a/client-admin/app/_components/ReportCard/ProgressSteps/useReportProgressPolling.ts
+++ b/client-admin/app/_components/ReportCard/ProgressSteps/useReportProgressPolling.ts
@@ -1,7 +1,7 @@
-import type { stepKeys } from './ProgressSteps';
 import { useEffect, useState } from "react";
+import type { stepKeys } from "./ProgressSteps";
 
-type Progress = typeof stepKeys[number] | "loading" | "completed";
+type Progress = (typeof stepKeys)[number] | "loading" | "completed";
 
 export function useReportProgressPoll(slug: string) {
   const [progress, setProgress] = useState<Progress>("loading");
@@ -45,7 +45,6 @@ export function useReportProgressPoll(slug: string) {
             setIsPolling(false);
             return;
           }
-
 
           if (data.current_step === "completed") {
             setIsPolling(false);

--- a/client-admin/app/_components/ReportCard/ReportEditDialog/ReportEditDialog.test.tsx
+++ b/client-admin/app/_components/ReportCard/ReportEditDialog/ReportEditDialog.test.tsx
@@ -1,8 +1,8 @@
+import { Provider } from "@/components/ui/provider";
 import { toaster } from "@/components/ui/toaster";
 import type { Report } from "@/type";
 import { ReportVisibility } from "@/type";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
-import { Provider } from "@/components/ui/provider";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { ReportEditDialog } from "./ReportEditDialog";
 
 // Mock toaster
@@ -79,9 +79,7 @@ describe("ReportEditDialog", () => {
     });
 
     it("ダイアログが閉じている時は表示されない", () => {
-      renderWithProvider(
-        <ReportEditDialog {...defaultProps} isEditDialogOpen={false} />
-      );
+      renderWithProvider(<ReportEditDialog {...defaultProps} isEditDialogOpen={false} />);
 
       expect(screen.queryByText("レポートを編集")).not.toBeInTheDocument();
     });
@@ -108,9 +106,7 @@ describe("ReportEditDialog", () => {
 
     it("キャンセルボタンを押すとダイアログが閉じる", () => {
       const mockSetIsEditDialogOpen = jest.fn();
-      renderWithProvider(
-        <ReportEditDialog {...defaultProps} setIsEditDialogOpen={mockSetIsEditDialogOpen} />
-      );
+      renderWithProvider(<ReportEditDialog {...defaultProps} setIsEditDialogOpen={mockSetIsEditDialogOpen} />);
 
       const cancelButton = screen.getByText("キャンセル");
       fireEvent.click(cancelButton);
@@ -133,7 +129,7 @@ describe("ReportEditDialog", () => {
           {...defaultProps}
           setReports={mockSetReports}
           setIsEditDialogOpen={mockSetIsEditDialogOpen}
-        />
+        />,
       );
 
       // タイトルと説明を変更
@@ -147,20 +143,17 @@ describe("ReportEditDialog", () => {
       fireEvent.click(saveButton);
 
       await waitFor(() => {
-        expect(fetch).toHaveBeenCalledWith(
-          "http://localhost:8000/admin/reports/test-report/config",
-          {
-            method: "PATCH",
-            headers: {
-              "x-api-key": "test-api-key",
-              "Content-Type": "application/json",
-            },
-            body: JSON.stringify({
-              question: "Updated Title",
-              intro: "Updated Description",
-            }),
-          }
-        );
+        expect(fetch).toHaveBeenCalledWith("http://localhost:8000/admin/reports/test-report/config", {
+          method: "PATCH",
+          headers: {
+            "x-api-key": "test-api-key",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            question: "Updated Title",
+            intro: "Updated Description",
+          }),
+        });
       });
 
       // レポート一覧が更新される
@@ -192,11 +185,7 @@ describe("ReportEditDialog", () => {
       });
 
       renderWithProvider(
-        <ReportEditDialog
-          {...defaultProps}
-          reports={undefined}
-          setIsEditDialogOpen={mockSetIsEditDialogOpen}
-        />
+        <ReportEditDialog {...defaultProps} reports={undefined} setIsEditDialogOpen={mockSetIsEditDialogOpen} />,
       );
 
       const saveButton = screen.getByText("保存");
@@ -222,12 +211,7 @@ describe("ReportEditDialog", () => {
         json: async () => ({ detail: "API Error Message" }),
       });
 
-      renderWithProvider(
-        <ReportEditDialog
-          {...defaultProps}
-          setIsEditDialogOpen={mockSetIsEditDialogOpen}
-        />
-      );
+      renderWithProvider(<ReportEditDialog {...defaultProps} setIsEditDialogOpen={mockSetIsEditDialogOpen} />);
 
       const saveButton = screen.getByText("保存");
       fireEvent.click(saveButton);
@@ -248,12 +232,7 @@ describe("ReportEditDialog", () => {
       const mockSetIsEditDialogOpen = jest.fn();
       (fetch as jest.Mock).mockRejectedValueOnce(new Error("Network Error"));
 
-      renderWithProvider(
-        <ReportEditDialog
-          {...defaultProps}
-          setIsEditDialogOpen={mockSetIsEditDialogOpen}
-        />
-      );
+      renderWithProvider(<ReportEditDialog {...defaultProps} setIsEditDialogOpen={mockSetIsEditDialogOpen} />);
 
       const saveButton = screen.getByText("保存");
       fireEvent.click(saveButton);

--- a/client-admin/app/_components/ReportCard/ReportEditDialog/ReportEditDialog.test.tsx
+++ b/client-admin/app/_components/ReportCard/ReportEditDialog/ReportEditDialog.test.tsx
@@ -33,7 +33,7 @@ global.fetch = jest.fn();
 
 const mockReport: Report = {
   slug: "test-report",
-  status: "completed",
+  status: "processing",
   title: "Test Report Title",
   description: "Test Report Description",
   isPubcom: false,

--- a/client-admin/app/_components/ReportCard/TokenUsage/analysisInfo.test.ts
+++ b/client-admin/app/_components/ReportCard/TokenUsage/analysisInfo.test.ts
@@ -5,7 +5,7 @@ import { analysisInfo } from "./analysisInfo";
 describe("analysisInfo", () => {
   const baseReport: Report = {
     slug: "test-report",
-    status: "completed",
+    status: "processing",
     title: "Test Report",
     description: "Test Description",
     isPubcom: false,

--- a/client-admin/app/_components/ReportCard/Visibility/Visibility.tsx
+++ b/client-admin/app/_components/ReportCard/Visibility/Visibility.tsx
@@ -45,9 +45,7 @@ export function Visibility({ report, setReports }: Props) {
 
         if (result.success) {
           setReports((prevReports) =>
-            prevReports.map((r) =>
-              r.slug === report.slug ? { ...r, visibility: result.visibility } : r,
-            ),
+            prevReports.map((r) => (r.slug === report.slug ? { ...r, visibility: result.visibility } : r)),
           );
         } else {
           toaster.create({

--- a/client-admin/app/create/components/AISettingsSection.tsx
+++ b/client-admin/app/create/components/AISettingsSection.tsx
@@ -188,7 +188,7 @@ export function AISettingsSection({
           ソースリンク機能を有効にする
         </Checkbox>
         <Field.HelperText>
-         ONにした場合は、CSVのurlカラムの情報を使って、レポートの散布図上でデータ点をクリックすると元のソースにアクセスできます。
+          ONにした場合は、CSVのurlカラムの情報を使って、レポートの散布図上でデータ点をクリックすると元のソースにアクセスできます。
         </Field.HelperText>
       </Field.Root>
 

--- a/client-admin/app/create/components/EnvironmentCheckDialog/ErrorIcon.tsx
+++ b/client-admin/app/create/components/EnvironmentCheckDialog/ErrorIcon.tsx
@@ -1,6 +1,13 @@
 export function ErrorIcon() {
   return (
-    <svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" aria-labelledby="errorIconTitle">
+    <svg
+      width="32"
+      height="32"
+      viewBox="0 0 32 32"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-labelledby="errorIconTitle"
+    >
       <title id="errorIconTitle">Error Icon</title>
       <path
         d="M15.9974 29.3327C23.3612 29.3327 29.3307 23.3631 29.3307 15.9993C29.3307 8.63555 23.3612 2.66602 15.9974 2.66602C8.6336 2.66602 2.66406 8.63555 2.66406 15.9993C2.66406 23.3631 8.6336 29.3327 15.9974 29.3327Z"

--- a/client-admin/app/create/components/EnvironmentCheckDialog/GradientCheckIcon.tsx
+++ b/client-admin/app/create/components/EnvironmentCheckDialog/GradientCheckIcon.tsx
@@ -1,6 +1,13 @@
 export function GradientCheckIcon() {
   return (
-    <svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" aria-labelledby="checkIconTitle">
+    <svg
+      width="32"
+      height="32"
+      viewBox="0 0 32 32"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-labelledby="checkIconTitle"
+    >
       <title id="checkIconTitle">Environment check icon</title>
       <path
         d="M15.9935 29.3317C23.3573 29.3317 29.3268 23.3622 29.3268 15.9984C29.3268 8.63458 23.3573 2.66504 15.9935 2.66504C8.62969 2.66504 2.66016 8.63458 2.66016 15.9984C2.66016 23.3622 8.62969 29.3317 15.9935 29.3317Z"

--- a/client-admin/app/create/parseCsv.ts
+++ b/client-admin/app/create/parseCsv.ts
@@ -33,13 +33,13 @@ export async function parseCsv(csvFile: File): Promise<CsvData[]> {
           const converted = data.map((row, index) => {
             // id または comment-id が存在する場合はその値を使用、存在しない場合は csv-${index + 1} を使用
             let finalId = `csv-${index + 1}`;
-            
-            if (row.id !== undefined && row.id !== null && row.id !== '') {
+
+            if (row.id !== undefined && row.id !== null && row.id !== "") {
               finalId = String(row.id);
-            } else if (row['comment-id'] !== undefined && row['comment-id'] !== null && row['comment-id'] !== '') {
-              finalId = String(row['comment-id']);
+            } else if (row["comment-id"] !== undefined && row["comment-id"] !== null && row["comment-id"] !== "") {
+              finalId = String(row["comment-id"]);
             }
-            
+
             return {
               ...row,
               id: finalId,

--- a/client-admin/components/theme/fonts.ts
+++ b/client-admin/components/theme/fonts.ts
@@ -1,5 +1,5 @@
-const fontFamily = '"BIZ UDPGothic", "Hiragino Kaku Gothic ProN", Meiryo, sans-serif'
+const fontFamily = '"BIZ UDPGothic", "Hiragino Kaku Gothic ProN", Meiryo, sans-serif';
 
 export const fonts = {
   main: { value: fontFamily },
-}
+};

--- a/client-admin/components/theme/recipe/link.ts
+++ b/client-admin/components/theme/recipe/link.ts
@@ -23,7 +23,7 @@ export const linkRecipe = defineRecipe({
         _hover: {
           opacity: 0.75,
           textDecoration: "none",
-        }
+        },
       },
     },
   },
@@ -31,4 +31,4 @@ export const linkRecipe = defineRecipe({
   defaultVariants: {
     variant: "underline",
   },
-})
+});

--- a/client-admin/jest.setup.js
+++ b/client-admin/jest.setup.js
@@ -1,6 +1,6 @@
 import "@testing-library/jest-dom";
 
-if(!global.structuredClone){
+if (!global.structuredClone) {
   global.structuredClone = function structuredClone(objectToClone) {
     if (objectToClone === undefined) return undefined;
     return JSON.parse(JSON.stringify(objectToClone));

--- a/client-admin/tsconfig.json
+++ b/client-admin/tsconfig.json
@@ -21,7 +21,7 @@
     "paths": {
       "@/*": ["./*"]
     },
-     "types": ["@testing-library/jest-dom"]
+    "types": ["@testing-library/jest-dom"]
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
# 変更の概要
- client-admin で biome の format error, TypeScript の type error があったので修正しました

# スクリーンショット
- なし

# 変更の背景
- format, type エラーがあった為

# 関連Issue
なし

# 動作確認の結果
<!-- 実装者は動作確認の結果を記載してください（例: レポート作成を実行し、正常にレポートが作成されることを確認した） 複数の動作確認を行った場合は、それぞれの結果を記載してください -->

- 管理画面でレポート一覧の表示・レポートの作成ができる

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

# マージ前のチェックリスト（レビュアーがマージ前に確認してください）
- [ ] CIが全て通過している
- [ ] 単体テストが実装されているか
- [ ] 今回実装した機能および影響を受けると思われる機能について、適切な動作確認が行われているかを確認する。


動作確認の項目については、実装者による動作確認のケースが適切かを確認してください。
必要に応じてレビュアー自身による動作確認も歓迎します（必須ではありません）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **スタイル**
  * テストやコンポーネントのインデント、改行、属性の整形など、コードのフォーマットを統一しました。
  * シングルクォートとダブルクォートの統一、セミコロンやカンマの追加など、記述スタイルを修正しました。
  * テストデータの一部プロパティ値（例: status）を変更しましたが、動作やテスト内容に影響はありません。

* **ドキュメント**
  * tsconfig.jsonのインデントを調整しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->