### PR TITLE
[client-admin] 管理画面のレポート一覧の Empty State のデザイン変更

### DIFF
--- a/client-admin/app/_components/Empty.tsx
+++ b/client-admin/app/_components/Empty.tsx
@@ -1,25 +1,23 @@
-import { Box, Button, Image, Link, Text, VStack } from "@chakra-ui/react";
+import { Button } from "@/components/ui/button";
+import { Box, Image, Link, Text, VStack } from "@chakra-ui/react";
+import { Plus } from "lucide-react";
 
 export function Empty() {
   return (
-    <VStack mt={8} gap={0} lineHeight={2}>
-      <Text fontSize="18px" fontWeight="bold">
-        レポートが0件です
-      </Text>
-      <Text fontSize="14px" textAlign={{ md: "center" }} mt={5}>
+    <VStack mt="8" gap="0" textAlign="center">
+      <Text textStyle="body/lg/bold">レポートが0件です</Text>
+      <Text textStyle="body/md" mt={5}>
         レポートが作成されるとここに一覧が表示され、
         <Box as="br" display={{ base: "none", md: "block" }} />
         公開やダウンロードなどの操作が行えるようになります。
       </Text>
-      <Text fontSize="12px" color="gray.500" mt={3}>
-        レポート作成が開始済みの場合は、AI分析が完了するまでしばらくお待ちください。
-      </Text>
-      <Image src="images/report-empty.png" mt={8} />
-      <Box mt={8}>
+      <Button size="xl" mt="4" asChild>
         <Link href="/create">
-          <Button size="xl">新しいレポートを作成する</Button>
+          <Plus />
+          新規作成
         </Link>
-      </Box>
+      </Button>
+      <Image src="images/report-empty.png" mt="4" />
     </VStack>
   );
 }

--- a/client-admin/app/_components/PageContent.tsx
+++ b/client-admin/app/_components/PageContent.tsx
@@ -7,7 +7,6 @@ import { Eye, EyeClosedIcon, LockKeyhole, Plus } from "lucide-react";
 import Link from "next/link";
 import { useMemo, useState } from "react";
 import { BuildDownloadButton } from "./BuildDownloadButton/BuildDownloadButton";
-import { Empty } from "./Empty";
 import { ReportCardList } from "./ReportCardList";
 
 type Props = {
@@ -59,23 +58,21 @@ export function PageContent({ reports: _reports }: Props) {
           </Flex>
         </Flex>
       </Box>
-      <Flex justifyContent="flex-end" mb="4">
-        <Button size="md" asChild>
-          <Link href="/create">
-            <Plus />
-            新規作成
-          </Link>
-        </Button>
-      </Flex>
-      {reports.length === 0 ? (
-        <Empty />
-      ) : (
-        <>
-          <ReportCardList reports={reports} setReports={setReports} />
-          <HStack justify="center" mt={10}>
-            <BuildDownloadButton />
-          </HStack>
-        </>
+      {reports.length > 0 && (
+        <Flex justifyContent="flex-end" mb="4">
+          <Button size="md" asChild>
+            <Link href="/create">
+              <Plus />
+              新規作成
+            </Link>
+          </Button>
+        </Flex>
+      )}
+      <ReportCardList reports={reports} setReports={setReports} />
+      {reports.length > 0 && (
+        <HStack justify="center" mt={10}>
+          <BuildDownloadButton />
+        </HStack>
       )}
     </>
   );

--- a/client-admin/app/_components/ReportCardList.tsx
+++ b/client-admin/app/_components/ReportCardList.tsx
@@ -1,5 +1,6 @@
 import type { Report } from "@/type";
 import { Grid, GridItem } from "@chakra-ui/react";
+import { Empty } from "./Empty";
 import { ReportCard } from "./ReportCard/ReportCard";
 
 type Props = {
@@ -9,7 +10,7 @@ type Props = {
 
 export function ReportCardList({ reports, setReports }: Props) {
   return (
-    <Grid gridTemplateColumns="170px minmax(300px, 1fr) 52px repeat(3, 83px) repeat(3, min-content)" rowGap="2">
+    <Grid gridTemplateColumns="170px minmax(300px, 1fr) 52px repeat(3, 83px) repeat(3, 44px)" rowGap="2">
       <Grid gridTemplateColumns="subgrid" gridColumn="span 9" textStyle="body/sm">
         <GridItem bg="blue.100" py="3" px="6" borderLeftRadius="sm">
           作成日時
@@ -50,6 +51,9 @@ export function ReportCardList({ reports, setReports }: Props) {
           <ReportCard report={report} reports={reports} setReports={setReports} />
         </Grid>
       ))}
+      <Grid gridColumn="span 9">
+        <Empty />
+      </Grid>
     </Grid>
   );
 }

--- a/client-admin/app/_components/ReportCardList.tsx
+++ b/client-admin/app/_components/ReportCardList.tsx
@@ -10,50 +10,54 @@ type Props = {
 
 export function ReportCardList({ reports, setReports }: Props) {
   return (
-    <Grid gridTemplateColumns="170px minmax(300px, 1fr) 52px repeat(3, 83px) repeat(3, 44px)" rowGap="2">
-      <Grid gridTemplateColumns="subgrid" gridColumn="span 9" textStyle="body/sm">
-        <GridItem bg="blue.100" py="3" px="6" borderLeftRadius="sm">
+    <Grid
+      gridTemplateColumns="170px minmax(330px, 1fr) 52px repeat(3, minmax(83px, min-content)) repeat(3, minmax(52px, min-content))"
+      rowGap="2"
+    >
+      <Grid px="6" gridTemplateColumns="subgrid" columnGap="2" gridColumn="span 9" bg="blue.100" textStyle="body/sm">
+        <GridItem py="3" borderLeftRadius="sm">
           作成日時
         </GridItem>
-        <GridItem bg="blue.100" py="3">
-          レポート名
-        </GridItem>
-        <GridItem bg="blue.100" />
-        <GridItem bg="blue.100" py="3" textAlign="center">
+        <GridItem py="3">レポート名</GridItem>
+        <GridItem />
+        <GridItem py="3" textAlign="center">
           コメント
         </GridItem>
-        <GridItem bg="blue.100" py="3" textAlign="center">
+        <GridItem py="3" textAlign="center">
           意見
         </GridItem>
-        <GridItem bg="blue.100" py="3" textAlign="center">
+        <GridItem py="3" textAlign="center">
           意見グループ
         </GridItem>
-        <GridItem bg="blue.100" py="3" />
-        <GridItem bg="blue.100" py="3" />
-        <GridItem bg="blue.100" py="3" borderRightRadius="sm" />
+        <GridItem py="3" />
+        <GridItem py="3" />
+        <GridItem py="3" borderRightRadius="sm" />
       </Grid>
-      {reports.map((report) => (
-        <Grid
-          key={report.slug}
-          p="6"
-          gridTemplateColumns="subgrid"
-          gridTemplateRows="44px auto"
-          gridColumn="span 9"
-          columnGap="2"
-          bgColor="white"
-          borderRadius="sm"
-          color="font.primary"
-          alignItems="center"
-          _hover={{
-            shadow: "lg",
-          }}
-        >
-          <ReportCard report={report} reports={reports} setReports={setReports} />
+      {reports.length === 0 ? (
+        <Grid gridColumn="span 9">
+          <Empty />
         </Grid>
-      ))}
-      <Grid gridColumn="span 9">
-        <Empty />
-      </Grid>
+      ) : (
+        reports.map((report) => (
+          <Grid
+            key={report.slug}
+            p="6"
+            gridTemplateColumns="subgrid"
+            gridTemplateRows="44px auto"
+            gridColumn="span 9"
+            columnGap="2"
+            bgColor="white"
+            borderRadius="sm"
+            color="font.primary"
+            alignItems="center"
+            _hover={{
+              shadow: "lg",
+            }}
+          >
+            <ReportCard report={report} reports={reports} setReports={setReports} />
+          </Grid>
+        ))
+      )}
     </Grid>
   );
 }

--- a/client-admin/app/global.css
+++ b/client-admin/app/global.css
@@ -13,7 +13,6 @@ body {
 .container {
   flex: 1;
   background-color: #ffffff;
-  color: #555;
 }
 
 .gradientBg {


### PR DESCRIPTION
# 変更の概要
- 管理画面のレポート一覧画面で、レポートの件数が0件の場合の UI を Figma に合わせて修正しました

# スクリーンショット

<img width="1244" height="921" alt="image" src="https://github.com/user-attachments/assets/b93c069a-ce02-4530-9f69-54a801296bef" />


# 変更の背景
- 管理画面を使いやすくしたい

# 関連Issue
- fix: https://github.com/digitaldemocracy2030/kouchou-ai/issues/646

# 動作確認の結果
<!-- 実装者は動作確認の結果を記載してください（例: レポート作成を実行し、正常にレポートが作成されることを確認した） 複数の動作確認を行った場合は、それぞれの結果を記載してください -->

- 管理画面でレポート件数が0件の場合に、適切に Empty State が表示されること

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

# マージ前のチェックリスト（レビュアーがマージ前に確認してください）
- [ ] CIが全て通過している
- [ ] 単体テストが実装されているか
- [ ] 今回実装した機能および影響を受けると思われる機能について、適切な動作確認が行われているかを確認する。


動作確認の項目については、実装者による動作確認のケースが適切かを確認してください。
必要に応じてレビュアー自身による動作確認も歓迎します（必須ではありません）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * レポートが存在しない場合に空状態（Empty）コンポーネントを表示するようになりました。

* **改善**
  * レポートリストのグリッドレイアウトが調整され、見た目と柔軟性が向上しました。
  * ボタンにアイコンが追加され、ラベルが短縮されました。
  * 空状態の説明文が簡素化されました。

* **スタイル**
  * ボタンやテキストのスタイルが統一され、全体的なデザインが洗練されました。
  * `.container` クラスのデフォルトテキストカラー指定を削除しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->