### PR TITLE
[client-admin] 管理画面でレポート削除を Server Function で実行・エラーハンドリングの改善

### DIFF
--- a/client-admin/app/_components/ReportCard/ActionMenu/ActionMenu.tsx
+++ b/client-admin/app/_components/ReportCard/ActionMenu/ActionMenu.tsx
@@ -13,9 +13,10 @@ type Props = {
   report: Report;
   setIsEditDialogOpen: Dispatch<SetStateAction<boolean>>;
   setIsClusterEditDialogOpen: Dispatch<SetStateAction<boolean>>;
+  setReports: Dispatch<SetStateAction<Report[]>>;
 };
 
-export function ActionMenu({ report, setIsEditDialogOpen, setIsClusterEditDialogOpen }: Props) {
+export function ActionMenu({ report, setIsEditDialogOpen, setIsClusterEditDialogOpen, setReports }: Props) {
   const [isOpen, setIsOpen] = useState(false);
 
   return (
@@ -113,7 +114,7 @@ export function ActionMenu({ report, setIsEditDialogOpen, setIsClusterEditDialog
           </MenuContent>
         </Portal>
       </MenuRoot>
-      <DeleteDialog isOpen={isOpen} setIsOpen={setIsOpen} report={report} />
+      <DeleteDialog isOpen={isOpen} setIsOpen={setIsOpen} report={report} setReports={setReports} />
     </>
   );
 }

--- a/client-admin/app/_components/ReportCard/DeleteButton.tsx
+++ b/client-admin/app/_components/ReportCard/DeleteButton.tsx
@@ -3,14 +3,15 @@
 import { IconButton } from "@/components/ui/icon-button";
 import type { Report } from "@/type";
 import { Trash2 } from "lucide-react";
-import { useState } from "react";
+import { type Dispatch, type SetStateAction, useState } from "react";
 import { DeleteDialog } from "./DeleteDialog";
 
 type Props = {
   report: Report;
+  setReports: Dispatch<SetStateAction<Report[]>>;
 };
 
-export function DeleteButton({ report }: Props) {
+export function DeleteButton({ report, setReports }: Props) {
   const [isOpen, setIsOpen] = useState(false);
 
   return (
@@ -25,7 +26,7 @@ export function DeleteButton({ report }: Props) {
       >
         <Trash2 />
       </IconButton>
-      <DeleteDialog isOpen={isOpen} setIsOpen={setIsOpen} report={report} />
+      <DeleteDialog isOpen={isOpen} setIsOpen={setIsOpen} report={report} setReports={setReports} />
     </>
   );
 }

--- a/client-admin/app/_components/ReportCard/DeleteDialog.tsx
+++ b/client-admin/app/_components/ReportCard/DeleteDialog.tsx
@@ -9,6 +9,7 @@ import {
   DialogRoot,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { toaster } from "@/components/ui/toaster";
 import type { Report } from "@/type";
 import { Center, Flex, Icon, Portal, Text, VStack } from "@chakra-ui/react";
 import { FileText, Trash2 } from "lucide-react";
@@ -23,6 +24,20 @@ type Props = {
 };
 
 export function DeleteDialog({ isOpen, setIsOpen, report, setReports }: Props) {
+  const handleDelete = async () => {
+    const result = await reportDelete(report.slug);
+    if (result.success) {
+      setReports((prevReports) => prevReports.filter((r) => r.slug !== report.slug));
+      setIsOpen(false);
+    } else {
+      toaster.create({
+        type: "error",
+        title: "エラー",
+        description: result.error,
+      });
+    }
+  };
+
   return (
     <DialogRoot size="sm" placement="center" open={isOpen} modal={true} closeOnInteractOutside={true} trapFocus={true}>
       <Portal>
@@ -58,17 +73,7 @@ export function DeleteDialog({ isOpen, setIsOpen, report, setReports }: Props) {
             <Button variant="tertiary" size="md" onClick={() => setIsOpen(false)}>
               キャンセル
             </Button>
-            <Button
-              variant="secondary"
-              size="md"
-              color="font.error"
-              borderColor="border.error"
-              onClick={async () => {
-                await reportDelete(report.slug);
-                setReports((prevReports) => prevReports.filter((r) => r.slug !== report.slug));
-                setIsOpen(false);
-              }}
-            >
+            <Button variant="secondary" size="md" color="font.error" borderColor="border.error" onClick={handleDelete}>
               削除する
             </Button>
           </DialogFooter>

--- a/client-admin/app/_components/ReportCard/DeleteDialog.tsx
+++ b/client-admin/app/_components/ReportCard/DeleteDialog.tsx
@@ -19,9 +19,10 @@ type Props = {
   isOpen: boolean;
   setIsOpen: Dispatch<SetStateAction<boolean>>;
   report: Report;
+  setReports: Dispatch<SetStateAction<Report[]>>;
 };
 
-export function DeleteDialog({ isOpen, setIsOpen, report }: Props) {
+export function DeleteDialog({ isOpen, setIsOpen, report, setReports }: Props) {
   return (
     <DialogRoot size="sm" placement="center" open={isOpen} modal={true} closeOnInteractOutside={true} trapFocus={true}>
       <Portal>
@@ -62,7 +63,11 @@ export function DeleteDialog({ isOpen, setIsOpen, report }: Props) {
               size="md"
               color="font.error"
               borderColor="border.error"
-              onClick={async () => await reportDelete(report.slug)}
+              onClick={async () => {
+                await reportDelete(report.slug);
+                setReports((prevReports) => prevReports.filter((r) => r.slug !== report.slug));
+                setIsOpen(false);
+              }}
             >
               削除する
             </Button>

--- a/client-admin/app/_components/ReportCard/DeleteDialog.tsx
+++ b/client-admin/app/_components/ReportCard/DeleteDialog.tsx
@@ -14,6 +14,7 @@ import type { Report } from "@/type";
 import { Center, Flex, Icon, Portal, Text, VStack } from "@chakra-ui/react";
 import { FileText, Trash2 } from "lucide-react";
 import type { Dispatch, SetStateAction } from "react";
+import { useTransition } from "react";
 import { reportDelete } from "./_actions/reportDelete";
 
 type Props = {
@@ -24,18 +25,22 @@ type Props = {
 };
 
 export function DeleteDialog({ isOpen, setIsOpen, report, setReports }: Props) {
-  const handleDelete = async () => {
-    const result = await reportDelete(report.slug);
-    if (result.success) {
-      setReports((prevReports) => prevReports.filter((r) => r.slug !== report.slug));
-      setIsOpen(false);
-    } else {
-      toaster.create({
-        type: "error",
-        title: "エラー",
-        description: result.error,
-      });
-    }
+  const [isPending, startTransition] = useTransition();
+
+  const handleDelete = () => {
+    startTransition(async () => {
+      const result = await reportDelete(report.slug);
+      if (result.success) {
+        setReports((prevReports) => prevReports.filter((r) => r.slug !== report.slug));
+        setIsOpen(false);
+      } else {
+        toaster.create({
+          type: "error",
+          title: "エラー",
+          description: result.error,
+        });
+      }
+    });
   };
 
   return (
@@ -73,7 +78,14 @@ export function DeleteDialog({ isOpen, setIsOpen, report, setReports }: Props) {
             <Button variant="tertiary" size="md" onClick={() => setIsOpen(false)}>
               キャンセル
             </Button>
-            <Button variant="secondary" size="md" color="font.error" borderColor="border.error" onClick={handleDelete}>
+            <Button
+              variant="secondary"
+              size="md"
+              color="font.error"
+              borderColor="border.error"
+              onClick={handleDelete}
+              disabled={isPending}
+            >
               削除する
             </Button>
           </DialogFooter>

--- a/client-admin/app/_components/ReportCard/ReportCard.tsx
+++ b/client-admin/app/_components/ReportCard/ReportCard.tsx
@@ -62,6 +62,7 @@ function ReportDataAndActions({ report, reports, setReports }: Props) {
                 report={report}
                 setIsEditDialogOpen={setIsEditDialogOpen}
                 setIsClusterEditDialogOpen={setIsClusterEditDialogOpen}
+                setReports={setReports}
               />
             </GridItem>
             <GridItem>
@@ -115,7 +116,7 @@ function ReportDataAndActions({ report, reports, setReports }: Props) {
                 <Text textStyle="body/sm/bold">エラーが発生しました。レポート生成設定を調整してください。</Text>
               </HStack>
             </motion.div>
-            <DeleteButton report={report} />
+            <DeleteButton report={report} setReports={setReports} />
           </>
         )}
       </AnimatePresence>

--- a/client-admin/app/_components/ReportCard/_actions/reportDelete.test.ts
+++ b/client-admin/app/_components/ReportCard/_actions/reportDelete.test.ts
@@ -29,13 +29,13 @@ describe("reportDelete", () => {
     process.env.NEXT_PUBLIC_ADMIN_API_KEY = undefined;
   });
 
-  it("成功時にDELETEリクエストを送信する", async () => {
+  it("成功時にDELETEリクエストを送信してsuccess:trueを返す", async () => {
     // 成功レスポンスをモック
     (fetch as jest.Mock).mockResolvedValueOnce({
       ok: true,
     });
 
-    await reportDelete(mockSlug);
+    const result = await reportDelete(mockSlug);
 
     // 正しいパラメータでfetchが呼ばれることを確認
     expect(fetch).toHaveBeenCalledWith(`${mockApiBaseUrl}/admin/reports/${mockSlug}`, {
@@ -46,10 +46,11 @@ describe("reportDelete", () => {
       },
     });
 
+    expect(result).toEqual({ success: true });
     expect(mockConsoleError).not.toHaveBeenCalled();
   });
 
-  it("レスポンスがエラーの場合にエラーをログに出力する", async () => {
+  it("レスポンスがエラーの場合にエラーをログに出力してsuccess:falseを返す", async () => {
     const mockErrorDetail = "レポートが見つかりません";
 
     // エラーレスポンスをモック
@@ -60,32 +61,36 @@ describe("reportDelete", () => {
       }),
     });
 
-    await reportDelete(mockSlug);
+    const result = await reportDelete(mockSlug);
 
+    // エラー結果が返されることを確認
+    expect(result).toEqual({ success: false, error: mockErrorDetail });
     // エラーがログに出力されることを確認
     expect(mockConsoleError).toHaveBeenCalledWith(new Error(mockErrorDetail));
   });
 
-  it("エラーレスポンスにdetailがない場合にデフォルトメッセージを使用する", async () => {
+  it("エラーレスポンスにdetailがない場合にデフォルトメッセージでsuccess:falseを返す", async () => {
     // detailなしのエラーレスポンスをモック
     (fetch as jest.Mock).mockResolvedValueOnce({
       ok: false,
       json: jest.fn().mockResolvedValueOnce({}),
     });
 
-    await reportDelete(mockSlug);
+    const result = await reportDelete(mockSlug);
 
+    expect(result).toEqual({ success: false, error: "レポートの削除に失敗しました" });
     expect(mockConsoleError).toHaveBeenCalledWith(new Error("レポートの削除に失敗しました"));
   });
 
-  it("fetch自体が失敗した場合にエラーをログに出力する", async () => {
+  it("fetch自体が失敗した場合にエラーをログに出力してsuccess:falseを返す", async () => {
     const mockError = new Error("ネットワークエラー");
 
     // fetchがエラーをスローすることをモック
     (fetch as jest.Mock).mockRejectedValueOnce(mockError);
 
-    await reportDelete(mockSlug);
+    const result = await reportDelete(mockSlug);
 
+    expect(result).toEqual({ success: false, error: "ネットワークエラー" });
     expect(mockConsoleError).toHaveBeenCalledWith(mockError);
   });
 
@@ -97,8 +102,9 @@ describe("reportDelete", () => {
       ok: true,
     });
 
-    await reportDelete(mockSlug);
+    const result = await reportDelete(mockSlug);
 
     expect(fetch).toHaveBeenCalledWith(`${customApiUrl}/admin/reports/${mockSlug}`, expect.any(Object));
+    expect(result).toEqual({ success: true });
   });
 });

--- a/client-admin/app/_components/ReportCard/_actions/reportDelete.test.ts
+++ b/client-admin/app/_components/ReportCard/_actions/reportDelete.test.ts
@@ -9,13 +9,6 @@ jest.mock("../../../utils/api", () => ({
 // fetchをモック化
 global.fetch = jest.fn();
 
-// window.location.reloadをモック化
-const mockReload = jest.fn();
-Object.defineProperty(window, "location", {
-  value: { reload: mockReload },
-  writable: true,
-});
-
 // console.errorをモック化してスパイ
 const mockConsoleError = jest.spyOn(console, "error").mockImplementation(() => {});
 
@@ -36,7 +29,7 @@ describe("reportDelete", () => {
     process.env.NEXT_PUBLIC_ADMIN_API_KEY = undefined;
   });
 
-  it("成功時にDELETEリクエストを送信してページをリロードする", async () => {
+  it("成功時にDELETEリクエストを送信する", async () => {
     // 成功レスポンスをモック
     (fetch as jest.Mock).mockResolvedValueOnce({
       ok: true,
@@ -53,8 +46,6 @@ describe("reportDelete", () => {
       },
     });
 
-    // ページがリロードされることを確認
-    expect(mockReload).toHaveBeenCalledTimes(1);
     expect(mockConsoleError).not.toHaveBeenCalled();
   });
 
@@ -73,7 +64,6 @@ describe("reportDelete", () => {
 
     // エラーがログに出力されることを確認
     expect(mockConsoleError).toHaveBeenCalledWith(new Error(mockErrorDetail));
-    expect(mockReload).not.toHaveBeenCalled();
   });
 
   it("エラーレスポンスにdetailがない場合にデフォルトメッセージを使用する", async () => {
@@ -97,7 +87,6 @@ describe("reportDelete", () => {
     await reportDelete(mockSlug);
 
     expect(mockConsoleError).toHaveBeenCalledWith(mockError);
-    expect(mockReload).not.toHaveBeenCalled();
   });
 
   it("正しいAPIエンドポイントURLを構築する", async () => {

--- a/client-admin/app/_components/ReportCard/_actions/reportDelete.ts
+++ b/client-admin/app/_components/ReportCard/_actions/reportDelete.ts
@@ -2,7 +2,9 @@
 
 import { getApiBaseUrl } from "../../../utils/api";
 
-export async function reportDelete(slug: string) {
+type DeleteResult = { success: true } | { success: false; error: string };
+
+export async function reportDelete(slug: string): Promise<DeleteResult> {
   try {
     const response = await fetch(`${getApiBaseUrl()}/admin/reports/${slug}`, {
       method: "DELETE",
@@ -13,9 +15,14 @@ export async function reportDelete(slug: string) {
     });
     if (!response.ok) {
       const errorData = await response.json();
-      throw new Error(errorData.detail || "レポートの削除に失敗しました");
+      const errorMessage = errorData.detail || "レポートの削除に失敗しました";
+      console.error(new Error(errorMessage));
+      return { success: false, error: errorMessage };
     }
+    return { success: true };
   } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : "レポートの削除に失敗しました";
     console.error(error);
+    return { success: false, error: errorMessage };
   }
 }

--- a/client-admin/app/_components/ReportCard/_actions/reportDelete.ts
+++ b/client-admin/app/_components/ReportCard/_actions/reportDelete.ts
@@ -1,3 +1,5 @@
+"use server";
+
 import { getApiBaseUrl } from "../../../utils/api";
 
 export async function reportDelete(slug: string) {
@@ -9,9 +11,7 @@ export async function reportDelete(slug: string) {
         "Content-Type": "application/json",
       },
     });
-    if (response.ok) {
-      window.location.reload();
-    } else {
+    if (!response.ok) {
       const errorData = await response.json();
       throw new Error(errorData.detail || "レポートの削除に失敗しました");
     }


### PR DESCRIPTION
# 変更の概要
- 管理画面の削除の処理を client -> Server Function で実行するようにしました
  - API キーがブラウザに露出するのを防ぐ為
 - エラー時に Toast でエラー内容を表示するようにしました
 - 削除の成功時にページのリロードなして UI が更新されるように変更しました

# スクリーンショット
- 削除時の流れ（ページリロードなしで UI が更新されるようにしました）
  https://github.com/user-attachments/assets/890adfdc-03e1-48bd-b8d8-abe82980593e

- エラー時の Toast 表示
  <img width="1475" height="790" alt="error" src="https://github.com/user-attachments/assets/7725c6ae-efa5-494a-846a-17d181ff3bcd" />

# 変更の背景
- API キーがブラウザに露出しているのを防ぎたい
- エラーの内容をユーザーに伝えたい

# 関連Issue
- fix: https://github.com/digitaldemocracy2030/kouchou-ai/issues/621
- https://github.com/digitaldemocracy2030/kouchou-ai/issues/547

# 動作確認の結果
<!-- 実装者は動作確認の結果を記載してください（例: レポート作成を実行し、正常にレポートが作成されることを確認した） 複数の動作確認を行った場合は、それぞれの結果を記載してください -->

- レポート生成が成功したレポートが削除できること
- レポート生成が失敗したレポートが削除できること

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

# マージ前のチェックリスト（レビュアーがマージ前に確認してください）
- [ ] CIが全て通過している
- [ ] 単体テストが実装されているか
- [ ] 今回実装した機能および影響を受けると思われる機能について、適切な動作確認が行われているかを確認する。


動作確認の項目については、実装者による動作確認のケースが適切かを確認してください。
必要に応じてレビュアー自身による動作確認も歓迎します（必須ではありません）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * レポート削除後に一覧が自動で更新されるようになりました。
  * 削除失敗時にエラーメッセージが表示されるようになりました。

* **バグ修正**
  * レポート削除時にページ全体がリロードされなくなりました。

* **テスト**
  * レポート削除のテストが、ページリロードの検証から削除結果の検証に変更されました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->