### PR TITLE
[client-admin] レポートのタイトルが短い場合の削除ダイアログのデザイン崩れを修正

### DIFF
--- a/client-admin/app/_components/ReportCard/DeleteDialog.tsx
+++ b/client-admin/app/_components/ReportCard/DeleteDialog.tsx
@@ -57,7 +57,7 @@ export function DeleteDialog({ isOpen, setIsOpen, report, setReports }: Props) {
             </DialogTitle>
           </DialogHeader>
           <DialogBody>
-            <VStack gap="3">
+            <VStack gap="3" alignItems="stretch">
               <Text textStyle="body/lg/bold" textAlign="center">
                 このレポートを
                 <br />


### PR DESCRIPTION


# 変更の概要
- レポートを削除するダイアログで、レポートのタイトルが短い場合にデザインが崩れるのを修正しました

# スクリーンショット
## before

<img width="508" height="423" alt="before" src="https://github.com/user-attachments/assets/ad5ef97c-65f7-41a3-8749-c71a9fe4badb" />

## after

<img width="490" height="426" alt="after" src="https://github.com/user-attachments/assets/fb27268d-b7b5-4cec-8d30-409dc074fd78" />


# 変更の背景
- レポートのタイトルが短い場合にデザインが崩れるため

# 関連Issue
- https://github.com/digitaldemocracy2030/kouchou-ai/issues/647

# 動作確認の結果
<!-- 実装者は動作確認の結果を記載してください（例: レポート作成を実行し、正常にレポートが作成されることを確認した） 複数の動作確認を行った場合は、それぞれの結果を記載してください -->

- レポートのタイトルが短い場合でも、削除ダイアログのデザインがくずれないこと

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

# マージ前のチェックリスト（レビュアーがマージ前に確認してください）
- [ ] CIが全て通過している
- [ ] 単体テストが実装されているか
- [ ] 今回実装した機能および影響を受けると思われる機能について、適切な動作確認が行われているかを確認する。


動作確認の項目については、実装者による動作確認のケースが適切かを確認してください。
必要に応じてレビュアー自身による動作確認も歓迎します（必須ではありません）。