### PR TITLE
[client-admin] レポート生成後のデータ fetch を Server Component で処理する

### DIFF
--- a/client-admin/app/_components/PageContent.tsx
+++ b/client-admin/app/_components/PageContent.tsx
@@ -5,7 +5,7 @@ import type { Report } from "@/type";
 import { Box, Flex, HStack, Heading, Icon, Text, VStack } from "@chakra-ui/react";
 import { Eye, EyeClosedIcon, LockKeyhole, Plus } from "lucide-react";
 import Link from "next/link";
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import { BuildDownloadButton } from "./BuildDownloadButton/BuildDownloadButton";
 import { ReportCardList } from "./ReportCardList";
 
@@ -13,9 +13,7 @@ type Props = {
   reports: Report[];
 };
 
-export function PageContent({ reports: _reports }: Props) {
-  const [reports, setReports] = useState<Report[]>(_reports);
-
+export function PageContent({ reports }: Props) {
   const counts = useMemo(
     () => ({
       public: reports.filter((report) => report.visibility === "public").length,
@@ -68,7 +66,7 @@ export function PageContent({ reports: _reports }: Props) {
           </Button>
         </Flex>
       )}
-      <ReportCardList reports={reports} setReports={setReports} />
+      <ReportCardList reports={reports} />
       {reports.length > 0 && (
         <HStack justify="center" mt={10}>
           <BuildDownloadButton />

--- a/client-admin/app/_components/ReportCard/ActionMenu/ActionMenu.tsx
+++ b/client-admin/app/_components/ReportCard/ActionMenu/ActionMenu.tsx
@@ -15,10 +15,9 @@ type Props = {
   report: Report;
   setIsEditDialogOpen: Dispatch<SetStateAction<boolean>>;
   setIsClusterEditDialogOpen: Dispatch<SetStateAction<boolean>>;
-  setReports: Dispatch<SetStateAction<Report[]>>;
 };
 
-export function ActionMenu({ report, setIsEditDialogOpen, setIsClusterEditDialogOpen, setReports }: Props) {
+export function ActionMenu({ report, setIsEditDialogOpen, setIsClusterEditDialogOpen }: Props) {
   const [isOpen, setIsOpen] = useState(false);
 
   return (
@@ -134,7 +133,7 @@ export function ActionMenu({ report, setIsEditDialogOpen, setIsClusterEditDialog
           </MenuContent>
         </Portal>
       </MenuRoot>
-      <DeleteDialog isOpen={isOpen} setIsOpen={setIsOpen} report={report} setReports={setReports} />
+      <DeleteDialog isOpen={isOpen} setIsOpen={setIsOpen} report={report} />
     </>
   );
 }

--- a/client-admin/app/_components/ReportCard/DeleteButton.tsx
+++ b/client-admin/app/_components/ReportCard/DeleteButton.tsx
@@ -3,15 +3,14 @@
 import { IconButton } from "@/components/ui/icon-button";
 import type { Report } from "@/type";
 import { Trash2 } from "lucide-react";
-import { type Dispatch, type SetStateAction, useState } from "react";
+import { useState } from "react";
 import { DeleteDialog } from "./DeleteDialog";
 
 type Props = {
   report: Report;
-  setReports: Dispatch<SetStateAction<Report[]>>;
 };
 
-export function DeleteButton({ report, setReports }: Props) {
+export function DeleteButton({ report }: Props) {
   const [isOpen, setIsOpen] = useState(false);
 
   return (
@@ -26,7 +25,7 @@ export function DeleteButton({ report, setReports }: Props) {
       >
         <Trash2 />
       </IconButton>
-      <DeleteDialog isOpen={isOpen} setIsOpen={setIsOpen} report={report} setReports={setReports} />
+      <DeleteDialog isOpen={isOpen} setIsOpen={setIsOpen} report={report} />
     </>
   );
 }

--- a/client-admin/app/_components/ReportCard/DeleteDialog.tsx
+++ b/client-admin/app/_components/ReportCard/DeleteDialog.tsx
@@ -13,6 +13,7 @@ import { toaster } from "@/components/ui/toaster";
 import type { Report } from "@/type";
 import { Center, Flex, Icon, Portal, Text, VStack } from "@chakra-ui/react";
 import { FileText, Trash2 } from "lucide-react";
+import { useRouter } from "next/navigation";
 import type { Dispatch, SetStateAction } from "react";
 import { useTransition } from "react";
 import { reportDelete } from "./_actions/reportDelete";
@@ -21,18 +22,18 @@ type Props = {
   isOpen: boolean;
   setIsOpen: Dispatch<SetStateAction<boolean>>;
   report: Report;
-  setReports: Dispatch<SetStateAction<Report[]>>;
 };
 
-export function DeleteDialog({ isOpen, setIsOpen, report, setReports }: Props) {
+export function DeleteDialog({ isOpen, setIsOpen, report }: Props) {
   const [isPending, startTransition] = useTransition();
+  const router = useRouter();
 
   const handleDelete = () => {
     startTransition(async () => {
       const result = await reportDelete(report.slug);
       if (result.success) {
-        setReports((prevReports) => prevReports.filter((r) => r.slug !== report.slug));
         setIsOpen(false);
+        router.refresh();
       } else {
         toaster.create({
           type: "error",

--- a/client-admin/app/_components/ReportCard/ReportCard.tsx
+++ b/client-admin/app/_components/ReportCard/ReportCard.tsx
@@ -2,7 +2,7 @@ import type { Report } from "@/type";
 import { GridItem, HStack, IconButton, Text } from "@chakra-ui/react";
 import { Bot, LinkIcon } from "lucide-react";
 import { AnimatePresence, LayoutGroup, motion } from "motion/react";
-import { type Dispatch, type SetStateAction, useState } from "react";
+import { useState } from "react";
 import { ActionMenu } from "./ActionMenu/ActionMenu";
 import { ClusterEditDialog } from "./ClusterEditDialog/ClusterEditDialog";
 import { DeleteButton } from "./DeleteButton";
@@ -16,12 +16,11 @@ import { Visibility } from "./Visibility/Visibility";
 type Props = {
   report: Report;
   reports: Report[];
-  setReports: Dispatch<SetStateAction<Report[]>>;
 };
 
 const duration = 0.3;
 
-function ReportDataAndActions({ report, reports, setReports }: Props) {
+function ReportDataAndActions({ report, reports }: Props) {
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
   const [isClusterEditDialogOpen, setIsClusterEditDialogOpen] = useState(false);
   return (
@@ -62,18 +61,15 @@ function ReportDataAndActions({ report, reports, setReports }: Props) {
                 report={report}
                 setIsEditDialogOpen={setIsEditDialogOpen}
                 setIsClusterEditDialogOpen={setIsClusterEditDialogOpen}
-                setReports={setReports}
               />
             </GridItem>
             <GridItem>
-              <Visibility report={report} setReports={setReports} />
+              <Visibility report={report} />
             </GridItem>
             <ReportEditDialog
               isEditDialogOpen={isEditDialogOpen}
               setIsEditDialogOpen={setIsEditDialogOpen}
               report={report}
-              reports={reports}
-              setReports={setReports}
             />
             <ClusterEditDialog
               report={report}
@@ -116,7 +112,7 @@ function ReportDataAndActions({ report, reports, setReports }: Props) {
                 <Text textStyle="body/sm/bold">エラーが発生しました。レポート生成設定を調整してください。</Text>
               </HStack>
             </motion.div>
-            <DeleteButton report={report} setReports={setReports} />
+            <DeleteButton report={report} />
           </>
         )}
       </AnimatePresence>
@@ -124,7 +120,7 @@ function ReportDataAndActions({ report, reports, setReports }: Props) {
   );
 }
 
-export function ReportCard({ report, reports, setReports }: Props) {
+export function ReportCard({ report, reports }: Props) {
   return (
     <>
       <GridItem>
@@ -133,7 +129,7 @@ export function ReportCard({ report, reports, setReports }: Props) {
       <GridItem ml="2">
         <ReportTitle report={report} />
       </GridItem>
-      {<ReportDataAndActions report={report} reports={reports} setReports={setReports} />}
+      {<ReportDataAndActions report={report} reports={reports} />}
       <AnimatePresence>
         {(report.status === "processing" || report.status === "error") && (
           <motion.div
@@ -145,7 +141,7 @@ export function ReportCard({ report, reports, setReports }: Props) {
             initial={{ opacity: 1 }}
             exit={{ opacity: 0, height: 0 }}
           >
-            <ProgressSteps slug={report.slug} setReports={setReports} />
+            <ProgressSteps slug={report.slug} />
           </motion.div>
         )}
       </AnimatePresence>

--- a/client-admin/app/_components/ReportCard/ReportEditDialog/ReportEditDialog.tsx
+++ b/client-admin/app/_components/ReportCard/ReportEditDialog/ReportEditDialog.tsx
@@ -1,6 +1,7 @@
 import { toaster } from "@/components/ui/toaster";
 import type { Report } from "@/type";
 import { Box, Button, Dialog, Input, Portal, Text, Textarea, VStack } from "@chakra-ui/react";
+import { useRouter } from "next/navigation";
 import { type Dispatch, type SetStateAction, useState } from "react";
 import { getApiBaseUrl } from "../../../utils/api";
 
@@ -8,13 +9,12 @@ type Props = {
   isEditDialogOpen: boolean;
   setIsEditDialogOpen: Dispatch<SetStateAction<boolean>>;
   report: Report;
-  reports: Report[];
-  setReports: Dispatch<SetStateAction<Report[]>>;
 };
 
-export function ReportEditDialog({ isEditDialogOpen, setIsEditDialogOpen, report, reports, setReports }: Props) {
+export function ReportEditDialog({ isEditDialogOpen, setIsEditDialogOpen, report }: Props) {
   const [editTitle, setEditTitle] = useState(report.title);
   const [editDescription, setEditDescription] = useState(report.description || "");
+  const router = useRouter();
 
   async function handleSubmit() {
     try {
@@ -35,19 +35,7 @@ export function ReportEditDialog({ isEditDialogOpen, setIsEditDialogOpen, report
         throw new Error(errorData.detail || "メタデータの更新に失敗しました");
       }
 
-      // レポート一覧を更新
-      if (reports) {
-        const updatedReports = reports.map((r) =>
-          r.slug === report.slug
-            ? {
-                ...r,
-                title: editTitle,
-                description: editDescription,
-              }
-            : r,
-        );
-        setReports(updatedReports);
-      }
+      router.refresh();
 
       // 成功メッセージを表示
       toaster.create({

--- a/client-admin/app/_components/ReportCard/Visibility/Visibility.tsx
+++ b/client-admin/app/_components/ReportCard/Visibility/Visibility.tsx
@@ -3,12 +3,11 @@ import { toaster } from "@/components/ui/toaster";
 import type { Report, ReportVisibility } from "@/type";
 import { IconButton, Portal } from "@chakra-ui/react";
 import { Eye, EyeClosedIcon, LockKeyhole } from "lucide-react";
-import type { Dispatch, SetStateAction } from "react";
+import { useRouter } from "next/navigation";
 import { updateReportVisibility } from "./actions";
 
 type Props = {
   report: Report;
-  setReports: Dispatch<SetStateAction<Report[]>>;
 };
 
 const iconStyles = {
@@ -35,7 +34,8 @@ const iconStyles = {
   },
 };
 
-export function Visibility({ report, setReports }: Props) {
+export function Visibility({ report }: Props) {
+  const router = useRouter();
   return (
     <MenuRoot
       onSelect={async (e) => {
@@ -44,9 +44,7 @@ export function Visibility({ report, setReports }: Props) {
         const result = await updateReportVisibility(report.slug, e.value as ReportVisibility);
 
         if (result.success) {
-          setReports((prevReports) =>
-            prevReports.map((r) => (r.slug === report.slug ? { ...r, visibility: result.visibility } : r)),
-          );
+          router.refresh();
         } else {
           toaster.create({
             type: "error",

--- a/client-admin/app/_components/ReportCardList.tsx
+++ b/client-admin/app/_components/ReportCardList.tsx
@@ -5,10 +5,9 @@ import { ReportCard } from "./ReportCard/ReportCard";
 
 type Props = {
   reports: Report[];
-  setReports: React.Dispatch<React.SetStateAction<Report[]>>;
 };
 
-export function ReportCardList({ reports, setReports }: Props) {
+export function ReportCardList({ reports }: Props) {
   return (
     <Grid
       gridTemplateColumns="170px minmax(330px, 1fr) 52px repeat(3, minmax(83px, min-content)) repeat(3, minmax(52px, min-content))"
@@ -54,7 +53,7 @@ export function ReportCardList({ reports, setReports }: Props) {
               shadow: "lg",
             }}
           >
-            <ReportCard report={report} reports={reports} setReports={setReports} />
+            <ReportCard report={report} reports={reports} />
           </Grid>
         ))
       )}


### PR DESCRIPTION
# 変更の概要
- レポート生成後のデータ fetch を Server Component で処理するようにしました
  - 今までは Client Component で実施しており、API キーが露出していた
  - 取得したデータの更新を useState で管理していましたが、[router.refresh](https://nextjs.org/docs/app/api-reference/functions/use-router) に変更しました
  - useState で更新することの課題点
    - フロントエンドでのデータ更新とAPI サーバー側でデータの更新が二重に行うことになるので、実装が冗長になる
    - フロントエンドでのデータ更新でデータ取得が必要な場合に、 API キーがクライアント側に露出する設計になってしまう
  -  router.refresh の利点 
     - データの更新や管理は APIサ ーバー側で行われているので、フロントエンドはデータを元に UI を構築する実装にして責務が分離できる
     - データの取得を Server Component に寄せられるので、自然と API キーがクライアントに露出しない設計になる

# スクリーンショット

https://github.com/user-attachments/assets/f8010947-a37c-4673-88e0-0380bb626420

# 変更の背景
- API サーバーの API キーがクライアント側に露出している

# 関連Issue
- https://github.com/digitaldemocracy2030/kouchou-ai/issues/547

# 動作確認の結果
<!-- 実装者は動作確認の結果を記載してください（例: レポート作成を実行し、正常にレポートが作成されることを確認した） 複数の動作確認を行った場合は、それぞれの結果を記載してください -->

- 管理画面で、レポート作成後に UI が適切に更新されること

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

# マージ前のチェックリスト（レビュアーがマージ前に確認してください）
- [ ] CIが全て通過している
- [ ] 単体テストが実装されているか
- [ ] 今回実装した機能および影響を受けると思われる機能について、適切な動作確認が行われているかを確認する。


動作確認の項目については、実装者による動作確認のケースが適切かを確認してください。
必要に応じてレビュアー自身による動作確認も歓迎します（必須ではありません）。