### PR TITLE
[client-admin] レポートのタイトル・説明文のを編集する fetch を Server Functions で実行する

### DIFF
--- a/client-admin/app/_components/ReportCard/ReportEditDialog/ReportEditDialog.tsx
+++ b/client-admin/app/_components/ReportCard/ReportEditDialog/ReportEditDialog.tsx
@@ -1,3 +1,4 @@
+import { DialogBackdrop, DialogBody, DialogCloseTrigger, DialogContent, DialogFooter, DialogHeader, DialogRoot, DialogTitle } from "@/components/ui/dialog";
 import { toaster } from "@/components/ui/toaster";
 import type { Report } from "@/type";
 import { Box, Button, Dialog, Input, Portal, Text, Textarea, VStack } from "@chakra-ui/react";
@@ -40,70 +41,42 @@ export function ReportEditDialog({ isEditDialogOpen, setIsEditDialogOpen, report
   }
 
   return (
-    <Dialog.Root
-      open={isEditDialogOpen}
-      onOpenChange={({ open }) => setIsEditDialogOpen(open)}
-      modal={true}
-      closeOnInteractOutside={true}
-      trapFocus={true}
-    >
+    <DialogRoot placement="center" open={isEditDialogOpen} onOpenChange={({ open }) => setIsEditDialogOpen(open)}>
       <Portal>
-        <Dialog.Backdrop
-          zIndex={1000}
-          position="fixed"
-          inset={0}
-          backgroundColor="blackAlpha.100"
-          backdropFilter="blur(2px)"
-        />
-        <Dialog.Positioner>
-          <Dialog.Content
-            pointerEvents="auto"
-            position="relative"
-            zIndex={1001}
-            boxShadow="md"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <Dialog.CloseTrigger position="absolute" top={3} right={3} />
-            <Dialog.Header>
-              <Dialog.Title>レポートを編集</Dialog.Title>
-            </Dialog.Header>
-            <form onSubmit={handleSubmit}>
-              <Dialog.Body>
-                <VStack gap={4} align="stretch">
-                  <Box>
-                    <Text mb={2} fontWeight="bold">
-                      タイトル
-                    </Text>
-                    <Input
-                      name="question"
-                      defaultValue={report.title}
-                      placeholder="レポートのタイトルを入力"
-                    />
-                  </Box>
-                  <Box>
-                    <Text mb={2} fontWeight="bold">
-                      調査概要
-                    </Text>
-                    <Textarea
-                      name="intro"
-                      defaultValue={report.description || ""}
-                      placeholder="調査の概要を入力"
-                    />
-                  </Box>
-                </VStack>
-              </Dialog.Body>
-              <Dialog.Footer>
-                <Button variant="outline" onClick={() => setIsEditDialogOpen(false)}>
-                  キャンセル
-                </Button>
-                <Button ml={3} type="submit">
-                  保存
-                </Button>
-              </Dialog.Footer>
-            </form>
-          </Dialog.Content>
-        </Dialog.Positioner>
+        <DialogBackdrop />
+        <DialogContent>
+          <DialogCloseTrigger />
+          <DialogHeader>
+            <DialogTitle>レポートを編集</DialogTitle>
+          </DialogHeader>
+          <form onSubmit={handleSubmit}>
+            <DialogBody>
+              <VStack gap={4} align="stretch">
+                <Box>
+                  <Text mb={2} fontWeight="bold">
+                    タイトル
+                  </Text>
+                  <Input name="question" defaultValue={report.title} placeholder="レポートのタイトルを入力" />
+                </Box>
+                <Box>
+                  <Text mb={2} fontWeight="bold">
+                    調査概要
+                  </Text>
+                  <Textarea name="intro" defaultValue={report.description || ""} placeholder="調査の概要を入力" />
+                </Box>
+              </VStack>
+            </DialogBody>
+            <DialogFooter>
+              <Button variant="outline" onClick={() => setIsEditDialogOpen(false)}>
+                キャンセル
+              </Button>
+              <Button ml={3} type="submit">
+                保存
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
       </Portal>
-    </Dialog.Root>
+    </DialogRoot>
   );
 }

--- a/client-admin/app/_components/ReportCard/ReportEditDialog/ReportEditDialog.tsx
+++ b/client-admin/app/_components/ReportCard/ReportEditDialog/ReportEditDialog.tsx
@@ -2,7 +2,7 @@ import { toaster } from "@/components/ui/toaster";
 import type { Report } from "@/type";
 import { Box, Button, Dialog, Input, Portal, Text, Textarea, VStack } from "@chakra-ui/react";
 import { useRouter } from "next/navigation";
-import { type Dispatch, type SetStateAction, useState } from "react";
+import type { Dispatch, FormEvent, SetStateAction } from "react";
 import { updateReportConfig } from "./actions";
 
 type Props = {
@@ -12,15 +12,12 @@ type Props = {
 };
 
 export function ReportEditDialog({ isEditDialogOpen, setIsEditDialogOpen, report }: Props) {
-  const [editTitle, setEditTitle] = useState(report.title);
-  const [editDescription, setEditDescription] = useState(report.description || "");
   const router = useRouter();
 
-  async function handleSubmit() {
-    const formData = new FormData();
-    formData.append("question", editTitle);
-    formData.append("intro", editDescription);
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
 
+    const formData = new FormData(event.currentTarget);
     const result = await updateReportConfig(report.slug, formData);
 
     if (result.success) {
@@ -70,38 +67,40 @@ export function ReportEditDialog({ isEditDialogOpen, setIsEditDialogOpen, report
             <Dialog.Header>
               <Dialog.Title>レポートを編集</Dialog.Title>
             </Dialog.Header>
-            <Dialog.Body>
-              <VStack gap={4} align="stretch">
-                <Box>
-                  <Text mb={2} fontWeight="bold">
-                    タイトル
-                  </Text>
-                  <Input
-                    value={editTitle}
-                    onChange={(e) => setEditTitle(e.target.value)}
-                    placeholder="レポートのタイトルを入力"
-                  />
-                </Box>
-                <Box>
-                  <Text mb={2} fontWeight="bold">
-                    調査概要
-                  </Text>
-                  <Textarea
-                    value={editDescription}
-                    onChange={(e) => setEditDescription(e.target.value)}
-                    placeholder="調査の概要を入力"
-                  />
-                </Box>
-              </VStack>
-            </Dialog.Body>
-            <Dialog.Footer>
-              <Button variant="outline" onClick={() => setIsEditDialogOpen(false)}>
-                キャンセル
-              </Button>
-              <Button ml={3} onClick={handleSubmit}>
-                保存
-              </Button>
-            </Dialog.Footer>
+            <form onSubmit={handleSubmit}>
+              <Dialog.Body>
+                <VStack gap={4} align="stretch">
+                  <Box>
+                    <Text mb={2} fontWeight="bold">
+                      タイトル
+                    </Text>
+                    <Input
+                      name="question"
+                      defaultValue={report.title}
+                      placeholder="レポートのタイトルを入力"
+                    />
+                  </Box>
+                  <Box>
+                    <Text mb={2} fontWeight="bold">
+                      調査概要
+                    </Text>
+                    <Textarea
+                      name="intro"
+                      defaultValue={report.description || ""}
+                      placeholder="調査の概要を入力"
+                    />
+                  </Box>
+                </VStack>
+              </Dialog.Body>
+              <Dialog.Footer>
+                <Button variant="outline" onClick={() => setIsEditDialogOpen(false)}>
+                  キャンセル
+                </Button>
+                <Button ml={3} type="submit">
+                  保存
+                </Button>
+              </Dialog.Footer>
+            </form>
           </Dialog.Content>
         </Dialog.Positioner>
       </Portal>

--- a/client-admin/app/_components/ReportCard/ReportEditDialog/actions.ts
+++ b/client-admin/app/_components/ReportCard/ReportEditDialog/actions.ts
@@ -1,0 +1,31 @@
+"use server";
+
+import { getApiBaseUrl } from "@/app/utils/api";
+
+export async function updateReportConfig(reportSlug: string, formData: FormData) {
+  const question = formData.get("question") as string;
+  const intro = formData.get("intro") as string;
+
+  try {
+    const response = await fetch(`${getApiBaseUrl()}/admin/reports/${reportSlug}/config`, {
+      method: "PATCH",
+      headers: {
+        "x-api-key": process.env.NEXT_PUBLIC_ADMIN_API_KEY || "",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        question,
+        intro,
+      }),
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json();
+      return { success: false, error: errorData.detail || "メタデータの更新に失敗しました" };
+    }
+
+    return { success: true };
+  } catch (error) {
+    return { success: false, error: "メタデータの更新に失敗しました" };
+  }
+}


### PR DESCRIPTION
# 変更の概要
- レポートのタイトルと説明文を編集する fetch を Server Functions で実行するように変更しました
  - API キーがブラウザに露出していた為
- form の入力値を formData を利用する形に変更しました
  - Next.js の公式で紹介されている方式なのと、今回は useState で管理する必要がない為
  - https://nextjs.org/docs/pages/guides/forms
- 他の Dialog と合わせて、ui 層で定義されている Dialog コンポーネントを利用するように変更

# スクリーンショット

<img width="651" height="477" alt="image" src="https://github.com/user-attachments/assets/2f2b640a-457c-4b9e-a5ff-630f4448e861" />

画面中央に配置して、背景の overlay も他の Dialog と色味を揃えました

# 変更の背景
- API キーをブラウザに露出しないようにしたい
- Dialog の実装を他の箇所と揃えたい

# 関連Issue
- https://github.com/digitaldemocracy2030/kouchou-ai/issues/547

# 動作確認の結果
<!-- 実装者は動作確認の結果を記載してください（例: レポート作成を実行し、正常にレポートが作成されることを確認した） 複数の動作確認を行った場合は、それぞれの結果を記載してください -->

- 管理画面で、レポートのタイトルと説明文が編集できること

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

# マージ前のチェックリスト（レビュアーがマージ前に確認してください）
- [ ] CIが全て通過している
- [ ] 単体テストが実装されているか
- [ ] 今回実装した機能および影響を受けると思われる機能について、適切な動作確認が行われているかを確認する。


動作確認の項目については、実装者による動作確認のケースが適切かを確認してください。
必要に応じてレビュアー自身による動作確認も歓迎します（必須ではありません）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * レポート設定の更新処理がサーバーアクションとして追加されました。

* **リファクタリング**
  * レポート編集ダイアログのフォーム管理方法を簡素化し、独自ダイアログUIに変更しました。
  * フォーム送信時のAPI呼び出しを直接fetchからサーバーアクション経由に変更しました。

* **テスト**
  * テストがサーバーアクションのモックを利用する形に修正されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->