### PR TITLE
[client-admin] コメント数が100万を超えたら1M単位で表示する

### DIFF
--- a/client-admin/app/_components/ReportCard/NumberDisplay.tsx
+++ b/client-admin/app/_components/ReportCard/NumberDisplay.tsx
@@ -1,0 +1,22 @@
+import { Text } from "@chakra-ui/react";
+
+type NumberDisplayProps = {
+  value: number;
+  textStyle?: string;
+  textAlign?: "start" | "end" | "left" | "right" | "center" | "justify" | "match-parent";
+};
+
+function formatNumber(value: number): string {
+  if (value >= 1000000) {
+    return `${Math.floor(value / 1000000)}M`;
+  }
+  return value.toString();
+}
+
+export function NumberDisplay({ value, textStyle = "body/md/bold", textAlign = "center" }: NumberDisplayProps) {
+  return (
+    <Text textStyle={textStyle} textAlign={textAlign}>
+      {formatNumber(value)}
+    </Text>
+  );
+}

--- a/client-admin/app/_components/ReportCard/ReportCard.tsx
+++ b/client-admin/app/_components/ReportCard/ReportCard.tsx
@@ -6,6 +6,7 @@ import { useState } from "react";
 import { ActionMenu } from "./ActionMenu/ActionMenu";
 import { ClusterEditDialog } from "./ClusterEditDialog/ClusterEditDialog";
 import { DeleteButton } from "./DeleteButton";
+import { NumberDisplay } from "./NumberDisplay";
 import { ProgressSteps } from "./ProgressSteps/ProgressSteps";
 import { ReportCreatedAt } from "./ReportCreatedAt";
 import { ReportEditDialog } from "./ReportEditDialog/ReportEditDialog";
@@ -44,14 +45,14 @@ function ReportDataAndActions({ report, reports }: Props) {
                 </a>
               </IconButton>
             </GridItem>
-            <GridItem textStyle="body/md/bold" textAlign="center">
-              {report.analysis.commentNum}
+            <GridItem>
+              <NumberDisplay value={report.analysis.commentNum} />
             </GridItem>
-            <GridItem textStyle="body/md/bold" textAlign="center">
-              {report.analysis.argumentsNum}
+            <GridItem>
+              <NumberDisplay value={report.analysis.argumentsNum} />
             </GridItem>
-            <GridItem textStyle="body/md/bold" textAlign="center">
-              {report.analysis.clusterNum}
+            <GridItem>
+              <NumberDisplay value={report.analysis.clusterNum} />
             </GridItem>
             <GridItem>
               <TokenUsage report={report} />


### PR DESCRIPTION

# 変更の概要
- 管理画面のレポート一覧で、コメント・意見・意見グループで、数が100万を超えたら1M単位で表示する

# スクリーンショット

<img width="1094" height="163" alt="image" src="https://github.com/user-attachments/assets/30ced436-d3c1-45d4-9a61-111cd98db620" />


# 変更の背景
- 管理画面を使いやすくしたい

# 関連Issue
- fix: https://github.com/digitaldemocracy2030/kouchou-ai/issues/645

# 動作確認の結果
<!-- 実装者は動作確認の結果を記載してください（例: レポート作成を実行し、正常にレポートが作成されることを確認した） 複数の動作確認を行った場合は、それぞれの結果を記載してください -->

- 管理画面のレポート一覧で、コメント数などが100万を超えたら1Mという表記になっていること

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

# マージ前のチェックリスト（レビュアーがマージ前に確認してください）
- [ ] CIが全て通過している
- [ ] 単体テストが実装されているか
- [ ] 今回実装した機能および影響を受けると思われる機能について、適切な動作確認が行われているかを確認する。


動作確認の項目については、実装者による動作確認のケースが適切かを確認してください。
必要に応じてレビュアー自身による動作確認も歓迎します（必須ではありません）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 数値を見やすく表示する「NumberDisplay」コンポーネントを追加しました。100万以上の値は「M」表記で簡略表示されます。

* **リファクタ**
  * レポートカードの数値表示を「NumberDisplay」コンポーネントに統一し、表示スタイルと整形を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->