### PR TITLE
[client-admin] 意見グループ編集の fetch を Server Functions で実行する

### DIFF
--- a/client-admin/app/_components/ReportCard/ClusterEditDialog/ClusterEditDialog.test.tsx
+++ b/client-admin/app/_components/ReportCard/ClusterEditDialog/ClusterEditDialog.test.tsx
@@ -147,7 +147,8 @@ describe("ClusterEditDialog", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByDisplayValue("Test Cluster 1")).toBeInTheDocument();
+      const titleInput = screen.getByPlaceholderText("タイトルを入力");
+      expect(titleInput).toHaveValue("Test Cluster 1");
     });
   });
 
@@ -159,10 +160,10 @@ describe("ClusterEditDialog", () => {
     );
 
     await waitFor(() => {
-      const titleInput = screen.getByDisplayValue("Test Cluster 1");
-      const descriptionTextarea = screen.getByDisplayValue("Description for cluster 1");
-      expect(titleInput).toBeInTheDocument();
-      expect(descriptionTextarea).toBeInTheDocument();
+      const titleInput = screen.getByPlaceholderText("タイトルを入力");
+      const descriptionTextarea = screen.getByPlaceholderText("説明を入力");
+      expect(titleInput).toHaveValue("Test Cluster 1");
+      expect(descriptionTextarea).toHaveValue("Description for cluster 1");
     });
   });
 
@@ -231,7 +232,7 @@ describe("ClusterEditDialog", () => {
     expect(mockOnClose).toHaveBeenCalled();
   });
 
-  it("クラスタが選択されていないときに保存ボタンが無効化される", async () => {
+  it("クラスタが存在しないときはダイアログが表示されない", async () => {
     mockFetchClusters.mockResolvedValue({
       success: true,
       clusters: [],
@@ -244,8 +245,7 @@ describe("ClusterEditDialog", () => {
     );
 
     await waitFor(() => {
-      const saveButton = screen.getByText("保存");
-      expect(saveButton).toBeDisabled();
+      expect(screen.queryByText("意見グループを編集")).not.toBeInTheDocument();
     });
   });
 

--- a/client-admin/app/_components/ReportCard/ClusterEditDialog/ClusterEditDialog.test.tsx
+++ b/client-admin/app/_components/ReportCard/ClusterEditDialog/ClusterEditDialog.test.tsx
@@ -205,12 +205,14 @@ describe("ClusterEditDialog", () => {
     await user.click(saveButton);
 
     await waitFor(() => {
-      expect(mockUpdateCluster).toHaveBeenCalledWith("test-report", {
-        id: "cluster-1",
-        label: "Updated Title",
-        description: "Description for cluster 1",
-      });
+      expect(mockUpdateCluster).toHaveBeenCalledWith("test-report", expect.any(FormData));
     });
+
+    // Verify FormData contents
+    const formDataCall = mockUpdateCluster.mock.calls[0][1] as FormData;
+    expect(formDataCall.get("id")).toBe("cluster-1");
+    expect(formDataCall.get("label")).toBe("Updated Title");
+    expect(formDataCall.get("description")).toBe("Description for cluster 1");
   });
 
   it("キャンセルボタンがクリックされたときにダイアログが閉じる", async () => {

--- a/client-admin/app/_components/ReportCard/ClusterEditDialog/ClusterEditDialog.tsx
+++ b/client-admin/app/_components/ReportCard/ClusterEditDialog/ClusterEditDialog.tsx
@@ -1,10 +1,19 @@
 import { getApiBaseUrl } from "@/app/utils/api";
+import {
+  DialogBackdrop,
+  DialogBody,
+  DialogCloseTrigger,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogRoot,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { toaster } from "@/components/ui/toaster";
 import type { ClusterResponse, Report } from "@/type";
 import {
   Box,
   Button,
-  Dialog,
   Heading,
   Input,
   Portal,
@@ -15,7 +24,7 @@ import {
   VStack,
   createListCollection,
 } from "@chakra-ui/react";
-import { type Dispatch, type SetStateAction, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { type Dispatch, type SetStateAction, useCallback, useEffect, useMemo, useState } from "react";
 
 type ClusterEditDialogProps = {
   report: Report;
@@ -24,7 +33,6 @@ type ClusterEditDialogProps = {
 };
 
 export function ClusterEditDialog({ report, isOpen, setIsClusterEditDialogOpen }: ClusterEditDialogProps) {
-  const clusterDialogContentRef = useRef<HTMLDivElement>(null);
   const [selectedClusterId, setSelectedClusterId] = useState<string | undefined>(undefined);
   const [editClusterTitle, setEditClusterTitle] = useState("");
   const [editClusterDescription, setEditClusterDescription] = useState("");
@@ -160,7 +168,7 @@ export function ClusterEditDialog({ report, isOpen, setIsClusterEditDialogOpen }
   }
 
   return (
-    <Dialog.Root
+    <DialogRoot
       open={isOpen}
       onOpenChange={({ open }) => setIsClusterEditDialogOpen(open)}
       modal={true}
@@ -168,156 +176,137 @@ export function ClusterEditDialog({ report, isOpen, setIsClusterEditDialogOpen }
       trapFocus={true}
     >
       <Portal>
-        <Dialog.Backdrop
-          zIndex={1000}
-          position="fixed"
-          inset={0}
-          backgroundColor="blackAlpha.100"
-          backdropFilter="blur(2px)"
-        />
-        <Dialog.Positioner>
-          <Dialog.Content
-            ref={clusterDialogContentRef}
-            pointerEvents="auto"
-            position="relative"
-            zIndex={1001}
-            boxShadow="md"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <Dialog.CloseTrigger position="absolute" top={3} right={3} />
-            <Dialog.Header>
-              <Dialog.Title>意見グループを編集</Dialog.Title>
-            </Dialog.Header>
-            <Dialog.Body>
-              <VStack gap={4} align="stretch">
-                <Heading size="md">編集対象の選択</Heading>
-                <Box>
-                  <Text mb={2} fontWeight="bold">
-                    意見グループの階層
-                  </Text>
-                  <Select.Root
-                    collection={createListCollection({
-                      items: availableLevels.map((level) => ({ label: `第${level}階層`, value: level })),
-                    })}
-                    value={[String(selectedLevel)]}
-                    onValueChange={(item) => {
-                      if (item?.value) {
-                        const level = Array.isArray(item.value) ? item.value[0] : item.value;
-                        setSelectedLevel(Number(level));
+        <DialogBackdrop />
+        <DialogContent>
+          <DialogCloseTrigger />
+          <DialogHeader>
+            <DialogTitle>意見グループを編集</DialogTitle>
+          </DialogHeader>
+          <DialogBody>
+            <VStack gap={4} align="stretch">
+              <Heading size="md">編集対象の選択</Heading>
+              <Box>
+                <Text mb={2} fontWeight="bold">
+                  意見グループの階層
+                </Text>
+                <Select.Root
+                  collection={createListCollection({
+                    items: availableLevels.map((level) => ({ label: `第${level}階層`, value: level })),
+                  })}
+                  value={[String(selectedLevel)]}
+                  onValueChange={(item) => {
+                    if (item?.value) {
+                      const level = Array.isArray(item.value) ? item.value[0] : item.value;
+                      setSelectedLevel(Number(level));
+                    }
+                  }}
+                >
+                  <Select.HiddenSelect />
+                  <Select.Control>
+                    <Select.Trigger>
+                      <Select.ValueText>{`第${selectedLevel}階層`}</Select.ValueText>
+                    </Select.Trigger>
+                    <Select.IndicatorGroup>
+                      <Select.Indicator />
+                    </Select.IndicatorGroup>
+                  </Select.Control>
+                  <Select.Positioner>
+                    <Select.Content>
+                      {availableLevels.map((level) => (
+                        <Select.Item item={{ label: `第${level}階層`, value: level }} key={level}>
+                          第{level}階層
+                          <Select.ItemIndicator />
+                        </Select.Item>
+                      ))}
+                    </Select.Content>
+                  </Select.Positioner>
+                </Select.Root>
+              </Box>
+              <Box>
+                <Text mb={2} fontWeight="bold">
+                  編集対象のグループ
+                </Text>
+                <Select.Root
+                  collection={createListCollection({
+                    items: filteredClusters.map((c) => ({ label: c.label, value: c.id })),
+                  })}
+                  value={selectedClusterId ? [selectedClusterId] : []}
+                  onValueChange={(item) => {
+                    if (item?.value) {
+                      const selectedId = Array.isArray(item.value) ? item.value[0] : item.value;
+                      setSelectedClusterId(selectedId);
+                      const selected = clusters.find((c) => c.id === selectedId);
+                      if (selected) {
+                        setEditClusterTitle(selected.label);
+                        setEditClusterDescription(selected.description);
                       }
-                    }}
-                  >
-                    <Select.HiddenSelect />
-                    <Select.Control>
-                      <Select.Trigger>
-                        <Select.ValueText>{`第${selectedLevel}階層`}</Select.ValueText>
-                      </Select.Trigger>
-                      <Select.IndicatorGroup>
-                        <Select.Indicator />
-                      </Select.IndicatorGroup>
-                    </Select.Control>
-                    <Portal container={clusterDialogContentRef}>
-                      <Select.Positioner zIndex={1002}>
-                        <Select.Content>
-                          {availableLevels.map((level) => (
-                            <Select.Item item={{ label: `第${level}階層`, value: level }} key={level}>
-                              第{level}階層
-                              <Select.ItemIndicator />
-                            </Select.Item>
-                          ))}
-                        </Select.Content>
-                      </Select.Positioner>
-                    </Portal>
-                  </Select.Root>
-                </Box>
-                <Box>
-                  <Text mb={2} fontWeight="bold">
-                    編集対象のグループ
-                  </Text>
-                  <Select.Root
-                    collection={createListCollection({
-                      items: filteredClusters.map((c) => ({ label: c.label, value: c.id })),
-                    })}
-                    value={selectedClusterId ? [selectedClusterId] : []}
-                    onValueChange={(item) => {
-                      if (item?.value) {
-                        const selectedId = Array.isArray(item.value) ? item.value[0] : item.value;
-                        setSelectedClusterId(selectedId);
-                        const selected = clusters.find((c) => c.id === selectedId);
-                        if (selected) {
-                          setEditClusterTitle(selected.label);
-                          setEditClusterDescription(selected.description);
-                        }
-                      }
-                    }}
-                  >
-                    <Select.HiddenSelect />
-                    <Select.Control>
-                      <Select.Trigger>
-                        <Select.ValueText>
-                          {selectedClusterId
-                            ? clusters.find((c) => c.id === selectedClusterId)?.label || "意見グループを選択"
-                            : "意見グループを選択"}
-                        </Select.ValueText>
-                      </Select.Trigger>
-                      <Select.IndicatorGroup>
-                        <Select.Indicator />
-                      </Select.IndicatorGroup>
-                    </Select.Control>
-                    <Portal container={clusterDialogContentRef}>
-                      <Select.Positioner zIndex={2500}>
-                        <Select.Content>
-                          {filteredClusters.map((c) => (
-                            <Select.Item item={{ label: c.label, value: c.id }} key={c.id}>
-                              {c.label}
-                              <Select.ItemIndicator />
-                            </Select.Item>
-                          ))}
-                        </Select.Content>
-                      </Select.Positioner>
-                    </Portal>
-                  </Select.Root>
-                </Box>
-                {selectedClusterId && (
-                  <>
-                    <Separator my={4} />
-                    <Heading size="md">意見グループの編集</Heading>
-                    <Box>
-                      <Text mb={2} fontWeight="bold">
-                        タイトル
-                      </Text>
-                      <Input
-                        value={editClusterTitle}
-                        onChange={(e) => setEditClusterTitle(e.target.value)}
-                        placeholder="タイトルを入力"
-                      />
-                    </Box>
-                    <Box>
-                      <Text mb={2} fontWeight="bold">
-                        説明
-                      </Text>
-                      <Textarea
-                        value={editClusterDescription}
-                        onChange={(e) => setEditClusterDescription(e.target.value)}
-                        placeholder="説明を入力"
-                        height="150px"
-                      />
-                    </Box>
-                  </>
-                )}
-              </VStack>
-            </Dialog.Body>
-            <Dialog.Footer>
-              <Button variant="outline" onClick={() => setIsClusterEditDialogOpen(false)}>
-                キャンセル
-              </Button>
-              <Button ml={3} disabled={!selectedClusterId} onClick={handleSubmit}>
-                保存
-              </Button>
-            </Dialog.Footer>
-          </Dialog.Content>
-        </Dialog.Positioner>
+                    }
+                  }}
+                >
+                  <Select.HiddenSelect />
+                  <Select.Control>
+                    <Select.Trigger>
+                      <Select.ValueText>
+                        {selectedClusterId
+                          ? clusters.find((c) => c.id === selectedClusterId)?.label || "意見グループを選択"
+                          : "意見グループを選択"}
+                      </Select.ValueText>
+                    </Select.Trigger>
+                    <Select.IndicatorGroup>
+                      <Select.Indicator />
+                    </Select.IndicatorGroup>
+                  </Select.Control>
+                  <Select.Positioner>
+                    <Select.Content>
+                      {filteredClusters.map((c) => (
+                        <Select.Item item={{ label: c.label, value: c.id }} key={c.id}>
+                          {c.label}
+                          <Select.ItemIndicator />
+                        </Select.Item>
+                      ))}
+                    </Select.Content>
+                  </Select.Positioner>
+                </Select.Root>
+              </Box>
+              {selectedClusterId && (
+                <>
+                  <Separator my={4} />
+                  <Heading size="md">意見グループの編集</Heading>
+                  <Box>
+                    <Text mb={2} fontWeight="bold">
+                      タイトル
+                    </Text>
+                    <Input
+                      value={editClusterTitle}
+                      onChange={(e) => setEditClusterTitle(e.target.value)}
+                      placeholder="タイトルを入力"
+                    />
+                  </Box>
+                  <Box>
+                    <Text mb={2} fontWeight="bold">
+                      説明
+                    </Text>
+                    <Textarea
+                      value={editClusterDescription}
+                      onChange={(e) => setEditClusterDescription(e.target.value)}
+                      placeholder="説明を入力"
+                      height="150px"
+                    />
+                  </Box>
+                </>
+              )}
+            </VStack>
+          </DialogBody>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setIsClusterEditDialogOpen(false)}>
+              キャンセル
+            </Button>
+            <Button ml={3} disabled={!selectedClusterId} onClick={handleSubmit}>
+              保存
+            </Button>
+          </DialogFooter>
+        </DialogContent>
       </Portal>
-    </Dialog.Root>
+    </DialogRoot>
   );
 }

--- a/client-admin/app/_components/ReportCard/ClusterEditDialog/ClusterEditDialog.tsx
+++ b/client-admin/app/_components/ReportCard/ClusterEditDialog/ClusterEditDialog.tsx
@@ -117,7 +117,7 @@ function Dialog({ clusters, report, isOpen, setIsOpen }: DialogProps) {
   }
 
   return (
-    <DialogRoot open={isOpen} modal={true} closeOnInteractOutside={true} trapFocus={true}>
+    <DialogRoot placement="center" open={isOpen} modal={true} closeOnInteractOutside={true} trapFocus={true}>
       <Portal>
         <DialogBackdrop />
         <DialogContent>

--- a/client-admin/app/_components/ReportCard/ClusterEditDialog/ClusterEditDialog.tsx
+++ b/client-admin/app/_components/ReportCard/ClusterEditDialog/ClusterEditDialog.tsx
@@ -116,30 +116,12 @@ export function ClusterEditDialog({ report, isOpen, setIsClusterEditDialogOpen }
       return;
     }
 
-    // 意見グループ一覧を再取得して更新
-    const updatedClusters = await fetchClustersData();
-    if (updatedClusters) {
-      // 更新された意見グループ情報をフォームに再設定
-      const updatedSelectedCluster = updatedClusters.find((c: ClusterResponse) => c.id === selectedClusterId);
-      if (updatedSelectedCluster) {
-        setEditClusterTitle(updatedSelectedCluster.label);
-        setEditClusterDescription(updatedSelectedCluster.description);
-      }
-    } else {
-      // クラスター一覧取得のエラーを処理
-      console.error("意見グループ一覧の取得に失敗しました");
-      toaster.create({
-        type: "warning",
-        title: "一部データの取得に失敗",
-        description: "最新の意見グループ一覧の取得に失敗しましたが、変更は保存されています",
-      });
-    }
-
     toaster.create({
       type: "success",
       title: "更新完了",
       description: "意見グループ情報が更新されました",
     });
+
     setIsClusterEditDialogOpen(false);
   }
 

--- a/client-admin/app/_components/ReportCard/ClusterEditDialog/ClusterEditDialog.tsx
+++ b/client-admin/app/_components/ReportCard/ClusterEditDialog/ClusterEditDialog.tsx
@@ -147,7 +147,7 @@ function Dialog({ clusters, report, isOpen, setIsOpen }: DialogProps) {
                     <Select.HiddenSelect />
                     <Select.Control>
                       <Select.Trigger>
-                        <Select.ValueText placeholder="test" />
+                        <Select.ValueText placeholder="階層を選択" />
                       </Select.Trigger>
                       <Select.IndicatorGroup>
                         <Select.Indicator />

--- a/client-admin/app/_components/ReportCard/ClusterEditDialog/actions.ts
+++ b/client-admin/app/_components/ReportCard/ClusterEditDialog/actions.ts
@@ -1,0 +1,62 @@
+"use server";
+
+import { getApiBaseUrl } from "@/app/utils/api";
+import type { ClusterResponse, ClusterUpdate } from "@/type";
+
+type FetchClustersResult = {
+  success: boolean;
+  clusters?: ClusterResponse[];
+  error?: string;
+};
+
+export async function fetchClusters(reportSlug: string): Promise<FetchClustersResult> {
+  try {
+    const response = await fetch(`${getApiBaseUrl()}/admin/reports/${reportSlug}/cluster-labels`, {
+      headers: {
+        "x-api-key": process.env.NEXT_PUBLIC_ADMIN_API_KEY || "",
+      },
+    });
+
+    if (!response.ok) {
+      return { success: false, error: "クラスタ一覧の取得に失敗しました" };
+    }
+
+    const data = await response.json();
+    return { success: true, clusters: data.clusters };
+  } catch (error) {
+    return { success: false, error: "クラスタ一覧の取得に失敗しました" };
+  }
+}
+
+type UpdateClusterResult = {
+  success: boolean;
+  error?: string;
+};
+
+export async function updateCluster(reportSlug: string, clusterUpdate: ClusterUpdate): Promise<UpdateClusterResult> {
+  try {
+    const response = await fetch(`${getApiBaseUrl()}/admin/reports/${reportSlug}/cluster-label`, {
+      method: "PATCH",
+      headers: {
+        "x-api-key": process.env.NEXT_PUBLIC_ADMIN_API_KEY || "",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(clusterUpdate),
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json();
+      let errorMessage = errorData.detail || "意見グループ情報の更新に失敗しました";
+      if (response.status === 400) {
+        errorMessage = `入力データが不正です: ${errorMessage}`;
+      } else if (response.status === 404) {
+        errorMessage = "指定されたレポートの意見グループが見つかりません";
+      }
+      return { success: false, error: errorMessage };
+    }
+
+    return { success: true };
+  } catch (error) {
+    return { success: false, error: "意見グループ情報の更新に失敗しました" };
+  }
+}

--- a/client-admin/app/_components/ReportCard/ClusterEditDialog/actions.ts
+++ b/client-admin/app/_components/ReportCard/ClusterEditDialog/actions.ts
@@ -3,11 +3,15 @@
 import { getApiBaseUrl } from "@/app/utils/api";
 import type { ClusterResponse, ClusterUpdate } from "@/type";
 
-type FetchClustersResult = {
-  success: boolean;
-  clusters?: ClusterResponse[];
-  error?: string;
-};
+type FetchClustersResult =
+  | {
+      success: true;
+      clusters: ClusterResponse[];
+    }
+  | {
+      success: false;
+      error: string;
+    };
 
 export async function fetchClusters(reportSlug: string): Promise<FetchClustersResult> {
   try {

--- a/client-admin/app/_components/ReportCard/ClusterEditDialog/actions.ts
+++ b/client-admin/app/_components/ReportCard/ClusterEditDialog/actions.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { getApiBaseUrl } from "@/app/utils/api";
-import type { ClusterResponse, ClusterUpdate } from "@/type";
+import type { ClusterResponse } from "@/type";
 
 type FetchClustersResult =
   | {
@@ -37,7 +37,11 @@ type UpdateClusterResult = {
   error?: string;
 };
 
-export async function updateCluster(reportSlug: string, clusterUpdate: ClusterUpdate): Promise<UpdateClusterResult> {
+export async function updateCluster(reportSlug: string, formData: FormData): Promise<UpdateClusterResult> {
+  const id = formData.get("id") as string;
+  const label = formData.get("label") as string;
+  const description = formData.get("description") as string;
+
   try {
     const response = await fetch(`${getApiBaseUrl()}/admin/reports/${reportSlug}/cluster-label`, {
       method: "PATCH",
@@ -45,7 +49,7 @@ export async function updateCluster(reportSlug: string, clusterUpdate: ClusterUp
         "x-api-key": process.env.NEXT_PUBLIC_ADMIN_API_KEY || "",
         "Content-Type": "application/json",
       },
-      body: JSON.stringify(clusterUpdate),
+      body: JSON.stringify({ id, label, description }),
     });
 
     if (!response.ok) {

--- a/client-admin/app/_components/ReportCard/ReportEditDialog/ReportEditDialog.test.tsx
+++ b/client-admin/app/_components/ReportCard/ReportEditDialog/ReportEditDialog.test.tsx
@@ -45,7 +45,6 @@ afterEach(() => {
   process.env = originalEnv;
 });
 
-
 const mockReport: Report = {
   slug: "test-report",
   status: "processing",
@@ -54,7 +53,6 @@ const mockReport: Report = {
   isPubcom: false,
   visibility: ReportVisibility.PUBLIC,
 };
-
 
 const defaultProps = {
   isEditDialogOpen: true,

--- a/client-admin/app/_components/ReportCard/ReportEditDialog/ReportEditDialog.tsx
+++ b/client-admin/app/_components/ReportCard/ReportEditDialog/ReportEditDialog.tsx
@@ -1,4 +1,13 @@
-import { DialogBackdrop, DialogBody, DialogCloseTrigger, DialogContent, DialogFooter, DialogHeader, DialogRoot, DialogTitle } from "@/components/ui/dialog";
+import {
+  DialogBackdrop,
+  DialogBody,
+  DialogCloseTrigger,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogRoot,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { toaster } from "@/components/ui/toaster";
 import type { Report } from "@/type";
 import { Box, Button, Dialog, Input, Portal, Text, Textarea, VStack } from "@chakra-ui/react";


### PR DESCRIPTION
# 変更の概要
- 管理画面で意見グループを編集する際のデータ取得と api サーバーへの POST を Server Fucntions で実行するように変更しました
  - api キーをクライアント（ブラウザ）に露出させないため
- Dialog の実装を他の箇所と合わせて ui 層に定義された Dialog コンポーネントを利用する形に変更しました
- useState で管理していた form の入力値を formData で渡すように変更しました

# スクリーンショット

https://github.com/user-attachments/assets/8818bb55-d127-4516-b0d6-1af247a172b2



# 変更の背景
- api キーがクライアントに露出している

# 関連Issue
- https://github.com/digitaldemocracy2030/kouchou-ai/issues/547

# 動作確認の結果
<!-- 実装者は動作確認の結果を記載してください（例: レポート作成を実行し、正常にレポートが作成されることを確認した） 複数の動作確認を行った場合は、それぞれの結果を記載してください -->

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

# マージ前のチェックリスト（レビュアーがマージ前に確認してください）
- [ ] CIが全て通過している
- [ ] 単体テストが実装されているか
- [ ] 今回実装した機能および影響を受けると思われる機能について、適切な動作確認が行われているかを確認する。


動作確認の項目については、実装者による動作確認のケースが適切かを確認してください。
必要に応じてレビュアー自身による動作確認も歓迎します（必須ではありません）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * クラスターの取得と更新を行うサーバーアクションが追加され、レポート編集ダイアログで利用可能になりました。

* **リファクタ**
  * クラスター編集ダイアログのUIとロジックを分離し、よりモジュール化された構成に変更しました。
  * フォーム送信をネイティブなform要素と非制御入力に切り替えました。
  * Chakra UIのダイアログからカスタムダイアログコンポーネントに置き換えました。

* **テスト**
  * クラスター編集ダイアログのテストをサーバーアクションのモック利用に変更し、テスト内容を最新の実装に合わせて調整しました。

* **スタイル**
  * レポート編集ダイアログのインポート文を整理しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->