### PR TITLE
Makefile 利用時に .env の自動更新を行う

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .env.azure.generated
 .env.azure
 .env
+.env-hashes
 .idea
 .next
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -248,8 +248,6 @@ azure-build:
 	docker build --platform linux/amd64 --no-cache -t $(AZURE_ACR_NAME).azurecr.io/client-admin:latest ./client-admin
 	docker build --platform linux/amd64 --no-cache -t $(AZURE_ACR_NAME).azurecr.io/client-static-build:latest -f ./client-static-build/Dockerfile .
 
-
-
 # イメージをAzureにプッシュ（ローカルのDockerから）
 azure-push:
 	$(call read-env)

--- a/Makefile
+++ b/Makefile
@@ -5,13 +5,121 @@ azure-cli azure-login azure-build azure-push azure-deploy azure-info azure-confi
 azure-logs-client azure-logs-api azure-logs-admin azure-logs-client-static-build
 
 ##############################################################################
+# envファイル変更チェック機能
+##############################################################################
+
+HASH_DIR := .env-hashes
+
+ENV_HASH_FILE := $(HASH_DIR)/.env.hash
+AZURE_ENV_HASH_FILE := $(HASH_DIR)/.env.azure.hash
+
+define check_env_changes
+changed=false; \
+if [ -f .env ]; then \
+	current_hash=$$(sha256sum .env | cut -d' ' -f1); \
+	stored_hash=$$([ -f $(ENV_HASH_FILE) ] && cat $(ENV_HASH_FILE) || echo "no_hash"); \
+	if [ "$$current_hash" != "$$stored_hash" ]; then \
+		changed=true; \
+	fi; \
+fi; \
+if [ -f .env.azure ]; then \
+	current_hash=$$(sha256sum .env.azure | cut -d' ' -f1); \
+	stored_hash=$$([ -f $(AZURE_ENV_HASH_FILE) ] && cat $(AZURE_ENV_HASH_FILE) || echo "no_hash"); \
+	if [ "$$current_hash" != "$$stored_hash" ]; then \
+		changed=true; \
+	fi; \
+fi
+endef
+
+define update_env_hashes
+mkdir -p $(HASH_DIR); \
+if [ -f .env ]; then sha256sum .env | cut -d' ' -f1 > $(ENV_HASH_FILE); fi; \
+if [ -f .env.azure ]; then sha256sum .env.azure | cut -d' ' -f1 > $(AZURE_ENV_HASH_FILE); fi
+endef
+
+$(HASH_DIR):
+	@mkdir -p $(HASH_DIR)
+
+check-env-status:
+	@echo "🔍 envファイルの変更状況:"
+	@echo "----------------------------------------"
+	@if [ -f .env ]; then \
+		current_hash=$$(sha256sum .env | cut -d' ' -f1); \
+		stored_hash=$$([ -f $(ENV_HASH_FILE) ] && cat $(ENV_HASH_FILE) || echo "no_hash"); \
+		if [ "$$current_hash" != "$$stored_hash" ]; then \
+			echo ".env: 変更あり"; \
+		else \
+			echo ".env: 変更なし"; \
+		fi; \
+	else \
+		echo ".env: ファイルなし"; \
+	fi
+	@if [ -f .env.azure ]; then \
+		current_hash=$$(sha256sum .env.azure | cut -d' ' -f1); \
+		stored_hash=$$([ -f $(AZURE_ENV_HASH_FILE) ] && cat $(AZURE_ENV_HASH_FILE) || echo "no_hash"); \
+		if [ "$$current_hash" != "$$stored_hash" ]; then \
+			echo ".env.azure: 変更あり"; \
+		else \
+			echo ".env.azure: 変更なし"; \
+		fi; \
+	else \
+		echo ".env.azure: ファイルなし"; \
+	fi
+	@echo "----------------------------------------"
+
+update-hashes: | $(HASH_DIR)
+	@mkdir -p $(HASH_DIR)
+	@if [ -f .env ]; then \
+		sha256sum .env | cut -d' ' -f1 > $(ENV_HASH_FILE); \
+		echo ".envのハッシュを更新しました"; \
+	fi
+	@if [ -f .env.azure ]; then \
+		sha256sum .env.azure | cut -d' ' -f1 > $(AZURE_ENV_HASH_FILE); \
+		echo ".env.azureのハッシュを更新しました"; \
+	fi
+
+clean-env-hashes:
+	@echo ">>> envファイルのハッシュをクリーンアップ中..."
+	@rm -rf $(HASH_DIR)
+	@echo "ハッシュファイルをクリーンアップしました"
+
+check-only: check-env-status
+
+##############################################################################
 # ローカル開発環境のコマンド
 ##############################################################################
 
 build:
-	docker compose build
+	@$(check_env_changes); \
+	if [ "$$changed" = "true" ]; then \
+		echo "envファイルの変更が検出されました。再ビルドを実行します..."; \
+		docker compose down 2>/dev/null || true; \
+		docker compose build --no-cache; \
+		$(update_env_hashes); \
+		echo "再ビルド完了"; \
+	else \
+		echo "envファイルに変更はありません。通常ビルドを実行します..."; \
+		docker compose build; \
+	fi
 
 up:
+	@$(check_env_changes); \
+	if [ "$$changed" = "true" ]; then \
+		echo "envファイルの変更が検出されました。再ビルドして起動します..."; \
+		docker compose down 2>/dev/null || true; \
+		docker compose up --build; \
+		$(update_env_hashes); \
+	else \
+		echo "envファイルに変更はありません。通常起動します..."; \
+		docker compose up --build; \
+	fi
+
+build-force:
+	@echo ">>> チェックをスキップしてビルド..."
+	docker compose build
+
+up-force:
+	@echo ">>> チェックをスキップして起動..."
 	docker compose up --build
 
 down:

--- a/Makefile
+++ b/Makefile
@@ -235,10 +235,19 @@ azure-acr-login-auto:
 # Azure用のイメージをビルド
 azure-build:
 	$(call read-env)
+	@$(check_env_changes); \
+	if [ "$changed" = "true" ]; then \
+		echo "envファイルの変更が検出されました。Azure用イメージを再ビルドします..."; \
+		$(update_env_hashes); \
+	else \
+		echo "envファイルに変更はありません。Azure用イメージをビルドします..."; \
+	fi
+	@echo ">>> Azure用イメージをビルド中..."
 	docker build --platform linux/amd64 -t $(AZURE_ACR_NAME).azurecr.io/api:latest ./server
 	docker build --platform linux/amd64 -t $(AZURE_ACR_NAME).azurecr.io/client:latest ./client
 	docker build --platform linux/amd64 --no-cache -t $(AZURE_ACR_NAME).azurecr.io/client-admin:latest ./client-admin
 	docker build --platform linux/amd64 --no-cache -t $(AZURE_ACR_NAME).azurecr.io/client-static-build:latest -f ./client-static-build/Dockerfile .
+
 
 # イメージをAzureにプッシュ（ローカルのDockerから）
 azure-push:

--- a/Makefile
+++ b/Makefile
@@ -98,8 +98,6 @@ clean-env-hashes:
 	@rm -rf $(HASH_DIR)
 	@echo "ハッシュファイルをクリーンアップしました"
 
-check-only: check-env-status
-
 ##############################################################################
 # ローカル開発環境のコマンド
 ##############################################################################
@@ -109,7 +107,7 @@ build:
 
 up:
 	@$(build_with_env_check)
-	docker compose up --build
+	docker compose up
 
 build-force:
 	@echo ">>> チェックをスキップしてビルド..."


### PR DESCRIPTION
# 変更の概要
- Makefile に .env, .env.azure の変更チェック機能を追加
  - ハッシュファイル生成を行うため、ハッシュファイル生成先ディレクトリを.gitignoreに追加

# スクリーンショット
env ファイル変更あり
<img width="801" height="88" alt="2025-07-25_11-30-58" src="https://github.com/user-attachments/assets/ea9d01e8-04ad-4d68-8d70-3f3257496516" />

env ファイル変更なし
<img width="792" height="58" alt="2025-07-25_11-36-35" src="https://github.com/user-attachments/assets/999f9d3a-5b82-46b3-af78-dea1f8641dee" />


# 変更の背景
- fix: #594 

# 動作確認の結果
.env ファイルの変更後、`make up`, `make build`を実行することで環境変数の反映を確認
Azure環境でのチェックは**行えていない**ため、確認をお願いしたいです。
(ただ、行う処理自体は同じなので大きな影響はないと思います)

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

# マージ前のチェックリスト（レビュアーがマージ前に確認してください）
- [ ] CIが全て通過している
- [ ] 単体テストが実装されているか
- [ ] 今回実装した機能および影響を受けると思われる機能について、適切な動作確認が行われているかを確認する。


動作確認の項目については、実装者による動作確認のケースが適切かを確認してください。
必要に応じてレビュアー自身による動作確認も歓迎します（必須ではありません）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 環境ファイル（.env, .env.azure）の変更を自動検知し、変更時にビルドや起動時に再ビルドが実行されるようになりました。
  * 環境ファイルの変更状況を確認・更新・クリアする新しいコマンドが追加されました。

* **その他**
  * `.env-hashes` ディレクトリがGit管理対象外になりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->