### PR TITLE
[client-admin] レポート作成のリクエストを Server Functions で実行する

### DIFF
--- a/client-admin/app/create/api/createReport.ts
+++ b/client-admin/app/create/api/createReport.ts
@@ -1,9 +1,14 @@
+"use server";
+
+import { getApiBaseUrl } from "@/app/utils/api";
 import type { CsvData } from "../parseCsv";
 import type { PromptSettings } from "../types";
 
-/**
- * レポート作成APIを呼び出す
- */
+type CreateReportResult = {
+  success: boolean;
+  error?: string;
+};
+
 export async function createReport({
   input,
   question,
@@ -34,9 +39,9 @@ export async function createReport({
   is_embedded_at_local: boolean;
   enable_source_link: boolean;
   local_llm_address?: string;
-}): Promise<void> {
+}): Promise<CreateReportResult> {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_API_BASEPATH}/admin/reports`, {
+    const response = await fetch(`${getApiBaseUrl()}/admin/reports`, {
       method: "POST",
       headers: {
         "x-api-key": process.env.NEXT_PUBLIC_ADMIN_API_KEY || "",
@@ -61,11 +66,11 @@ export async function createReport({
     });
 
     if (!response.ok) {
-      throw new Error(response.statusText);
+      return { success: false, error: response.statusText };
     }
 
-    return;
+    return { success: true };
   } catch (error) {
-    throw Error("レポート作成に失敗しました");
+    return { success: false, error: "レポート作成に失敗しました" };
   }
 }

--- a/client-admin/app/create/api/report.ts
+++ b/client-admin/app/create/api/report.ts
@@ -1,6 +1,5 @@
 import type { CsvData } from "../parseCsv";
 import type { PromptSettings } from "../types";
-import { handleApiError } from "../utils/error-handler";
 
 /**
  * レポート作成APIを呼び出す
@@ -67,6 +66,6 @@ export async function createReport({
 
     return;
   } catch (error) {
-    throw handleApiError(error, "レポート作成に失敗しました");
+    throw Error("レポート作成に失敗しました");
   }
 }

--- a/client-admin/app/create/page.tsx
+++ b/client-admin/app/create/page.tsx
@@ -5,7 +5,7 @@ import { toaster } from "@/components/ui/toaster";
 import { Box, Button, Field, HStack, Heading, Presence, Tabs, Text, VStack, useDisclosure } from "@chakra-ui/react";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
-import { createReport } from "./api/report";
+import { createReport } from "./api/createReport";
 import { AISettingsSection } from "./components/AISettingsSection";
 import { BasicInfoSection } from "./components/BasicInfoSection";
 import { CsvFileTab } from "./components/CsvFileTab";
@@ -18,7 +18,6 @@ import { useClusterSettings } from "./hooks/useClusterSettings";
 import { useInputData } from "./hooks/useInputData";
 import { usePromptSettings } from "./hooks/usePromptSettings";
 import { type CsvData, parseCsv } from "./parseCsv";
-import { showErrorToast } from "./utils/error-handler";
 import { validateFormValues } from "./utils/validation";
 
 /**
@@ -150,26 +149,26 @@ export default function Page() {
       return;
     }
 
-    try {
-      const promptData = promptSettings.getPromptSettings();
+    const promptData = promptSettings.getPromptSettings();
 
-      await createReport({
-        input: basicInfo.input,
-        question: basicInfo.question,
-        intro: basicInfo.intro,
-        comments,
-        cluster: [clusterSettings.clusterLv1, clusterSettings.clusterLv2],
-        provider: aiSettings.provider,
-        model: aiSettings.model,
-        workers: aiSettings.workers,
-        prompt: promptData,
-        is_pubcom: aiSettings.isPubcomMode,
-        inputType: inputData.inputType,
-        is_embedded_at_local: aiSettings.isEmbeddedAtLocal,
-        enable_source_link: aiSettings.enableSourceLink,
-        local_llm_address: aiSettings.provider === "local" ? aiSettings.localLLMAddress : undefined,
-      });
+    const result = await createReport({
+      input: basicInfo.input,
+      question: basicInfo.question,
+      intro: basicInfo.intro,
+      comments,
+      cluster: [clusterSettings.clusterLv1, clusterSettings.clusterLv2],
+      provider: aiSettings.provider,
+      model: aiSettings.model,
+      workers: aiSettings.workers,
+      prompt: promptData,
+      is_pubcom: aiSettings.isPubcomMode,
+      inputType: inputData.inputType,
+      is_embedded_at_local: aiSettings.isEmbeddedAtLocal,
+      enable_source_link: aiSettings.enableSourceLink,
+      local_llm_address: aiSettings.provider === "local" ? aiSettings.localLLMAddress : undefined,
+    });
 
+    if (result.success) {
       toaster.create({
         duration: 5000,
         type: "success",
@@ -177,11 +176,15 @@ export default function Page() {
       });
 
       router.replace("/");
-    } catch (e) {
-      showErrorToast(toaster, e, "レポート作成に失敗しました");
-    } finally {
-      setLoading(false);
+    } else {
+      toaster.create({
+        type: "error",
+        title: "レポート作成に失敗しました",
+        description: result.error,
+      });
     }
+
+    setLoading(false);
   };
 
   // メインコンポーネントのレンダリング


### PR DESCRIPTION

# 変更の概要
- client-admin でレポートを作成するリクエストを Server Functions で実行するようにしました
  - API キーがブラウザに露出しているのを改善するため

# スクリーンショット
- UI の変更はありません

# 変更の背景
- API キーがブラウザに露出しているため

# 関連Issue
- https://github.com/digitaldemocracy2030/kouchou-ai/issues/547

# 動作確認の結果
<!-- 実装者は動作確認の結果を記載してください（例: レポート作成を実行し、正常にレポートが作成されることを確認した） 複数の動作確認を行った場合は、それぞれの結果を記載してください -->

- レポートの作成ができること
- レポートを作成するリクエストに API key が乗っていないこと

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

# マージ前のチェックリスト（レビュアーがマージ前に確認してください）
- [x] CIが全て通過している
- [ ] 単体テストが実装されているか
- [x] 今回実装した機能および影響を受けると思われる機能について、適切な動作確認が行われているかを確認する。


動作確認の項目については、実装者による動作確認のケースが適切かを確認してください。
必要に応じてレビュアー自身による動作確認も歓迎します（必須ではありません）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * レポート作成時のエラーハンドリングが改善され、失敗時に明確なエラーメッセージが表示されるようになりました。

* **リファクタリング**
  * レポート作成処理の結果判定が例外処理から戻り値による判定に変更され、操作後のフィードバックがより分かりやすくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->