### PR TITLE
[api] レポート管理画面の意見グループ数の表記を変更する

### DIFF
--- a/server/src/services/report_status.py
+++ b/server/src/services/report_status.py
@@ -263,4 +263,4 @@ def add_analysis_data(report: Report) -> Report:
 
 
 def get_cluster_num(result: dict) -> int:
-    return sum(1 for c in result.get("clusters", []) if c.get("level") == 2)
+    return sum(1 for c in result.get("clusters", []) if c.get("level") == 1)

--- a/server/tests/services/test_report_status.py
+++ b/server/tests/services/test_report_status.py
@@ -194,7 +194,7 @@ class TestAddAnalysisData:
         assert updated.analysis is not None
         assert updated.analysis.comment_num == 150
         assert updated.analysis.arguments_num == 3
-        assert updated.analysis.cluster_num == 2  # level 2 のみ
+        assert updated.analysis.cluster_num == 1  # level 1 のみ
 
     @patch("src.services.report_status.settings")
     def test_add_analysis_data_file_not_found(self, mock_settings, ready_report):


### PR DESCRIPTION
# 変更の概要
- 管理画面の意見グループの数値を分析 UI の左の数値に変更しました

# スクリーンショット
<img width="781" height="268" alt="image" src="https://github.com/user-attachments/assets/13705369-2aeb-448a-b7d5-41d9a11f42db" />

<img width="1058" height="183" alt="image" src="https://github.com/user-attachments/assets/b28ca6c6-2bd1-43c9-b7d1-abbcce288c79" />


# 変更の背景
- 最終的な意見グループ数は分析 UI の右の数値を想定していたが、実際は左の数値だった

# 関連Issue
- fix: https://github.com/digitaldemocracy2030/kouchou-ai/issues/687

# 動作確認の結果
<!-- 実装者は動作確認の結果を記載してください（例: レポート作成を実行し、正常にレポートが作成されることを確認した） 複数の動作確認を行った場合は、それぞれの結果を記載してください -->

- 管理画面の意見グループの数値を分析 UI の右の数値になっていること

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

# マージ前のチェックリスト（レビュアーがマージ前に確認してください）
- [x] CIが全て通過している
- [x] 単体テストが実装されているか
- [x] 今回実装した機能および影響を受けると思われる機能について、適切な動作確認が行われているかを確認する。


動作確認の項目については、実装者による動作確認のケースが適切かを確認してください。
必要に応じてレビュアー自身による動作確認も歓迎します（必須ではありません）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * クラスター数の集計基準がレベル2からレベル1に変更され、正しいクラスター数が表示されるようになりました。

* **テスト**
  * クラスター数の判定基準変更に伴い、関連するテストケースの期待値が更新されました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->