### PR TITLE
docs: ビルド結果コピー時にドットファイルも含めるよう修正

### DIFF
--- a/docs/github-pages-hosting.md
+++ b/docs/github-pages-hosting.md
@@ -62,7 +62,7 @@ make build && make client-build-static
 
 ```bash
 # ビルド結果をコピー
-cp -r out/* /path/to/kouchou-ai-reports/
+cp -r out/. /path/to/kouchou-ai-reports/
 ```
 
 **注意**: `out`ディレクトリは毎回のビルドで削除されるため、`.git`ディレクトリも削除されてしまいます。そのため、別のディレクトリにリポジトリをクローンしておき、そこにビルド結果をコピーする方法を推奨します。


### PR DESCRIPTION
# 変更の概要
静的エクスポートをするときに.nojekyllファイルも生成しているが、以前のコマンドではコピーできていないので、修正。

# スクリーンショット
- UIの変更を伴う場合は、変更前後のスクリーンショットもしくはgif画像をこちらに記載してください

# 変更の背景
.nojekyllがコピーできずに、ドキュメント通りに実行してもGitHub Pagesでうまく表示できない問題が発生している。

# 関連Issue
[#693](https://github.com/digitaldemocracy2030/kouchou-ai/issues/693)

# 動作確認の結果
変更したコマンドを用いてGitHub Pagesで公開できることを確認した

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

# マージ前のチェックリスト（レビュアーがマージ前に確認してください）
- [ ] CIが全て通過している
- [ ] 単体テストが実装されているか
- [ ] 今回実装した機能および影響を受けると思われる機能について、適切な動作確認が行われているかを確認する。


動作確認の項目については、実装者による動作確認のケースが適切かを確認してください。
必要に応じてレビュアー自身による動作確認も歓迎します（必須ではありません）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * GitHub Pagesへのホスティング手順にて、ビルド出力ファイルのコピー方法を修正し、隠しファイルも含めてコピーされるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->