### PR TITLE
[FEATURE]ハイフンで終わるIDが受理されないことを注意書きやエラーで知らせたい

### DIFF
--- a/client-admin/app/create/components/BasicInfoSection.tsx
+++ b/client-admin/app/create/components/BasicInfoSection.tsx
@@ -7,7 +7,8 @@ export function BasicInfoSection({
   input,
   question,
   intro,
-  isIdValid,
+  isReportIdValid,
+  reportIdErrorMessage,
   onIdChange,
   onQuestionChange,
   onIntroChange,
@@ -15,7 +16,8 @@ export function BasicInfoSection({
   input: string;
   question: string;
   intro: string;
-  isIdValid: boolean;
+  isReportIdValid: boolean;
+  reportIdErrorMessage: string;
   onIdChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onQuestionChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onIntroChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
@@ -49,13 +51,13 @@ export function BasicInfoSection({
           value={input}
           onChange={onIdChange}
           placeholder="例：example"
-          aria-invalid={!isIdValid}
-          borderColor={!isIdValid ? "red.300" : undefined}
-          _hover={!isIdValid ? { borderColor: "red.400" } : undefined}
+          aria-invalid={!isReportIdValid}
+          borderColor={!isReportIdValid ? "red.300" : undefined}
+          _hover={!isReportIdValid ? { borderColor: "red.400" } : undefined}
         />
-        {!isIdValid && (
+        {!isReportIdValid && (
           <Text color="red.500" fontSize="sm" mt={1}>
-            IDは英小文字、数字、ハイフンのみ使用できます
+            {reportIdErrorMessage}
           </Text>
         )}
         <Field.HelperText>英字小文字と数字とハイフンのみ(URLで利用されます)</Field.HelperText>

--- a/client-admin/app/create/hooks/useBasicInfo.ts
+++ b/client-admin/app/create/hooks/useBasicInfo.ts
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { isValidId } from "../utils/validation";
+import { validateReportId } from "../utils/validation";
 
 /**
  * 基本情報を管理するカスタムフック
@@ -9,7 +9,8 @@ export function useBasicInfo() {
   const [input, setInput] = useState<string>(crypto.randomUUID());
   const [question, setQuestion] = useState<string>("");
   const [intro, setIntro] = useState<string>("");
-  const [isIdValid, setIsIdValid] = useState<boolean>(true);
+  const [isReportIdValid, setIsReportIdValid] = useState<boolean>(true);
+  const [reportIdErrorMessage, setReportIdErrorMessage] = useState<string>("");
 
   /**
    * ID変更時のハンドラー
@@ -17,7 +18,9 @@ export function useBasicInfo() {
   const handleIdChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newId = e.target.value;
     setInput(newId);
-    setIsIdValid(isValidId(newId));
+    const reportIdValidation = validateReportId(newId);
+    setIsReportIdValid(reportIdValidation.isValid);
+    setReportIdErrorMessage(reportIdValidation.errorMessage || "");
   };
 
   /**
@@ -41,14 +44,16 @@ export function useBasicInfo() {
     setInput(crypto.randomUUID());
     setQuestion("");
     setIntro("");
-    setIsIdValid(true);
+    setIsReportIdValid(true);
+    setReportIdErrorMessage("");
   };
 
   return {
     input,
     question,
     intro,
-    isIdValid,
+    isReportIdValid,
+    reportIdErrorMessage,
     handleIdChange,
     handleQuestionChange,
     handleIntroChange,

--- a/client-admin/app/create/page.tsx
+++ b/client-admin/app/create/page.tsx
@@ -202,7 +202,8 @@ export default function Page() {
             input={basicInfo.input}
             question={basicInfo.question}
             intro={basicInfo.intro}
-            isIdValid={basicInfo.isIdValid}
+            isReportIdValid={basicInfo.isReportIdValid}
+            reportIdErrorMessage={basicInfo.reportIdErrorMessage}
             onIdChange={basicInfo.handleIdChange}
             onQuestionChange={basicInfo.handleQuestionChange}
             onIntroChange={basicInfo.handleIntroChange}

--- a/client-admin/app/create/utils/validation.ts
+++ b/client-admin/app/create/utils/validation.ts
@@ -9,6 +9,35 @@ export function isValidId(id: string): boolean {
 }
 
 /**
+ * レポートIDのバリデーション
+ * @param id バリデーション対象のレポートID
+ * @returns バリデーション結果とエラーメッセージ
+ */
+export function validateReportId(id: string): { isValid: boolean; errorMessage?: string } {
+  if (id.length === 0) {
+    return { isValid: false, errorMessage: "IDを入力してください" };
+  }
+
+  if (id.length > 255) {
+    return { isValid: false, errorMessage: "IDは255文字以内で入力してください" };
+  }
+
+  if (!/^[a-z0-9-]+$/.test(id)) {
+    return { isValid: false, errorMessage: "IDは英小文字、数字、ハイフンのみ使用できます" };
+  }
+
+  if (id.startsWith('-')) {
+    return { isValid: false, errorMessage: "IDはハイフンで始めることができません" };
+  }
+
+  if (id.endsWith('-')) {
+    return { isValid: false, errorMessage: "IDはハイフンで終わることができません" };
+  }
+
+  return { isValid: true };
+}
+
+/**
  * フォーム入力値のバリデーション
  * @param values バリデーション対象の値
  * @returns バリデーション結果と、エラーメッセージ


### PR DESCRIPTION
# 変更の概要
https://github.com/digitaldemocracy2030/kouchou-ai/issues/692

既存のバリデーションロジックにおいて、ハイフン始まり / 終わり に対する
バリデーションメッセージの表示がなかったので表示するようにしました

# スクリーンショット

https://github.com/user-attachments/assets/9c54d566-e678-4ddb-8fe8-cf809796ceb2


# 変更の背景
- ここに変更が必要となった背景を記載してください

# 関連Issue
関連するIssueのリンクをこちらに記載してください

# 動作確認の結果
<!-- 実装者は動作確認の結果を記載してください（例: レポート作成を実行し、正常にレポートが作成されることを確認した） 複数の動作確認を行った場合は、それぞれの結果を記載してください -->

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [ ] CLAの内容を読み、同意しました

# マージ前のチェックリスト（レビュアーがマージ前に確認してください）
- [ ] CIが全て通過している
- [ ] 単体テストが実装されているか
- [ ] 今回実装した機能および影響を受けると思われる機能について、適切な動作確認が行われているかを確認する。


動作確認の項目については、実装者による動作確認のケースが適切かを確認してください。
必要に応じてレビュアー自身による動作確認も歓迎します（必須ではありません）。