### PR TITLE
client開発環境が正しく動くように修正

### DIFF
--- a/client-admin/app/_components/ReportCard/NumberDisplay.tsx
+++ b/client-admin/app/_components/ReportCard/NumberDisplay.tsx
@@ -1,12 +1,15 @@
 import { Text } from "@chakra-ui/react";
 
 type NumberDisplayProps = {
-  value: number;
+  value: number | undefined;
   textStyle?: string;
   textAlign?: "start" | "end" | "left" | "right" | "center" | "justify" | "match-parent";
 };
 
-function formatNumber(value: number): string {
+function formatNumber(value: number | undefined): string {
+  if (value === undefined) {
+    return "-";
+  }
   if (value >= 1000000) {
     return `${Math.floor(value / 1000000)}M`;
   }

--- a/client-admin/app/_components/ReportCard/ReportCard.tsx
+++ b/client-admin/app/_components/ReportCard/ReportCard.tsx
@@ -50,13 +50,13 @@ function ReportDataAndActions({ report }: Props) {
               </IconButton>
             </GridItem>
             <GridItem>
-              <NumberDisplay value={report.analysis.commentNum} />
+              <NumberDisplay value={report.analysis?.commentNum} />
             </GridItem>
             <GridItem>
-              <NumberDisplay value={report.analysis.argumentsNum} />
+              <NumberDisplay value={report.analysis?.argumentsNum} />
             </GridItem>
             <GridItem>
-              <NumberDisplay value={report.analysis.clusterNum} />
+              <NumberDisplay value={report.analysis?.clusterNum} />
             </GridItem>
             <GridItem>
               <TokenUsage report={report} />

--- a/client-admin/app/_components/ReportCard/Visibility/Visibility.tsx
+++ b/client-admin/app/_components/ReportCard/Visibility/Visibility.tsx
@@ -36,6 +36,8 @@ const iconStyles = {
 
 export function Visibility({ report }: Props) {
   const router = useRouter();
+  const visibility = report.visibility || 'private'; // fallback to 'private'
+  
   return (
     <MenuRoot
       onSelect={async (e) => {
@@ -58,7 +60,7 @@ export function Visibility({ report }: Props) {
         <IconButton
           size="lg"
           border="1px solid"
-          {...iconStyles[report.visibility]}
+          {...iconStyles[visibility]}
           _icon={{
             w: 5,
             h: 5,
@@ -67,7 +69,7 @@ export function Visibility({ report }: Props) {
             shadow: "inset 0 0 0 44px rgba(0, 0, 0, 0.06)",
           }}
         >
-          {iconStyles[report.visibility].icon}
+          {iconStyles[visibility].icon}
         </IconButton>
       </MenuTrigger>
       <Portal>

--- a/client/.env-sample
+++ b/client/.env-sample
@@ -1,4 +1,5 @@
 NEXT_PUBLIC_API_BASEPATH="http://localhost:8000"
+API_BASEPATH="http://localhost:8000"
 NEXT_PUBLIC_PUBLIC_API_KEY="xxxxxxxxxx"
 NEXT_PUBLIC_SITE_URL="http://localhost:3000"
 NEXT_PUBLIC_GA_MEASUREMENT_ID=""


### PR DESCRIPTION
# 変更の概要
`README.md` の "[client の開発環境の構築手順](https://github.com/digitaldemocracy2030/kouchou-ai?tab=readme-ov-file#client-%E3%81%AE%E9%96%8B%E7%99%BA%E7%92%B0%E5%A2%83%E3%81%AE%E6%A7%8B%E7%AF%89%E6%89%8B%E9%A0%86)" が正しく動くように修正しました。

**client**
- `client/entrypoint.sh` と同様に `API_BASEURL` 環境変数を `client/.env.sample` に追加

**client-admin**
- dummy APIからのデータが不完全だったので、不完全データに対応できるよう変更
    - Optinal Chainingで `report.analysis` があるかどうか確認、ない場合はレポートの コメント/意見/意見グループが`-`と表示される
    - レポートのデフォルト公開設定を`private` に変更 

必要であれば dummy dataも更新します

# 変更の背景
- clientの開発環境を構築しようとしたら予期せぬエラーがあったので修正

# 関連Issue
#712 

# 動作確認の結果
デフォルト値が設定されたdummy dataレポート
<img width="1067" height="370" alt="image" src="https://github.com/user-attachments/assets/453c4c26-c69f-4565-bb0b-ea9c317e7d16" />

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

# マージ前のチェックリスト（レビュアーがマージ前に確認してください）
- [ ] CIが全て通過している
- [ ] 単体テストが実装されているか
- [ ] 今回実装した機能および影響を受けると思われる機能について、適切な動作確認が行われているかを確認する。


動作確認の項目については、実装者による動作確認のケースが適切かを確認してください。
必要に応じてレビュアー自身による動作確認も歓迎します（必須ではありません）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- バグ修正
  - NumberDisplay が未定義の値を受け取り「-」を表示。大きな数値のフォーマットは従来どおり。
  - ReportCard の分析値取得をオプショナルチェイニング化し、analysis 未定義でもランタイムエラーを防止。
  - 可視性アイコンは未設定時に private を既定値として表示し、表示不整合を回避。

- ドキュメント
  - client/.env-sample に API_BASEPATH を追加し、ローカル設定例を明確化。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->