### PR TITLE
fix(admin): Add cluster settings for plugin imports

### DIFF
--- a/apps/admin/app/create/page.tsx
+++ b/apps/admin/app/create/page.tsx
@@ -8,6 +8,7 @@ import { useState } from "react";
 import { createReport } from "./api/createReport";
 import { AISettingsSection } from "./components/AISettingsSection";
 import { BasicInfoSection } from "./components/BasicInfoSection";
+import { ClusterSettingsSection } from "./components/ClusterSettingsSection";
 import { CsvFileTab } from "./components/CsvFileTab";
 import { EnvironmentCheckDialog } from "./components/EnvironmentCheckDialog/EnvironmentCheckDialog";
 import { PluginTab } from "./components/PluginTab";
@@ -38,6 +39,8 @@ export default function Page() {
   const aiSettings = useAISettings();
   const inputData = useInputData(clusterSettings.setRecommended);
   const pluginData = usePluginData(clusterSettings.setRecommended);
+  const activePluginId = inputData.inputType.startsWith("plugin:") ? inputData.inputType.replace("plugin:", "") : null;
+  const activePluginState = activePluginId ? pluginData.getPluginState(activePluginId) : undefined;
 
   /**
    * タブ切り替え時の処理
@@ -347,6 +350,17 @@ export default function Page() {
                     />
                   </Presence>
                 ))}
+
+                {inputData.inputType.startsWith("plugin:") && activePluginState?.imported && (
+                  <ClusterSettingsSection
+                    clusterLv1={clusterSettings.clusterLv1}
+                    clusterLv2={clusterSettings.clusterLv2}
+                    recommendedClusters={clusterSettings.recommendedClusters}
+                    autoAdjusted={clusterSettings.autoAdjusted}
+                    onLv1Change={clusterSettings.handleLv1Change}
+                    onLv2Change={clusterSettings.handleLv2Change}
+                  />
+                )}
               </Box>
             </Tabs.Root>
           </Field.Root>


### PR DESCRIPTION
## Summary

プラグイン（YouTube等）でデータをインポートした際に、クラスタ設定セクションが表示されない問題を修正しました。

CSVアップロード時と同様に、プラグインでインポート完了後にクラスタ数（Lv1/Lv2）を調整できるようになります。

## Changes

- プラグインタブでインポート完了後に `ClusterSettingsSection` を表示
- `activePluginId` と `activePluginState` を追加してプラグインの状態を追跡

## Test plan

- [x] YouTube プラグイン等でデータをインポート
- [x] インポート完了後にクラスタ設定セクションが表示されることを確認
- [x] クラスタ数を変更してレポート作成が成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能

* **プラグイン設定の拡張**
  * プラグイン導入時にクラスター設定が構成できるようになりました。プラグインデータに対するクラスター関連の設定オプションがUI上で利用可能になります。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->