### PR TITLE
feat(admin): レポート可視性アイコンにツールチップを追加

### DIFF
--- a/apps/admin/app/_components/PageContent.tsx
+++ b/apps/admin/app/_components/PageContent.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
+import { Tooltip } from "@/components/ui/tooltip";
 import type { Report } from "@/type";
 import { Box, Flex, HStack, Heading, Icon, Text, VStack } from "@chakra-ui/react";
 import { Eye, EyeClosedIcon, LockKeyhole, Plus } from "lucide-react";
@@ -29,30 +30,41 @@ export function PageContent({ reports }: Props) {
         <Flex justifyContent="space-between">
           <Heading textStyle="heading/xl">レポート管理</Heading>
           <Flex gap="3">
-            <VStack gap="2" w="88px" h="80px" bg="white" justifyContent="center">
-              <Icon color="font.public">
-                <Eye />
-              </Icon>
-              <Text textStyle="body/lg/bold" lineHeight="1.38">
-                {counts.public}
-              </Text>
-            </VStack>
-            <VStack gap="2" w="88px" h="80px" bg="white" justifyContent="center">
-              <Icon color="font.limitedPublic">
-                <LockKeyhole />
-              </Icon>
-              <Text textStyle="body/lg/bold" lineHeight="1.38">
-                {counts.unlisted}
-              </Text>
-            </VStack>
-            <VStack gap="2" w="88px" h="80px" bg="white" justifyContent="center">
-              <Icon color="font.error">
-                <EyeClosedIcon />
-              </Icon>
-              <Text textStyle="body/lg/bold" lineHeight="1.38">
-                {counts.private}
-              </Text>
-            </VStack>
+            <Tooltip showArrow openDelay={300} closeDelay={100} content={<Text textStyle="body/sm/bold">公開</Text>}>
+              <VStack gap="2" w="88px" h="80px" bg="white" justifyContent="center">
+                <Icon color="font.public">
+                  <Eye />
+                </Icon>
+                <Text textStyle="body/lg/bold" lineHeight="1.38">
+                  {counts.public}
+                </Text>
+              </VStack>
+            </Tooltip>
+            <Tooltip
+              showArrow
+              openDelay={300}
+              closeDelay={100}
+              content={<Text textStyle="body/sm/bold">限定公開</Text>}
+            >
+              <VStack gap="2" w="88px" h="80px" bg="white" justifyContent="center">
+                <Icon color="font.limitedPublic">
+                  <LockKeyhole />
+                </Icon>
+                <Text textStyle="body/lg/bold" lineHeight="1.38">
+                  {counts.unlisted}
+                </Text>
+              </VStack>
+            </Tooltip>
+            <Tooltip showArrow openDelay={300} closeDelay={100} content={<Text textStyle="body/sm/bold">非公開</Text>}>
+              <VStack gap="2" w="88px" h="80px" bg="white" justifyContent="center">
+                <Icon color="font.error">
+                  <EyeClosedIcon />
+                </Icon>
+                <Text textStyle="body/lg/bold" lineHeight="1.38">
+                  {counts.private}
+                </Text>
+              </VStack>
+            </Tooltip>
           </Flex>
         </Flex>
       </Box>

--- a/apps/admin/app/_components/ReportCard/ActionMenu/ActionMenu.tsx
+++ b/apps/admin/app/_components/ReportCard/ActionMenu/ActionMenu.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import { downloadFile } from "@/app/utils/downloadFile";
-import { MenuContent, MenuItem, MenuPositioner, MenuRoot, MenuTrigger, MenuTriggerItem } from "@/components/ui/menu";
+import { MenuContent, MenuItem, MenuRoot, MenuTrigger, MenuTriggerItem } from "@/components/ui/menu";
 import { toaster } from "@/components/ui/toaster";
 import type { Report } from "@/type";
-import { IconButton, Portal } from "@chakra-ui/react";
+import { IconButton } from "@chakra-ui/react";
 import { Copy, Ellipsis, Eye, FileSpreadsheet, FileText, FolderDown, Pencil, TextIcon, Trash2 } from "lucide-react";
 import { type Dispatch, type SetStateAction, useState } from "react";
 import { useRouter } from "next/navigation";
@@ -47,184 +47,178 @@ export function ActionMenu({
             <Ellipsis />
           </IconButton>
         </MenuTrigger>
-        <Portal>
-          <MenuContent>
-            {(report.status === "ready" || report.status === "error") && (
-              <MenuItem
-                value="duplicate"
-                textStyle="body/md/bold"
-                onClick={() => {
-                  setIsOpen(false);
-                  router.push(`/reuse/${report.slug}`);
-                }}
-                _icon={{
-                  w: 5,
-                  h: 5,
-                }}
-              >
-                <Copy />
-                再利用
-              </MenuItem>
-            )}
+        <MenuContent>
+          <MenuItem
+            value="edit"
+            textStyle="body/md/bold"
+            onClick={() => {
+              setIsEditDialogOpen(true);
+            }}
+            _icon={{
+              w: 5,
+              h: 5,
+            }}
+          >
+            <Pencil />
+            レポート名編集
+          </MenuItem>
+          {(report.status === "ready" || report.status === "error") && (
             <MenuItem
-              value="edit"
+              value="duplicate"
               textStyle="body/md/bold"
               onClick={() => {
-                setIsEditDialogOpen(true);
+                setIsOpen(false);
+                router.push(`/reuse/${report.slug}`);
               }}
               _icon={{
                 w: 5,
                 h: 5,
               }}
             >
-              <Pencil />
-              レポート名編集
+              <Copy />
+              再利用
             </MenuItem>
-            {report.status === "ready" && (
-              <MenuItem
-                value="edit-cluster"
+          )}
+          {report.status === "ready" && (
+            <MenuItem
+              value="edit-cluster"
+              textStyle="body/md/bold"
+              onClick={() => {
+                setIsClusterEditDialogOpen(true);
+              }}
+              _icon={{
+                w: 5,
+                h: 5,
+              }}
+            >
+              <TextIcon />
+              意見グループ編集
+            </MenuItem>
+          )}
+          {report.status === "ready" && (
+            <MenuItem
+              value="visualization-config"
+              textStyle="body/md/bold"
+              onClick={() => {
+                setIsVisualizationConfigDialogOpen(true);
+              }}
+              _icon={{
+                w: 5,
+                h: 5,
+              }}
+            >
+              <Eye />
+              可視化設定
+            </MenuItem>
+          )}
+          {report.status === "ready" && report.isPubcom && (
+            <MenuRoot positioning={{ placement: "right-start", gutter: 4 }}>
+              <MenuTriggerItem
+                value="csv-download-list"
                 textStyle="body/md/bold"
-                onClick={() => {
-                  setIsClusterEditDialogOpen(true);
-                }}
                 _icon={{
                   w: 5,
                   h: 5,
                 }}
               >
-                <TextIcon />
-                意見グループ編集
-              </MenuItem>
-            )}
-            {report.status === "ready" && (
-              <MenuItem
-                value="visualization-config"
-                textStyle="body/md/bold"
-                onClick={() => {
-                  setIsVisualizationConfigDialogOpen(true);
-                }}
-                _icon={{
-                  w: 5,
-                  h: 5,
-                }}
-              >
-                <Eye />
-                可視化設定
-              </MenuItem>
-            )}
-            {report.status === "ready" && report.isPubcom && (
-              <MenuRoot positioning={{ placement: "right-start", gutter: 4 }}>
-                <MenuTriggerItem
-                  value="csv-download-list"
+                <FileSpreadsheet />
+                CSVダウンロード
+              </MenuTriggerItem>
+              <MenuContent>
+                <MenuItem
+                  value="csv-download"
                   textStyle="body/md/bold"
-                  _icon={{
-                    w: 5,
-                    h: 5,
+                  onClick={async () => {
+                    const result = await csvDownload(report.slug);
+                    if (result.success) {
+                      downloadFile(result);
+                    } else {
+                      toaster.create({
+                        title: "エラー",
+                        type: "error",
+                        description: result.error,
+                      });
+                    }
                   }}
                 >
-                  <FileSpreadsheet />
                   CSVダウンロード
-                </MenuTriggerItem>
-                <Portal>
-                  <MenuPositioner>
-                    <MenuContent>
-                      <MenuItem
-                        value="csv-download"
-                        textStyle="body/md/bold"
-                        onClick={async () => {
-                          const result = await csvDownload(report.slug);
-                          if (result.success) {
-                            downloadFile(result);
-                          } else {
-                            toaster.create({
-                              title: "エラー",
-                              type: "error",
-                              description: result.error,
-                            });
-                          }
-                        }}
-                      >
-                        CSVダウンロード
-                      </MenuItem>
-                      <MenuItem
-                        value="csv-download-for-windows"
-                        textStyle="body/md/bold"
-                        onClick={async () => {
-                          const result = await csvDownloadForWindows(report.slug);
-                          if (result.success) {
-                            downloadFile(result);
-                          } else {
-                            toaster.create({
-                              title: "エラー",
-                              type: "error",
-                              description: result.error,
-                            });
-                          }
-                        }}
-                      >
-                        CSV for Excelダウンロード
-                      </MenuItem>
-                    </MenuContent>
-                  </MenuPositioner>
-                </Portal>
-              </MenuRoot>
-            )}
-            {report.status === "ready" && (
-              <MenuItem
-                value="json-download"
-                textStyle="body/md/bold"
-                onClick={async () => {
-                  const result = await jsonDownload(report.slug);
-                  if (result.success) {
-                    downloadFile(result);
-                  } else {
-                    toaster.create({
-                      title: "エラー",
-                      type: "error",
-                      description: result.error,
-                    });
-                  }
-                }}
-                _icon={{
-                  w: 5,
-                  h: 5,
-                }}
-              >
-                <FileText />
-                JSONダウンロード
-              </MenuItem>
-            )}
+                </MenuItem>
+                <MenuItem
+                  value="csv-download-for-windows"
+                  textStyle="body/md/bold"
+                  onClick={async () => {
+                    const result = await csvDownloadForWindows(report.slug);
+                    if (result.success) {
+                      downloadFile(result);
+                    } else {
+                      toaster.create({
+                        title: "エラー",
+                        type: "error",
+                        description: result.error,
+                      });
+                    }
+                  }}
+                >
+                  CSV for Excelダウンロード
+                </MenuItem>
+              </MenuContent>
+            </MenuRoot>
+          )}
+          {report.status === "ready" && (
             <MenuItem
-              value="static-export"
+              value="json-download"
               textStyle="body/md/bold"
-              onClick={() => {
-                if (!isVisible) return;
-                exportStaticHTML([report.slug]);
+              onClick={async () => {
+                const result = await jsonDownload(report.slug);
+                if (result.success) {
+                  downloadFile(result);
+                } else {
+                  toaster.create({
+                    title: "エラー",
+                    type: "error",
+                    description: result.error,
+                  });
+                }
               }}
               _icon={{
                 w: 5,
                 h: 5,
               }}
-              disabled={!isVisible}
             >
-              <FolderDown />
-              HTML書き出し
+              <FileText />
+              JSONダウンロード
             </MenuItem>
-            <MenuItem
-              value="delete"
-              color="fg.error"
-              textStyle="body/md/bold"
-              _icon={{
-                w: 5,
-                h: 5,
-              }}
-              onClick={() => setIsOpen(true)}
-            >
-              <Trash2 />
-              削除
-            </MenuItem>
-          </MenuContent>
-        </Portal>
+          )}
+          <MenuItem
+            value="static-export"
+            textStyle="body/md/bold"
+            onClick={() => {
+              if (!isVisible) return;
+              exportStaticHTML([report.slug]);
+            }}
+            _icon={{
+              w: 5,
+              h: 5,
+            }}
+            disabled={!isVisible}
+          >
+            <FolderDown />
+            HTML書き出し
+          </MenuItem>
+          <MenuItem
+            value="delete"
+            color="fg.error"
+            textStyle="body/md/bold"
+            _icon={{
+              w: 5,
+              h: 5,
+            }}
+            onClick={() => setIsOpen(true)}
+          >
+            <Trash2 />
+            削除
+          </MenuItem>
+        </MenuContent>
       </MenuRoot>
       <DeleteDialog isOpen={isOpen} setIsOpen={setIsOpen} report={report} />
     </>

--- a/apps/admin/app/_components/ReportCard/Visibility/Visibility.tsx
+++ b/apps/admin/app/_components/ReportCard/Visibility/Visibility.tsx
@@ -4,7 +4,7 @@ import { MenuContent, MenuItem, MenuRoot, MenuTrigger } from "@/components/ui/me
 import { toaster } from "@/components/ui/toaster";
 import { Tooltip } from "@/components/ui/tooltip";
 import type { Report, ReportVisibility } from "@/type";
-import { IconButton, Portal } from "@chakra-ui/react";
+import { Box, IconButton } from "@chakra-ui/react";
 import { Eye, EyeClosedIcon, LockKeyhole } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
@@ -66,49 +66,49 @@ export function Visibility({ report }: Props) {
       }}
     >
       <Tooltip showArrow openDelay={300} closeDelay={100} content={iconStyles[visibility].text} disabled={isMenuOpen}>
-        <MenuTrigger asChild>
-          <IconButton
-            size="lg"
-            border="1px solid"
-            aria-label={iconStyles[visibility].ariaLabel}
-            {...iconStyles[visibility]}
-            _icon={{
-              w: 5,
-              h: 5,
-            }}
-            _hover={{
-              shadow: "inset 0 0 0 44px rgba(0, 0, 0, 0.06)",
-            }}
-          >
-            {iconStyles[visibility].icon}
-          </IconButton>
-        </MenuTrigger>
-      </Tooltip>
-      <Portal>
-        <MenuContent>
-          {Object.entries(iconStyles).map(([key, style]) => (
-            <MenuItem
-              key={key}
-              value={key}
-              color={style.color}
-              textStyle="body/md/bold"
+        <Box display="inline-flex">
+          <MenuTrigger asChild>
+            <IconButton
+              size="lg"
               border="1px solid"
-              borderColor="transparent"
+              aria-label={iconStyles[visibility].ariaLabel}
+              {...iconStyles[visibility]}
               _icon={{
                 w: 5,
                 h: 5,
               }}
               _hover={{
-                borderColor: style.borderColor,
-                bg: style.bg,
+                shadow: "inset 0 0 0 44px rgba(0, 0, 0, 0.06)",
               }}
             >
-              {style.icon}
-              {style.text}
-            </MenuItem>
-          ))}
-        </MenuContent>
-      </Portal>
+              {iconStyles[visibility].icon}
+            </IconButton>
+          </MenuTrigger>
+        </Box>
+      </Tooltip>
+      <MenuContent>
+        {Object.entries(iconStyles).map(([key, style]) => (
+          <MenuItem
+            key={key}
+            value={key}
+            color={style.color}
+            textStyle="body/md/bold"
+            border="1px solid"
+            borderColor="transparent"
+            _icon={{
+              w: 5,
+              h: 5,
+            }}
+            _hover={{
+              borderColor: style.borderColor,
+              bg: style.bg,
+            }}
+          >
+            {style.icon}
+            {style.text}
+          </MenuItem>
+        ))}
+      </MenuContent>
     </MenuRoot>
   );
 }

--- a/apps/admin/components/ui/tooltip.tsx
+++ b/apps/admin/components/ui/tooltip.tsx
@@ -13,10 +13,8 @@ export interface TooltipProps extends ChakraTooltip.RootProps {
 export const Tooltip = React.forwardRef<HTMLDivElement, TooltipProps>(function Tooltip(props, ref) {
   const { showArrow, children, disabled, portalled = true, content, contentProps, portalRef, ...rest } = props;
 
-  if (disabled) return children;
-
   return (
-    <ChakraTooltip.Root {...rest}>
+    <ChakraTooltip.Root {...rest} disabled={disabled}>
       <ChakraTooltip.Trigger asChild>{children}</ChakraTooltip.Trigger>
       <Portal disabled={!portalled} container={portalRef}>
         <ChakraTooltip.Positioner>


### PR DESCRIPTION
# 変更の概要
- 管理画面のレポートカードにある可視性アイコン（公開/限定公開/非公開）にマウスホバー時のツールチップを追加
- ツールチップには現在の可視性状態のテキスト（「公開」「限定公開」「非公開」）が表示される
- メニューが開いている間はツールチップを非表示にする制御を追加
- IconButtonに`aria-label`を追加してアクセシビリティを向上

# スクリーンショット
<img width="309" height="132" alt="image" src="https://github.com/user-attachments/assets/7368eccc-76ae-4f2a-abeb-f36504e8bbcc" />
<img width="149" height="153" alt="image" src="https://github.com/user-attachments/assets/1cae96ed-cb32-45db-917b-3c9f50621aaf" />


- ローカル環境で動作確認済み（ツールチップが正しく表示されることを確認）

# 変更の背景
アイコンだけでは意味がわからないユーザーがいるため、マウスホバー時にツールチップで説明を表示することでUXを改善する。

Slackでの依頼: https://dd2030.slack.com/archives/C08PRQVQWSE/p1770228861671249

# 関連Issue
なし

# 動作確認の結果
- ローカル環境でdummy-serverとadminアプリを起動し、以下を確認：
  - 可視性アイコンにマウスホバーするとツールチップが表示される
  - ツールチップに正しい可視性テキスト（「非公開」など）が表示される
  - メニューを開くとツールチップが消える

# レビュー時の確認ポイント
- ツールチップがホバー時に正しく表示されるか
- ツールチップとメニューの開閉が干渉しないか（メニューを開いた際にツールチップが消えるか）
- スクリーンリーダーで`aria-label`が正しく読み上げられるか

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

# マージ前のチェックリスト（レビュアーがマージ前に確認してください）
- [x] CIが全て通過している

---
Link to Devin run: https://app.devin.ai/sessions/0dcf4f55f28d439f9b6e0533fe174b0d
Requested by: NISHIO (@nishio)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 各レポート数ブロックにツールチップを追加し、可視性ラベルをホバーで表示。
  * アクションメニューに「レポート名編集」「再利用」「CSV/JSON/HTML出力」など新しい項目を追加（ダウンロード種別の選択やグループ化を含む）。
* **Refactor**
  * メニュー構造とツールチップの表示ロジックを整理し重複表示を回避。
  * ツールチップの振る舞いをルート側で制御するよう改善。
* **アクセシビリティ**
  * 各操作要素にaria-labelを追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->