### PR TITLE
public-viewer の turbopack root を明示して起動時ビルドを修正

### DIFF
--- a/apps/public-viewer/next.config.ts
+++ b/apps/public-viewer/next.config.ts
@@ -1,4 +1,5 @@
 import type { NextConfig } from "next";
+import path from "path";
 
 const isStaticExport = process.env.NEXT_PUBLIC_OUTPUT_MODE === "export";
 const BASE_PATH = process.env.NEXT_PUBLIC_STATIC_EXPORT_BASE_PATH || "";
@@ -10,6 +11,10 @@ const nextConfig: NextConfig = {
   output: isStaticExport ? "export" : undefined,
   distDir: isStaticExport ? DIST_DIR : ".next",
   trailingSlash: true,
+  turbopack: {
+    // Ensure Turbopack resolves the monorepo workspace root correctly.
+    root: path.join(__dirname, "../.."),
+  },
   experimental: {
     optimizePackageImports: ["@chakra-ui/react"],
   },


### PR DESCRIPTION
## 概要
- `apps/public-viewer/next.config.ts` に `turbopack.root` を明示して、モノレポのワークスペースルート解決に失敗する問題を回避します。

## 背景
- `public-viewer` の起動時 `next build` が Turbopack の root 推論に失敗し、コンテナが起動できずヘルスチェックがタイムアウトしていました。

## 影響
- Viewer の起動失敗を解消し、CI のヘルスチェックも通るようにします。

Fixes #783

## テスト
- 未実施（インフラ/設定変更）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **その他**
  * ビルドシステムの設定を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->