### PR TITLE
Azure Deployment のヘルスチェックを改善（public-viewer 起動遅延を許容）

### DIFF
--- a/.github/workflows/azure-deploy.yml
+++ b/.github/workflows/azure-deploy.yml
@@ -253,20 +253,19 @@ jobs:
           fi
 
           # リトライ付きヘルスチェック
-          RETRY_COUNT=6
+          # public-viewer は起動時に next build を実行するため、初回起動が数分かかる場合がある
+          RETRY_COUNT=15
           RETRY_INTERVAL=20
 
           for i in $(seq 1 $RETRY_COUNT); do
             echo "ヘルスチェック試行 $i/$RETRY_COUNT..."
-            api_ok=0
-            viewer_ok=0
-            if curl -f "https://$API_DOMAIN/" --max-time 10 > /dev/null 2>&1; then
-              api_ok=1
-            fi
-            if curl -f "https://$PUBLIC_VIEWER_DOMAIN/" --max-time 10 > /dev/null 2>&1; then
-              viewer_ok=1
-            fi
-            if [ "$api_ok" -eq 1 ] && [ "$viewer_ok" -eq 1 ]; then
+            api_code="$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "https://$API_DOMAIN/" || true)"
+            viewer_code="$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "https://$PUBLIC_VIEWER_DOMAIN/" || true)"
+            api_code="${api_code:-000}"
+            viewer_code="${viewer_code:-000}"
+            echo "  API=$api_code viewer=$viewer_code"
+
+            if [ "$api_code" -ge 200 ] && [ "$api_code" -lt 400 ] && [ "$viewer_code" -ge 200 ] && [ "$viewer_code" -lt 400 ]; then
               echo "✅ デプロイ成功: https://$API_DOMAIN"
               echo "✅ デプロイ成功: https://$PUBLIC_VIEWER_DOMAIN"
               exit 0
@@ -275,4 +274,10 @@ jobs:
           done
 
           echo "❌ ヘルスチェック失敗"
+          echo "API revision status:"
+          az containerapp revision list --name api --resource-group ${AZURE_RESOURCE_GROUP} \
+            --query "sort_by(@,&properties.createdTime)[-1].{name:name,health:properties.healthState,running:properties.runningState,details:properties.runningStateDetails}" -o json || true
+          echo "public-viewer revision status:"
+          az containerapp revision list --name public-viewer --resource-group ${AZURE_RESOURCE_GROUP} \
+            --query "sort_by(@,&properties.createdTime)[-1].{name:name,health:properties.healthState,running:properties.runningState,details:properties.runningStateDetails}" -o json || true
           exit 1


### PR DESCRIPTION
## 概要
Azure Deployment の「デプロイ確認」(ヘルスチェック) を、`public-viewer` の起動に時間がかかる場合でも false negative にならないように改善します。

## 背景
`public-viewer` は起動時に `next build` を実行するため、デプロイ直後に数分間 200 を返せないことがあります。
現状のリトライ回数 (6回) だと、実際にはその後正常起動しているのに CI 側が失敗扱いになるケースがありました。

## 変更内容
- リトライ回数を 6回 -> 15回 に増加
- 各試行で API / viewer の HTTP ステータスコードを表示
- 失敗時に API / public-viewer の最新 revision 状態 (health/running/details) を出力

## 期待する効果
- `public-viewer` の起動遅延による一時的なタイムアウトで CI が落ちにくくなる
- 失敗時の原因調査がログだけでしやすくなる


- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善点**
  * デプロイメント時のヘルスチェック機能を強化しました。リトライメカニズムを改善し、より堅牢なサービス検証機能を実装しました。エラー時の診断情報も拡張されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->