### PR TITLE
docs: Azure Container Apps 移行メモを実装に合わせて更新

### DIFF
--- a/docs/deployment/azure-migration-20260207.md
+++ b/docs/deployment/azure-migration-20260207.md
@@ -4,71 +4,75 @@
 - リソースグループ: `dd2030-kouchouai-demo-rg`
 - サブスクリプション: `kouchou-ai` (`079e8ef5-7461-407d-84b6-b4f37b9f31c1`)
 - Container Apps 環境: `kouchouai-demo-container-env`
+- 関連ドキュメント: `docs/refactoring/naming_convention.md`
 
-## nishioの作業
+## 目的
+- リファクタ後の命名規約に合わせて Azure 上の Container Apps 名を揃える
+- GitHub Actions `Azure Deployment` が失敗しない状態に戻す
 
-Azure環境のリファクタリング後の構成への変更について
+## 事前状況（問題）
+- Azure 側に旧名称の Container Apps しか存在しない:
+  - `api`, `client`, `client-admin`, `client-static-build`
+- リポジトリ側（Makefile / GitHub Actions）は新名称を前提:
+  - `public-viewer`, `admin`, `static-site-builder`
+- その結果、デプロイ時に `az containerapp show/update/secret set` が `... does not exist` で失敗する
 
-- 1: Azure環境 `c4jadmindd2030.onmicrosoft.com` へのアクセス権をもらい ​​https://portal.azure.com/#@c4jadmindd2030.onmicrosoft.com/resource/subscriptions/079e8ef5-7461-407d-84b6-b4f37b9f31c1/resourceGroups/dd2030-kouchouai-demo-rg/overview でリソースグループを見ることができるのを確認
- 
-- 2: az login --tenant c4jadmindd2030.onmicrosoft.com でCodexにログインさせる
-- 3: 作業(詳細は下記)
-- 4: GitHub ActionのAzure Deploymentをre-runしてsuccessするのを確認: https://github.com/digitaldemocracy2030/kouchou-ai/actions/runs/21740920722/job/62820695796
-- 5: 管理画面を確認、既存のレポートはStorageから復元されているようだ
-
-
-## 概要
-- 旧名称の Container Apps (`client`, `client-admin`, `client-static-build`) を新名称 (`public-viewer`, `admin`, `static-site-builder`) へ移行しました。
-- 既存の ACR イメージを使って新アプリを作成し、旧アプリのシークレットをコピーしました。
-- 新ドメインに合わせて環境変数を更新し、シークレット反映のため再起動しました。
-- 旧アプリは削除しました。
-
-## 発生原因
-- GitHub Actions と Makefile は新名称 (`public-viewer`, `admin`, `static-site-builder`) を前提にしていました。
-- Azure 側に旧名称 (`client*`) しか存在せず、`az containerapp show` などが `does not exist` で失敗していました。
-
-## 実施内容
-- 正しいテナント/サブスクリプションにログイン。
-- 新規 Container Apps を作成。
-- 旧アプリからシークレットを取得して新アプリへ登録。
-- 新ドメインを使うように環境変数を更新。
-- シークレット反映のため全アプリを再起動。
-- 旧アプリを削除。
-
-## 現在の状態
-- `api`: `https://api.wittyisland-cc57c95f.japaneast.azurecontainerapps.io`
-- `public-viewer`: `https://public-viewer.wittyisland-cc57c95f.japaneast.azurecontainerapps.io`
-- `admin`: `https://admin.wittyisland-cc57c95f.japaneast.azurecontainerapps.io`
-- `static-site-builder`: `https://static-site-builder.internal.wittyisland-cc57c95f.japaneast.azurecontainerapps.io`
-
-## 実行コマンド（マスク済み）
-代表的な実行内容のみ抜粋しています。値はすべてマスク済みです。
+## 実施した移行作業（Azure 側）
+### 1) ログイン
 
 ```bash
-# ログイン
 az login --tenant c4jadmindd2030.onmicrosoft.com
 az account set --subscription 079e8ef5-7461-407d-84b6-b4f37b9f31c1
+```
 
-# 現状確認
+### 2) 現状確認
+
+```bash
 az containerapp list -g dd2030-kouchouai-demo-rg -o table
+az containerapp env list -g dd2030-kouchouai-demo-rg -o table
+```
 
-# 新アプリ作成
+### 3) 新名称の Container Apps を作成
+既存の ACR イメージを使って新アプリを作成（旧アプリは残したまま）。
+
+```bash
 az containerapp create --name public-viewer --resource-group dd2030-kouchouai-demo-rg \
-  --environment kouchouai-demo-container-env --image dd2030kouchouai.azurecr.io/public-viewer:latest \
-  --registry-server dd2030kouchouai.azurecr.io --registry-username dd2030kouchouai --registry-password <acr-password> \
+  --environment kouchouai-demo-container-env \
+  --image dd2030kouchouai.azurecr.io/public-viewer:latest \
+  --registry-server dd2030kouchouai.azurecr.io \
+  --registry-username dd2030kouchouai \
+  --registry-password <acr-password> \
   --target-port 3000 --ingress external --min-replicas 1
 
 az containerapp create --name admin --resource-group dd2030-kouchouai-demo-rg \
-  --environment kouchouai-demo-container-env --image dd2030kouchouai.azurecr.io/admin:latest \
-  --registry-server dd2030kouchouai.azurecr.io --registry-username dd2030kouchouai --registry-password <acr-password> \
+  --environment kouchouai-demo-container-env \
+  --image dd2030kouchouai.azurecr.io/admin:latest \
+  --registry-server dd2030kouchouai.azurecr.io \
+  --registry-username dd2030kouchouai \
+  --registry-password <acr-password> \
   --target-port 4000 --ingress external --min-replicas 1
 
 az containerapp create --name static-site-builder --resource-group dd2030-kouchouai-demo-rg \
-  --environment kouchouai-demo-container-env --image dd2030kouchouai.azurecr.io/static-site-builder:latest \
-  --registry-server dd2030kouchouai.azurecr.io --registry-username dd2030kouchouai --registry-password <acr-password> \
+  --environment kouchouai-demo-container-env \
+  --image dd2030kouchouai.azurecr.io/static-site-builder:latest \
+  --registry-server dd2030kouchouai.azurecr.io \
+  --registry-username dd2030kouchouai \
+  --registry-password <acr-password> \
   --target-port 3200 --ingress internal --min-replicas 1
+```
 
-# シークレット設定（値は省略）
+### 4) シークレット移設（旧アプリ -> 新アプリ）
+注意:
+- `az containerapp secret list` はデフォルトで値を返さないため、コピー用途では `--show-values` が必須
+- `secret set` の後は **コンテナ再起動が必要**（Azure CLI が warning を出す）
+
+```bash
+# 旧アプリからシークレット値を取得（例）
+az containerapp secret list --name client --resource-group dd2030-kouchouai-demo-rg --show-values
+az containerapp secret list --name client-admin --resource-group dd2030-kouchouai-demo-rg --show-values
+az containerapp secret list --name api --resource-group dd2030-kouchouai-demo-rg --show-values
+
+# 新アプリへ設定（値はマスク）
 az containerapp secret set --name public-viewer --resource-group dd2030-kouchouai-demo-rg --secrets \
   public-api-key=<value> revalidate-secret=<value>
 
@@ -77,8 +81,14 @@ az containerapp secret set --name admin --resource-group dd2030-kouchouai-demo-r
 
 az containerapp secret set --name static-site-builder --resource-group dd2030-kouchouai-demo-rg --secrets \
   public-api-key=<value>
+```
 
-# 環境変数更新
+### 5) 環境変数の更新
+ポイント:
+- `secretref:` を使って secret を環境変数に紐付ける
+- `api` の `REVALIDATE_URL` は `public-viewer` の新 FQDN に合わせて更新
+
+```bash
 az containerapp update --name public-viewer --resource-group dd2030-kouchouai-demo-rg --set-env-vars \
   NEXT_PUBLIC_PUBLIC_API_KEY=secretref:public-api-key \
   NEXT_PUBLIC_API_BASEPATH=https://api.wittyisland-cc57c95f.japaneast.azurecontainerapps.io \
@@ -102,22 +112,72 @@ az containerapp update --name static-site-builder --resource-group dd2030-koucho
 az containerapp update --name api --resource-group dd2030-kouchouai-demo-rg --set-env-vars \
   REVALIDATE_URL=https://public-viewer.wittyisland-cc57c95f.japaneast.azurecontainerapps.io/api/revalidate \
   REVALIDATE_SECRET=secretref:revalidate-secret
+```
 
-# 再起動
-az containerapp update --name public-viewer --resource-group dd2030-kouchouai-demo-rg --min-replicas 0
-az containerapp update --name public-viewer --resource-group dd2030-kouchouai-demo-rg --min-replicas 1
-# admin / static-site-builder / api も同様
+### 6) 再起動（secret 反映）
 
-# 旧アプリ削除
+```bash
+for app in public-viewer admin static-site-builder api; do
+  az containerapp update --name "$app" --resource-group dd2030-kouchouai-demo-rg --min-replicas 0
+  sleep 5
+  az containerapp update --name "$app" --resource-group dd2030-kouchouai-demo-rg --min-replicas 1
+done
+```
+
+### 7) 旧アプリ削除
+旧名称の Container App は rename 不可のため削除。
+
+```bash
 az containerapp delete --name client --resource-group dd2030-kouchouai-demo-rg --yes
 az containerapp delete --name client-admin --resource-group dd2030-kouchouai-demo-rg --yes
 az containerapp delete --name client-static-build --resource-group dd2030-kouchouai-demo-rg --yes
 ```
 
-## フォローアップ推奨
-- GitHub Actions の `Azure Deployment` を再実行して、新ドメインを `NEXT_PUBLIC_*` に焼き込んだイメージを再ビルドしてください。
-- 必要に応じて `make azure-apply-policies` でヘルスチェック/ポリシーを適用してください（`.env.azure` が必要）。
+### 8) 動作確認
 
-## 注意点
-- シークレット値はログに出力せずに移行しています。
-- `static-site-builder` は内部向けのままです。
+```bash
+az containerapp list -g dd2030-kouchouai-demo-rg -o table
+curl -f "https://api.wittyisland-cc57c95f.japaneast.azurecontainerapps.io/" --max-time 15
+curl -f "https://public-viewer.wittyisland-cc57c95f.japaneast.azurecontainerapps.io/" --max-time 15
+```
+
+## 移行後に発生した問題と恒久対策（リポジトリ側）
+### public-viewer が stream timeout になる（起動できない）
+原因:
+- `apps/public-viewer/entrypoint.sh` が **起動時に `pnpm run build` を実行**する
+- その `next build` が Turbopack の workspace root 推論に失敗すると、コンテナが起動できず viewer がタイムアウトする
+
+対策（実装済み）:
+- PR #784: `apps/public-viewer/next.config.ts` に `turbopack.root` を明示（root 推論に依存しない）
+- PR #782: `apps/public-viewer/Dockerfile` の runner イメージに monorepo ルート情報（`package.json` / `pnpm-workspace.yaml` / `.npmrc`）をコピー
+- PR #782: `apps/public-viewer/entrypoint.sh` に `set -e` を入れて、ビルド失敗を即座にコンテナ失敗として扱う
+
+診断用コマンド:
+
+```bash
+az containerapp logs show --name public-viewer --resource-group dd2030-kouchouai-demo-rg --tail 200
+az containerapp revision list --name public-viewer --resource-group dd2030-kouchouai-demo-rg -o table
+```
+
+### CI のヘルスチェックが早すぎて false negative になる
+原因:
+- `public-viewer` は起動時に build するため、デプロイ直後は数分 200 を返せない場合がある（レポート数により変動）
+
+対策（実装済み）:
+- PR #785: `.github/workflows/azure-deploy.yml` のヘルスチェックを以下のように改善
+  - リトライ回数を増加（6回 -> 15回）
+  - 各試行で API/viewer の HTTP ステータスをログ出力
+  - 失敗時に最新 revision の health/running/details をログ出力
+
+## 現在の構成（2026-02-07 時点）
+- `api`: `https://api.wittyisland-cc57c95f.japaneast.azurecontainerapps.io`
+- `public-viewer`: `https://public-viewer.wittyisland-cc57c95f.japaneast.azurecontainerapps.io`
+- `admin`: `https://admin.wittyisland-cc57c95f.japaneast.azurecontainerapps.io`
+- `static-site-builder`（internal）: `https://static-site-builder.internal.wittyisland-cc57c95f.japaneast.azurecontainerapps.io`
+
+## 運用メモ
+- admin の Basic 認証は `admin` Container App の secrets にある:
+  - `basic-auth-username`
+  - `basic-auth-password`
+- `static-site-builder` は internal ingress のため、外部ネットワークから直接アクセスできない
+- `public-viewer` は起動時 build のため、環境変数変更を確実に反映したい場合はコンテナ再起動（新 revision 作成）を行う


### PR DESCRIPTION
## 何をしたか
`docs/deployment/azure-migration-20260207.md` を、実際に動作する状態まで到達した手順/対策に合わせて更新しました。

- Azure 側の移行手順を、運用者がそのまま再現できる形で整理
- 旧 `client*` から新 `public-viewer/admin/static-site-builder` への作成/secret 移設/環境変数更新/再起動/削除
- 移行後に出た `public-viewer` の起動タイムアウトと CI ヘルスチェック false negative の恒久対策を追記
  - PR #782 / #784 / #785 の内容を前提に記載

## 背景
リファクタ後は命名規約（`docs/refactoring/naming_convention.md`）に合わせて Container Apps 名も `apps/*` と揃う前提ですが、既存 Azure 環境には旧名称の Container Apps しか残っておらず、GitHub Actions/Makefile のデプロイで `... does not exist` が発生していました。

## 注意
- secret 値はドキュメント上ではマスクし、`<value>` で表記しています。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * Azure マイグレーション ガイドを詳細化し、ステップバイステップの手順を追加しました。
  * 具体的なコマンド例と実行結果のサンプルを含めました。
  * トラブルシューティング セクションとマイグレーション後の検証手順を追加しました。
  * 既知の問題と実装済みの対策をドキュメント化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->