### PR TITLE
fix: filter out empty/whitespace-only comments before LLM processing (#583)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,3 @@
+reviews:
+  auto_review:
+    drafts: true

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,36 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ["python", "javascript"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3

--- a/packages/analysis-core/src/analysis_core/steps/extraction.py
+++ b/packages/analysis-core/src/analysis_core/steps/extraction.py
@@ -20,6 +20,7 @@ class ExtractionResponse(BaseModel):
 
 
 def _validate_property_columns(property_columns: list[str], comments: pl.DataFrame) -> None:
+    """Raise ValueError if any required property column is missing from the DataFrame."""
     if not all(property in comments.columns for property in property_columns):
         raise ValueError(f"Properties {property_columns} not found in comments. Columns are {comments.columns}")
 
@@ -107,6 +108,7 @@ def extraction(config):
 
 
 def extract_batch(batch, prompt, model, workers, provider="openai", local_llm_address=None, config=None):
+    """Run argument extraction concurrently for a batch of comment texts."""
     with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
         futures_with_index = [
             (i, executor.submit(extract_arguments, input, prompt, model, provider, local_llm_address))
@@ -151,6 +153,7 @@ def extract_batch(batch, prompt, model, workers, provider="openai", local_llm_ad
 
 
 def extract_arguments(input, prompt, model, provider="openai", local_llm_address=None):
+    """Send a single comment to the LLM and return extracted arguments."""
     messages = [
         {"role": "system", "content": prompt},
         {"role": "user", "content": input},

--- a/packages/analysis-core/src/analysis_core/steps/extraction.py
+++ b/packages/analysis-core/src/analysis_core/steps/extraction.py
@@ -42,6 +42,11 @@ def _filter_empty_comments(comments: pl.DataFrame) -> pl.DataFrame:
     return filtered
 
 
+def filter_empty_comments(comments: pl.DataFrame) -> pl.DataFrame:
+    """Public wrapper for filtering empty/whitespace-only comments before LLM processing."""
+    return _filter_empty_comments(comments)
+
+
 def extraction(config):
     """Extract arguments from comments using LLM, skipping empty/whitespace-only entries."""
     dataset = config["output_dir"]

--- a/packages/analysis-core/src/analysis_core/steps/extraction.py
+++ b/packages/analysis-core/src/analysis_core/steps/extraction.py
@@ -25,6 +25,7 @@ def _validate_property_columns(property_columns: list[str], comments: pl.DataFra
 
 
 def extraction(config):
+    """Extract arguments from comments using LLM, skipping empty/whitespace-only entries."""
     dataset = config["output_dir"]
     output_base_dir = config.get("_output_base_dir", "outputs")
     input_base_dir = config.get("_input_base_dir", "inputs")

--- a/packages/analysis-core/tests/test_extraction_filter.py
+++ b/packages/analysis-core/tests/test_extraction_filter.py
@@ -3,7 +3,7 @@
 import polars as pl
 import pytest
 
-from analysis_core.steps.extraction import _filter_empty_comments
+from analysis_core.steps.extraction import filter_empty_comments as _filter_empty_comments
 
 
 class TestEmptyCommentFiltering:

--- a/packages/analysis-core/tests/test_extraction_filter.py
+++ b/packages/analysis-core/tests/test_extraction_filter.py
@@ -1,0 +1,122 @@
+"""Test that empty/whitespace-only comments are filtered out in extraction step (#583)."""
+
+import os
+import tempfile
+
+import polars as pl
+import pytest
+
+
+class TestEmptyCommentFiltering:
+    """Test filtering of empty/whitespace-only comments before LLM processing."""
+
+    def _create_csv(self, rows: list[dict], path: str) -> None:
+        df = pl.DataFrame(rows)
+        df.write_csv(path)
+
+    def test_filters_empty_strings(self, tmp_path):
+        """Empty string comments should be removed."""
+        csv_path = str(tmp_path / "input.csv")
+        self._create_csv(
+            [
+                {"comment-id": "1", "comment-body": "valid comment"},
+                {"comment-id": "2", "comment-body": ""},
+                {"comment-id": "3", "comment-body": "another valid comment"},
+            ],
+            csv_path,
+        )
+
+        comments = pl.read_csv(csv_path, columns=["comment-id", "comment-body"])
+        comments = comments.filter(
+            pl.col("comment-body").is_not_null() & (pl.col("comment-body").str.strip_chars() != "")
+        )
+
+        assert len(comments) == 2
+        assert comments["comment-id"].to_list() == [1, 3]
+
+    def test_filters_whitespace_only(self, tmp_path):
+        """Whitespace-only comments should be removed."""
+        csv_path = str(tmp_path / "input.csv")
+        self._create_csv(
+            [
+                {"comment-id": "1", "comment-body": "valid comment"},
+                {"comment-id": "2", "comment-body": "   "},
+                {"comment-id": "3", "comment-body": "\t\n"},
+            ],
+            csv_path,
+        )
+
+        comments = pl.read_csv(csv_path, columns=["comment-id", "comment-body"])
+        comments = comments.filter(
+            pl.col("comment-body").is_not_null() & (pl.col("comment-body").str.strip_chars() != "")
+        )
+
+        assert len(comments) == 1
+        assert comments["comment-id"].to_list() == [1]
+
+    def test_keeps_valid_comments(self, tmp_path):
+        """Valid comments should not be filtered out."""
+        csv_path = str(tmp_path / "input.csv")
+        self._create_csv(
+            [
+                {"comment-id": "1", "comment-body": "first comment"},
+                {"comment-id": "2", "comment-body": "second comment"},
+                {"comment-id": "3", "comment-body": "third comment"},
+            ],
+            csv_path,
+        )
+
+        comments = pl.read_csv(csv_path, columns=["comment-id", "comment-body"])
+        original_count = len(comments)
+        comments = comments.filter(
+            pl.col("comment-body").is_not_null() & (pl.col("comment-body").str.strip_chars() != "")
+        )
+
+        assert len(comments) == original_count
+
+    def test_all_empty_raises_error(self, tmp_path):
+        """When all comments are empty, a RuntimeError should be raised."""
+        csv_path = str(tmp_path / "input.csv")
+        self._create_csv(
+            [
+                {"comment-id": "1", "comment-body": ""},
+                {"comment-id": "2", "comment-body": "   "},
+                {"comment-id": "3", "comment-body": "\n"},
+            ],
+            csv_path,
+        )
+
+        comments = pl.read_csv(csv_path, columns=["comment-id", "comment-body"])
+        comments = comments.filter(
+            pl.col("comment-body").is_not_null() & (pl.col("comment-body").str.strip_chars() != "")
+        )
+
+        assert len(comments) == 0
+        with pytest.raises(RuntimeError, match="All comments are empty"):
+            if len(comments) == 0:
+                raise RuntimeError("All comments are empty or whitespace-only after filtering")
+
+    def test_mixed_empty_and_valid(self, tmp_path):
+        """Mixed input should keep only valid comments."""
+        csv_path = str(tmp_path / "input.csv")
+        self._create_csv(
+            [
+                {"comment-id": "1", "comment-body": "valid"},
+                {"comment-id": "2", "comment-body": ""},
+                {"comment-id": "3", "comment-body": "   "},
+                {"comment-id": "4", "comment-body": "also valid"},
+                {"comment-id": "5", "comment-body": "\n\n"},
+            ],
+            csv_path,
+        )
+
+        comments = pl.read_csv(csv_path, columns=["comment-id", "comment-body"])
+        original_count = len(comments)
+        comments = comments.filter(
+            pl.col("comment-body").is_not_null() & (pl.col("comment-body").str.strip_chars() != "")
+        )
+        filtered_count = original_count - len(comments)
+
+        assert len(comments) == 2
+        assert filtered_count == 3
+        assert comments["comment-id"].to_list() == [1, 4]

--- a/packages/analysis-core/tests/test_extraction_filter.py
+++ b/packages/analysis-core/tests/test_extraction_filter.py
@@ -1,123 +1,65 @@
 """Test that empty/whitespace-only comments are filtered out in extraction step (#583)."""
 
-import os
-import tempfile
-
 import polars as pl
 import pytest
+
+from analysis_core.steps.extraction import _filter_empty_comments
 
 
 class TestEmptyCommentFiltering:
     """Test filtering of empty/whitespace-only comments before LLM processing."""
 
-    def _create_csv(self, rows: list[dict], path: str) -> None:
-        """Write a list of dicts as a CSV file to the given path."""
-        df = pl.DataFrame(rows)
-        df.write_csv(path)
-
-    def test_filters_empty_strings(self, tmp_path):
+    def test_filters_empty_strings(self):
         """Empty string comments should be removed."""
-        csv_path = str(tmp_path / "input.csv")
-        self._create_csv(
-            [
-                {"comment-id": "1", "comment-body": "valid comment"},
-                {"comment-id": "2", "comment-body": ""},
-                {"comment-id": "3", "comment-body": "another valid comment"},
-            ],
-            csv_path,
-        )
+        df = pl.DataFrame([
+            {"comment-id": "1", "comment-body": "valid comment"},
+            {"comment-id": "2", "comment-body": ""},
+            {"comment-id": "3", "comment-body": "another valid comment"},
+        ])
+        result = _filter_empty_comments(df)
+        assert len(result) == 2
+        assert result["comment-id"].to_list() == ["1", "3"]
 
-        comments = pl.read_csv(csv_path, columns=["comment-id", "comment-body"])
-        comments = comments.filter(
-            pl.col("comment-body").is_not_null() & (pl.col("comment-body").str.strip_chars() != "")
-        )
-
-        assert len(comments) == 2
-        assert comments["comment-id"].to_list() == [1, 3]
-
-    def test_filters_whitespace_only(self, tmp_path):
+    def test_filters_whitespace_only(self):
         """Whitespace-only comments should be removed."""
-        csv_path = str(tmp_path / "input.csv")
-        self._create_csv(
-            [
-                {"comment-id": "1", "comment-body": "valid comment"},
-                {"comment-id": "2", "comment-body": "   "},
-                {"comment-id": "3", "comment-body": "\t\n"},
-            ],
-            csv_path,
-        )
+        df = pl.DataFrame([
+            {"comment-id": "1", "comment-body": "valid comment"},
+            {"comment-id": "2", "comment-body": "   "},
+            {"comment-id": "3", "comment-body": "\t\n"},
+        ])
+        result = _filter_empty_comments(df)
+        assert len(result) == 1
+        assert result["comment-id"].to_list() == ["1"]
 
-        comments = pl.read_csv(csv_path, columns=["comment-id", "comment-body"])
-        comments = comments.filter(
-            pl.col("comment-body").is_not_null() & (pl.col("comment-body").str.strip_chars() != "")
-        )
-
-        assert len(comments) == 1
-        assert comments["comment-id"].to_list() == [1]
-
-    def test_keeps_valid_comments(self, tmp_path):
+    def test_keeps_valid_comments(self):
         """Valid comments should not be filtered out."""
-        csv_path = str(tmp_path / "input.csv")
-        self._create_csv(
-            [
-                {"comment-id": "1", "comment-body": "first comment"},
-                {"comment-id": "2", "comment-body": "second comment"},
-                {"comment-id": "3", "comment-body": "third comment"},
-            ],
-            csv_path,
-        )
+        df = pl.DataFrame([
+            {"comment-id": "1", "comment-body": "first comment"},
+            {"comment-id": "2", "comment-body": "second comment"},
+            {"comment-id": "3", "comment-body": "third comment"},
+        ])
+        result = _filter_empty_comments(df)
+        assert len(result) == 3
 
-        comments = pl.read_csv(csv_path, columns=["comment-id", "comment-body"])
-        original_count = len(comments)
-        comments = comments.filter(
-            pl.col("comment-body").is_not_null() & (pl.col("comment-body").str.strip_chars() != "")
-        )
-
-        assert len(comments) == original_count
-
-    def test_all_empty_raises_error(self, tmp_path):
+    def test_all_empty_raises_error(self):
         """When all comments are empty, a RuntimeError should be raised."""
-        csv_path = str(tmp_path / "input.csv")
-        self._create_csv(
-            [
-                {"comment-id": "1", "comment-body": ""},
-                {"comment-id": "2", "comment-body": "   "},
-                {"comment-id": "3", "comment-body": "\n"},
-            ],
-            csv_path,
-        )
-
-        comments = pl.read_csv(csv_path, columns=["comment-id", "comment-body"])
-        comments = comments.filter(
-            pl.col("comment-body").is_not_null() & (pl.col("comment-body").str.strip_chars() != "")
-        )
-
-        assert len(comments) == 0
+        df = pl.DataFrame([
+            {"comment-id": "1", "comment-body": ""},
+            {"comment-id": "2", "comment-body": "   "},
+            {"comment-id": "3", "comment-body": "\n"},
+        ])
         with pytest.raises(RuntimeError, match="All comments are empty"):
-            if len(comments) == 0:
-                raise RuntimeError("All comments are empty or whitespace-only after filtering")
+            _filter_empty_comments(df)
 
-    def test_mixed_empty_and_valid(self, tmp_path):
+    def test_mixed_empty_and_valid(self):
         """Mixed input should keep only valid comments."""
-        csv_path = str(tmp_path / "input.csv")
-        self._create_csv(
-            [
-                {"comment-id": "1", "comment-body": "valid"},
-                {"comment-id": "2", "comment-body": ""},
-                {"comment-id": "3", "comment-body": "   "},
-                {"comment-id": "4", "comment-body": "also valid"},
-                {"comment-id": "5", "comment-body": "\n\n"},
-            ],
-            csv_path,
-        )
-
-        comments = pl.read_csv(csv_path, columns=["comment-id", "comment-body"])
-        original_count = len(comments)
-        comments = comments.filter(
-            pl.col("comment-body").is_not_null() & (pl.col("comment-body").str.strip_chars() != "")
-        )
-        filtered_count = original_count - len(comments)
-
-        assert len(comments) == 2
-        assert filtered_count == 3
-        assert comments["comment-id"].to_list() == [1, 4]
+        df = pl.DataFrame([
+            {"comment-id": "1", "comment-body": "valid"},
+            {"comment-id": "2", "comment-body": ""},
+            {"comment-id": "3", "comment-body": "   "},
+            {"comment-id": "4", "comment-body": "also valid"},
+            {"comment-id": "5", "comment-body": "\n\n"},
+        ])
+        result = _filter_empty_comments(df)
+        assert len(result) == 2
+        assert result["comment-id"].to_list() == ["1", "4"]

--- a/packages/analysis-core/tests/test_extraction_filter.py
+++ b/packages/analysis-core/tests/test_extraction_filter.py
@@ -11,6 +11,7 @@ class TestEmptyCommentFiltering:
     """Test filtering of empty/whitespace-only comments before LLM processing."""
 
     def _create_csv(self, rows: list[dict], path: str) -> None:
+        """Write a list of dicts as a CSV file to the given path."""
         df = pl.DataFrame(rows)
         df.write_csv(path)
 

--- a/packages/analysis-core/tests/test_extraction_filter.py
+++ b/packages/analysis-core/tests/test_extraction_filter.py
@@ -40,6 +40,8 @@ class TestEmptyCommentFiltering:
         ])
         result = _filter_empty_comments(df)
         assert len(result) == 3
+        assert result["comment-id"].to_list() == ["1", "2", "3"]
+        assert result["comment-body"].to_list() == ["first comment", "second comment", "third comment"]
 
     def test_all_empty_raises_error(self):
         """When all comments are empty, a RuntimeError should be raised."""
@@ -63,3 +65,21 @@ class TestEmptyCommentFiltering:
         result = _filter_empty_comments(df)
         assert len(result) == 2
         assert result["comment-id"].to_list() == ["1", "4"]
+
+    def test_filters_null_comments(self):
+        """Null (None) comment-body values should be removed."""
+        df = pl.DataFrame(
+            {"comment-id": ["1", "2", "3"], "comment-body": ["valid comment", None, "another valid"]}
+        )
+        result = _filter_empty_comments(df)
+        assert len(result) == 2
+        assert result["comment-id"].to_list() == ["1", "3"]
+        assert result["comment-body"].to_list() == ["valid comment", "another valid"]
+
+    def test_all_null_raises_error(self):
+        """When all comment-body values are None, a RuntimeError should be raised."""
+        df = pl.DataFrame(
+            {"comment-id": ["1", "2", "3"], "comment-body": [None, None, None]}
+        )
+        with pytest.raises(RuntimeError, match="All comments are empty"):
+            _filter_empty_comments(df)


### PR DESCRIPTION
# 変更の概要
- CSV入力の`comment-body`カラムに空文字列や空白のみの値が含まれている場合、フィルタで除外するようにした
- フィルタされた行数をloggingで出力するようにした
- 全件が空だった場合、明確なエラーメッセージで停止するようにした

# スクリーンショット
なし（コード・ロジック変更のみ）

# 変更の背景
分析対象カラムに空文字列や空白のみの値が含まれていると、それがそのままLLM APIに送信され、大量のエラーが発生する問題があった（#583）。

# 関連Issue
Closes #583

# 動作確認の結果
- `test_extraction_filter.py` に5件のテストケースを追加し、全て通過することを確認した
  - 空文字列のフィルタ
  - 空白のみ（スペース、タブ、改行）のフィルタ
  - 正常データが除外されないこと
  - 全件空の場合にRuntimeErrorが発生すること
  - 空・正常が混在するデータの正しいフィルタ

# CLAへの同意
- [x] CLAの内容を読み、同意しました

# マージ前のチェックリスト（レビュアーがマージ前に確認してください）
- [ ] CIが全て通過している
- [ ] 単体テストが実装されているか
- [ ] 今回実装した機能および影響を受けると思われる機能について、適切な動作確認が行われているかを確認する。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 自動コードレビューの設定を追加（ドラフトの自動作成を有効化）。
  * CodeQL による自動セキュリティ解析ワークフローを追加。
  * 抽出処理で空または空白のみのコメントを自動除外し、全件が空の場合はエラーを返す挙動を導入。

* **テスト**
  * コメントフィルタリングの包括的なテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->