### PR TITLE
feat(local-llm): accept full URL in `address`, support `LOCAL_LLM_API_KEY`

### DIFF
--- a/apps/api/broadlistening/pipeline/services/llm.py
+++ b/apps/api/broadlistening/pipeline/services/llm.py
@@ -388,6 +388,35 @@ def request_to_gemini_chatcompletion(
     raise RuntimeError("Gemini API call failed after retries")
 
 
+def _resolve_local_llm_base_url(address: str) -> str:
+    """`address` から OpenAI 互換ローカル LLM 用の base URL を組み立てる。
+
+    対応する形式:
+    - `"host:port"` または `"host"` → `"http://host:port/v1"` (Ollama / LM Studio のデフォルト想定)
+    - `"scheme://host[:port][/path]"` → 渡された URL をそのまま base URL として扱い、
+      末尾に `/v1` がなければ補う (社内 HTTPS OpenAI 互換ゲートウェイ用)
+
+    認証が必要なエンドポイントは `LOCAL_LLM_API_KEY` 環境変数で API key を渡せる。
+    """
+    if "://" in address:
+        base_url = address.rstrip("/")
+        if not base_url.endswith("/v1"):
+            base_url = base_url + "/v1"
+        return base_url
+    try:
+        if ":" in address:
+            host, port_str = address.split(":")
+            port = int(port_str)
+        else:
+            host = address
+            port = 11434  # デフォルトポート
+    except ValueError:
+        logging.warning(f"Invalid address format: {address}, using default")
+        host = "localhost"
+        port = 11434
+    return f"http://{host}:{port}/v1"
+
+
 def request_to_local_llm(
     messages: list[dict],
     model: str,
@@ -404,7 +433,8 @@ def request_to_local_llm(
         model: 使用するモデル名
         is_json: JSONレスポンスを要求するかどうか
         json_schema: JSONスキーマ（Pydanticモデルまたは辞書）
-        address: ローカルLLMのアドレス（例: 127.0.0.1:1234）
+        address: ローカルLLMのアドレス（例: `"127.0.0.1:1234"` または
+            `"https://my-gateway.example.com"` のような OpenAI 互換 URL）
 
     Returns:
         LLMからのレスポンスとトークン使用量(入力・出力・合計)のタプル
@@ -412,24 +442,14 @@ def request_to_local_llm(
     token_usage_input = 0  # 入力トークン使用量を追跡する変数
     token_usage_output = 0  # 出力トークン使用量を追跡する変数
     token_usage_total = 0  # 合計トークン使用量を追跡する変数
-    try:
-        if ":" in address:
-            host, port_str = address.split(":")
-            port = int(port_str)
-        else:
-            host = address
-            port = 11434  # デフォルトポート
-    except ValueError:
-        logging.warning(f"Invalid address format: {address}, using default")
-        host = "localhost"
-        port = 11434
 
-    base_url = f"http://{host}:{port}/v1"
+    base_url = _resolve_local_llm_base_url(address)
+    api_key = os.environ.get("LOCAL_LLM_API_KEY", "not-needed")
 
     try:
         client = OpenAI(
             base_url=base_url,
-            api_key="not-needed",  # OllamaとLM Studioは認証不要
+            api_key=api_key,
         )
 
         response_format = None
@@ -538,29 +558,19 @@ def request_to_local_llm_embed(args, model, address="localhost:11434"):
     Args:
         args: 埋め込みを取得するテキスト
         model: 使用するモデル名
-        address: ローカルLLMのアドレス（例: 127.0.0.1:1234）
+        address: ローカルLLMのアドレス（例: `"127.0.0.1:1234"` または
+            `"https://my-gateway.example.com"` のような OpenAI 互換 URL）
 
     Returns:
         埋め込みベクトルのリスト
     """
-    try:
-        if ":" in address:
-            host, port_str = address.split(":")
-            port = int(port_str)
-        else:
-            host = address
-            port = 11434  # デフォルトポート
-    except ValueError:
-        logging.warning(f"Invalid address format: {address}, using default")
-        host = "localhost"
-        port = 11434
-
-    base_url = f"http://{host}:{port}/v1"
+    base_url = _resolve_local_llm_base_url(address)
+    api_key = os.environ.get("LOCAL_LLM_API_KEY", "not-needed")
 
     try:
         client = OpenAI(
             base_url=base_url,
-            api_key="not-needed",  # OllamaとLM Studioは認証不要
+            api_key=api_key,
         )
 
         response = client.embeddings.create(input=args, model=model)

--- a/apps/api/broadlistening/pipeline/services/llm.py
+++ b/apps/api/broadlistening/pipeline/services/llm.py
@@ -395,8 +395,6 @@ def _resolve_local_llm_base_url(address: str) -> str:
     - `"host:port"` または `"host"` → `"http://host:port/v1"` (Ollama / LM Studio のデフォルト想定)
     - `"scheme://host[:port][/path]"` → 渡された URL をそのまま base URL として扱い、
       末尾に `/v1` がなければ補う (社内 HTTPS OpenAI 互換ゲートウェイ用)
-
-    認証が必要なエンドポイントは `LOCAL_LLM_API_KEY` 環境変数で API key を渡せる。
     """
     if "://" in address:
         base_url = address.rstrip("/")

--- a/packages/analysis-core/src/analysis_core/services/llm.py
+++ b/packages/analysis-core/src/analysis_core/services/llm.py
@@ -402,8 +402,6 @@ def _resolve_local_llm_base_url(address: str) -> str:
     - `"host:port"` または `"host"` → `"http://host:port/v1"` (Ollama / LM Studio のデフォルト想定)
     - `"scheme://host[:port][/path]"` → 渡された URL をそのまま base URL として扱い、
       末尾に `/v1` がなければ補う (社内 HTTPS OpenAI 互換ゲートウェイ用)
-
-    認証が必要なエンドポイントは `LOCAL_LLM_API_KEY` 環境変数で API key を渡せる。
     """
     if "://" in address:
         base_url = address.rstrip("/")

--- a/packages/analysis-core/src/analysis_core/services/llm.py
+++ b/packages/analysis-core/src/analysis_core/services/llm.py
@@ -395,6 +395,35 @@ def request_to_gemini_chatcompletion(
     raise RuntimeError("Gemini API call failed after retries")
 
 
+def _resolve_local_llm_base_url(address: str) -> str:
+    """`address` から OpenAI 互換ローカル LLM 用の base URL を組み立てる。
+
+    対応する形式:
+    - `"host:port"` または `"host"` → `"http://host:port/v1"` (Ollama / LM Studio のデフォルト想定)
+    - `"scheme://host[:port][/path]"` → 渡された URL をそのまま base URL として扱い、
+      末尾に `/v1` がなければ補う (社内 HTTPS OpenAI 互換ゲートウェイ用)
+
+    認証が必要なエンドポイントは `LOCAL_LLM_API_KEY` 環境変数で API key を渡せる。
+    """
+    if "://" in address:
+        base_url = address.rstrip("/")
+        if not base_url.endswith("/v1"):
+            base_url = base_url + "/v1"
+        return base_url
+    try:
+        if ":" in address:
+            host, port_str = address.split(":")
+            port = int(port_str)
+        else:
+            host = address
+            port = 11434  # デフォルトポート
+    except ValueError:
+        logging.warning(f"Invalid address format: {address}, using default")
+        host = "localhost"
+        port = 11434
+    return f"http://{host}:{port}/v1"
+
+
 def request_to_local_llm(
     messages: list[dict],
     model: str,
@@ -412,7 +441,8 @@ def request_to_local_llm(
         model: 使用するモデル名
         is_json: JSONレスポンスを要求するかどうか
         json_schema: JSONスキーマ（Pydanticモデルまたは辞書）
-        address: ローカルLLMのアドレス（例: 127.0.0.1:1234）
+        address: ローカルLLMのアドレス（例: `"127.0.0.1:1234"` または
+            `"https://my-gateway.example.com"` のような OpenAI 互換 URL）
 
     Returns:
         LLMからのレスポンスとトークン使用量(入力・出力・合計)のタプル
@@ -420,24 +450,14 @@ def request_to_local_llm(
     token_usage_input = 0  # 入力トークン使用量を追跡する変数
     token_usage_output = 0  # 出力トークン使用量を追跡する変数
     token_usage_total = 0  # 合計トークン使用量を追跡する変数
-    try:
-        if ":" in address:
-            host, port_str = address.split(":")
-            port = int(port_str)
-        else:
-            host = address
-            port = 11434  # デフォルトポート
-    except ValueError:
-        logging.warning(f"Invalid address format: {address}, using default")
-        host = "localhost"
-        port = 11434
 
-    base_url = f"http://{host}:{port}/v1"
+    base_url = _resolve_local_llm_base_url(address)
+    api_key = os.environ.get("LOCAL_LLM_API_KEY", "not-needed")
 
     try:
         client = OpenAI(
             base_url=base_url,
-            api_key="not-needed",  # OllamaとLM Studioは認証不要
+            api_key=api_key,
         )
 
         response_format = None
@@ -547,29 +567,19 @@ def request_to_local_llm_embed(args, model, address="localhost:11434"):
     Args:
         args: 埋め込みを取得するテキスト
         model: 使用するモデル名
-        address: ローカルLLMのアドレス（例: 127.0.0.1:1234）
+        address: ローカルLLMのアドレス（例: `"127.0.0.1:1234"` または
+            `"https://my-gateway.example.com"` のような OpenAI 互換 URL）
 
     Returns:
         埋め込みベクトルのリスト
     """
-    try:
-        if ":" in address:
-            host, port_str = address.split(":")
-            port = int(port_str)
-        else:
-            host = address
-            port = 11434  # デフォルトポート
-    except ValueError:
-        logging.warning(f"Invalid address format: {address}, using default")
-        host = "localhost"
-        port = 11434
-
-    base_url = f"http://{host}:{port}/v1"
+    base_url = _resolve_local_llm_base_url(address)
+    api_key = os.environ.get("LOCAL_LLM_API_KEY", "not-needed")
 
     try:
         client = OpenAI(
             base_url=base_url,
-            api_key="not-needed",  # OllamaとLM Studioは認証不要
+            api_key=api_key,
         )
 
         response = client.embeddings.create(input=args, model=model)

--- a/packages/analysis-core/tests/test_local_llm_base_url.py
+++ b/packages/analysis-core/tests/test_local_llm_base_url.py
@@ -1,0 +1,43 @@
+"""Tests for `_resolve_local_llm_base_url` helper.
+
+The helper backs `request_to_local_llm` / `request_to_local_llm_embed`. It
+must accept both the historic Ollama / LM Studio `"host:port"` form and a
+new full-URL form (e.g. a corporate HTTPS OpenAI-compatible gateway) without
+breaking the default.
+"""
+
+import pytest
+
+from analysis_core.services.llm import _resolve_local_llm_base_url
+
+
+class TestResolveLocalLlmBaseUrl:
+    @pytest.mark.parametrize(
+        ("address", "expected"),
+        [
+            # historic Ollama / LM Studio form
+            ("localhost:11434", "http://localhost:11434/v1"),
+            ("127.0.0.1:1234", "http://127.0.0.1:1234/v1"),
+            ("192.168.1.5:8080", "http://192.168.1.5:8080/v1"),
+            # bare host without port → falls back to Ollama default port
+            ("localhost", "http://localhost:11434/v1"),
+            # full URL form: corporate HTTPS endpoint without explicit port
+            ("https://my-gateway.example.com", "https://my-gateway.example.com/v1"),
+            # full URL with explicit port
+            ("https://my-gateway.example.com:8443", "https://my-gateway.example.com:8443/v1"),
+            # full URL already ending in /v1 → unchanged
+            ("https://my-gateway.example.com/v1", "https://my-gateway.example.com/v1"),
+            # trailing slash trimmed before checking suffix
+            ("https://my-gateway.example.com/v1/", "https://my-gateway.example.com/v1"),
+            # full URL with non-/v1 prefix path (gateway routing) → /v1 appended
+            ("http://my-gateway:8000/openai", "http://my-gateway:8000/openai/v1"),
+            # http (non-tls) full URL works too
+            ("http://my-gateway.example.com", "http://my-gateway.example.com/v1"),
+        ],
+    )
+    def test_resolves_address_to_base_url(self, address: str, expected: str) -> None:
+        assert _resolve_local_llm_base_url(address) == expected
+
+    def test_malformed_address_falls_back_to_default(self) -> None:
+        # "host:not-a-port" → int() raises → warn + fallback to default Ollama
+        assert _resolve_local_llm_base_url("localhost:not-a-port") == "http://localhost:11434/v1"


### PR DESCRIPTION
## 動機

`local` provider は Ollama / LM Studio を念頭に `address` を `"host:port"` 形式で受け取り、内部で `f"http://{host}:{port}/v1"` を組み立てています。このため、**OpenAI 互換の HTTPS gateway** (ポート省略 + TLS 終端、自前ホストや組織内ゲートウェイなど) を `local` provider 経由で叩く運用ができません。

例: `local_llm_address: "https://my-gateway.example.com"` を渡すと `int(port_str)` で `ValueError` → fallback で `localhost:11434` に接続失敗。

外部 API を使えない・使いたくない環境で広聴AI を `local` provider で動かそうとした際に発覚した制約です。

## 変更内容

### 1. `_resolve_local_llm_base_url(address)` ヘルパを追加

両ファイル (`apps/api/broadlistening/pipeline/services/llm.py` と `packages/analysis-core/src/analysis_core/services/llm.py`) に同じヘルパを追加し、URL 解決ロジックを 1 箇所に集約。

対応する `address` 形式:

| 入力 | 解決後の `base_url` | 互換性 |
|---|---|---|
| `"localhost:11434"` | `"http://localhost:11434/v1"` | 既存 (Ollama デフォルト) |
| `"127.0.0.1:1234"` | `"http://127.0.0.1:1234/v1"` | 既存 (LM Studio など) |
| `"localhost"` | `"http://localhost:11434/v1"` | 既存 (port 省略時の fallback) |
| `"https://my-gateway.example.com"` | `"https://my-gateway.example.com/v1"` | **新規** (HTTPS + ポート省略) |
| `"https://my-gateway.example.com/v1"` | 同上 | **新規** (`/v1` 既に付与済) |
| `"http://my-gateway:8000/openai"` | `"http://my-gateway:8000/openai/v1"` | **新規** (path 付き gateway) |

### 2. `LOCAL_LLM_API_KEY` 環境変数で API key を渡せるよう拡張

`request_to_local_llm` / `request_to_local_llm_embed` の両方で `os.environ.get(\"LOCAL_LLM_API_KEY\", \"not-needed\")` を参照。未設定なら従来通り `"not-needed"` がそのまま Bearer に乗るので、**Ollama / LM Studio 利用者には挙動変更なし**。認証付き gateway を使う場合のみ env で渡せる。

### 3. リファクタ

`request_to_local_llm` / `request_to_local_llm_embed` が同じ URL パースロジックを 4 箇所で重複していたのを helper 1 つに集約。

### 4. テスト

`packages/analysis-core/tests/test_local_llm_base_url.py` に parametrized 単体テストを追加 (11 ケース、後方互換 + 新規対応 + malformed fallback)。

```
$ pytest packages/analysis-core/tests/test_local_llm_base_url.py -v
============================== 11 passed in 7.06s ==============================
```

## 互換性

**破壊的変更なし**。

- 既存の `"host:port"` 形式は完全に同一の `base_url` を返す
- `LOCAL_LLM_API_KEY` 未設定時は従来通り `"not-needed"` を使う
- ドキュメンテーション: docstring の `address` 説明を「`"127.0.0.1:1234"` または `"https://..."`」に更新

## 動作確認

OpenAI 互換の HTTPS gateway 経由で `provider=local` のフルパイプライン (extraction / hierarchical_initial_labelling / hierarchical_merge_labelling / hierarchical_overview の各 LLM ステップ + ローカル embedding) を完走できることを確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced local LLM configuration to support multiple address formats including full URLs and HTTPS gateways
  * Added environment variable support for local LLM API key configuration

* **Improvements**
  * Automatic OpenAI-compatible URL normalization with `/v1` path handling
  * Updated documentation for address format requirements

* **Tests**
  * Added test coverage for address format validation and normalization

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/digitaldemocracy2030/kouchou-ai/pull/824)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->