### PR TITLE
feat(visualization): self-contained HTML report (replaces broken npm step) + fix `--without-html` default

### DIFF
--- a/docs/user-guide/cli-quickstart.md
+++ b/docs/user-guide/cli-quickstart.md
@@ -125,8 +125,10 @@ Execution Plan:
   [RUN] hierarchical_merge_labelling: no trace of previous run
   [RUN] hierarchical_overview: no trace of previous run
   [RUN] hierarchical_aggregation: no trace of previous run
-  [SKIP] hierarchical_visualization: skipping html output
+  [RUN] hierarchical_visualization: no trace of previous run
 ```
+
+`hierarchical_visualization` ステップは自己完結型の `report.html` を生成します（Plotly CDN のみ参照、データは inline）。HTML を生成したくない場合は `--without-html` を指定してください。
 
 ### 分析の実行
 
@@ -161,7 +163,8 @@ Output directory: outputs/config
 
 ```
 outputs/config/
-├── hierarchical_result.json    # 最終結果（Webビューア用）
+├── hierarchical_result.json    # 最終結果（Webビューア用 / report.html の元データ）
+├── report.html                 # 自己完結型 HTML レポート（散布図 + クラスタ階層、Plotly CDN 参照、データは inline）
 ├── hierarchical_overview.txt   # AI生成の要約テキスト
 ├── hierarchical_clusters.csv   # クラスタリング結果
 ├── hierarchical_initial_labels.csv
@@ -171,6 +174,17 @@ outputs/config/
 ├── relations.csv
 └── hierarchical_status.json    # 実行ステータス
 ```
+
+### `report.html` の確認
+
+ブラウザで開くだけで散布図と階層クラスタを閲覧できます。pnpm / Node / docker 不要、API サーバ不要、`file://` でも動作します。
+
+```bash
+open outputs/config/report.html  # macOS
+# xdg-open outputs/config/report.html  # Linux
+```
+
+`config.json` に `"report_url_pattern"` を指定すると、各点クリックで元コメントの URL を開けます（例: `"report_url_pattern": "https://example.com/comments/{comment_id}"`）。
 
 ### 要約の確認
 

--- a/packages/analysis-core/src/analysis_core/__main__.py
+++ b/packages/analysis-core/src/analysis_core/__main__.py
@@ -48,8 +48,9 @@ def main() -> int:
     parser.add_argument(
         "--without-html",
         action="store_true",
-        default=True,
-        help="Skip HTML visualization generation (default: True)",
+        default=False,
+        help="Skip HTML visualization generation. By default a self-contained "
+        "report.html is written next to hierarchical_result.json.",
     )
     parser.add_argument(
         "--output-dir",

--- a/packages/analysis-core/src/analysis_core/steps/hierarchical_visualization.py
+++ b/packages/analysis-core/src/analysis_core/steps/hierarchical_visualization.py
@@ -121,7 +121,7 @@ def build_html(
         args = data["arguments"]
 
     tree_html = _render_tree(data)
-    embedded = json.dumps(data, ensure_ascii=False, separators=(",", ":"))
+    embedded = _safe_inline_json(data)
     level_options = "".join(
         f'<option value="{lvl}"{" selected" if lvl == default_level else ""}>'
         f"level {lvl} ({_count_at(data, lvl)} clusters)</option>"
@@ -141,6 +141,11 @@ def build_html(
         palette_js=json.dumps(SOFT_COLORS),
         enable_source_link_js="true" if url_pattern else "false",
     )
+
+
+def _safe_inline_json(data: Any) -> str:
+    """Serialize JSON safely for embedding inside a ``<script>`` tag."""
+    return json.dumps(data, ensure_ascii=False, separators=(",", ":")).replace("</", "<\\/")
 
 
 def _count_at(data: dict[str, Any], level: int) -> int:

--- a/packages/analysis-core/src/analysis_core/steps/hierarchical_visualization.py
+++ b/packages/analysis-core/src/analysis_core/steps/hierarchical_visualization.py
@@ -1,36 +1,569 @@
-import subprocess
+"""Self-contained HTML visualization step.
+
+Reads ``hierarchical_result.json`` from the run's output directory and emits a
+single-file ``report.html`` that bundles all data inline. The viewer is
+written with vanilla JS and Plotly (loaded from a CDN); no Node, npm, or
+running API server is required, which makes the analysis viewable from a CLI /
+Coding Agent workflow without spinning up the full docker stack.
+
+The visual design intentionally mirrors ``apps/public-viewer``:
+
+* 750-px single column overview header (question / argument count / overview)
+* Scatter chart with no axes and the 40-color soft palette borrowed from
+  ``components/charts/ScatterChart.tsx`` (`softColors` array)
+* Cluster centroid annotations with the same per-character width based
+  wrap (``wrapLabelText``)
+* Cluster details list rendered like ``components/report/ClusterOverview.tsx``
+  with collapsible sub-cluster ``<details>`` for deeper levels
+
+The function ``build_html`` is exported so callers can use it standalone
+without the full pipeline orchestration (e.g. to render a HTML report from
+an already-generated ``hierarchical_result.json``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+PLOTLY_CDN = "https://cdn.plot.ly/plotly-2.35.2.min.js"
+
+# 40-color palette copied verbatim from
+# apps/public-viewer/components/charts/ScatterChart.tsx (softColors).
+SOFT_COLORS: list[str] = [
+    "#7ac943", "#3fa9f5", "#ff7997", "#e0dd02", "#d6410f",
+    "#b39647", "#7cccc3", "#a147e6", "#ff6b6b", "#4ecdc4",
+    "#ffbe0b", "#fb5607", "#8338ec", "#3a86ff", "#ff006e",
+    "#8ac926", "#1982c4", "#6a4c93", "#f72585", "#7209b7",
+    "#00b4d8", "#e76f51", "#606c38", "#9d4edd", "#457b9d",
+    "#bc6c25", "#2a9d8f", "#e07a5f", "#5e548e", "#81b29a",
+    "#f4a261", "#9b5de5", "#f15bb5", "#00bbf9", "#98c1d9",
+    "#84a59d", "#f28482", "#00afb9", "#cdb4db", "#fcbf49",
+]
 
 
-def hierarchical_visualization(config):
-    """Generate HTML visualization using npm build.
+def hierarchical_visualization(config: dict[str, Any]) -> None:
+    """Pipeline step entry point.
 
-    Config should contain:
-        - output_dir: output directory name
-        - report_dir: (optional) path to the report directory, defaults to "../report"
+    Reads ``outputs/{output_dir}/hierarchical_result.json`` and writes
+    ``outputs/{output_dir}/report.html`` next to it.
+
+    Optional ``config`` keys:
+        report_html_title: override the HTML <title>. Defaults to ``config["name"]``.
+        report_url_pattern: a Python str template like ``"https://example.com/r/{comment_id}"``.
+            When set, scatter points become clickable (open in new tab) and a 🔗
+            hint appears on hover, matching the public-viewer's
+            ``enable_source_link`` behaviour.
     """
     output_dir = config["output_dir"]
-    cwd = config.get("report_dir", "../report")
-    command = f"REPORT={output_dir} npm run build"
+    output_base_dir = config.get("_output_base_dir", "outputs")
+    result_path = Path(output_base_dir) / output_dir / "hierarchical_result.json"
+    html_path = Path(output_base_dir) / output_dir / "report.html"
 
-    try:
-        process = subprocess.Popen(
-            command,
-            shell=True,
-            cwd=cwd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            universal_newlines=True,
+    if not result_path.exists():
+        raise FileNotFoundError(
+            f"hierarchical_result.json not found at {result_path}. "
+            "Run the hierarchical_aggregation step first."
         )
-        while True:
-            output_line = process.stdout.readline()
-            if output_line == "" and process.poll() is not None:
-                break
-            if output_line:
-                print(output_line.strip())
-        process.wait()
-        errors = process.stderr.read()
-        if errors:
-            print("Errors:")
-            print(errors)
-    except subprocess.CalledProcessError as e:
-        print("Error: ", e)
+
+    data = json.loads(result_path.read_text(encoding="utf-8"))
+    html_str = build_html(
+        data,
+        title=config.get("report_html_title"),
+        url_pattern=config.get("report_url_pattern"),
+    )
+    html_path.write_text(html_str, encoding="utf-8")
+    print(f"  report.html: {html_path} ({html_path.stat().st_size / 1024:.1f} KB)")
+
+
+def build_html(
+    data: dict[str, Any],
+    title: str | None = None,
+    url_pattern: str | None = None,
+) -> str:
+    """Render a ``hierarchical_result.json`` payload into a single HTML string.
+
+    Args:
+        data: parsed contents of ``hierarchical_result.json``.
+        title: HTML ``<title>``. Defaults to ``data["config"]["name"]``.
+        url_pattern: Python ``str.format``-style template with ``{comment_id}``.
+            If provided, each scatter point becomes a clickable link to that URL
+            (target=_blank) and a 🔗 hint is added to the hover label.
+
+    Returns:
+        Full HTML document as a single string. Embeds the entire ``data`` payload
+        inline as ``<script id="report-data" type="application/json">``; Plotly is
+        loaded from the public CDN.
+    """
+    cfg = data.get("config", {}) or {}
+    title = title or cfg.get("name") or "kouchou-ai report"
+    question = cfg.get("question", "")
+    overview = data.get("overview", "") or ""
+    args = data.get("arguments", [])
+    n_args = len(args)
+    n_comments = data.get("comment_num", 0) or len({a.get("comment_id") for a in args})
+
+    levels = sorted({c["level"] for c in data["clusters"] if c["level"] > 0})
+    default_level = levels[0] if levels else 1
+
+    if url_pattern:
+        # Inject the resolved URL onto each argument so the JS click handler
+        # has it at hand. Mutates a shallow copy so the original isn't touched.
+        data = dict(data)
+        data["arguments"] = [
+            {**a, "url": a.get("url") or url_pattern.format(comment_id=a.get("comment_id"))}
+            for a in args
+        ]
+        args = data["arguments"]
+
+    tree_html = _render_tree(data)
+    embedded = json.dumps(data, ensure_ascii=False, separators=(",", ":"))
+    level_options = "".join(
+        f'<option value="{lvl}"{" selected" if lvl == default_level else ""}>'
+        f"level {lvl} ({_count_at(data, lvl)} clusters)</option>"
+        for lvl in levels
+    )
+
+    return _TEMPLATE.format(
+        title=html.escape(title),
+        question=html.escape(question),
+        overview=_paragraph(overview),
+        n_comments=f"{n_comments:,}",
+        n_args=f"{n_args:,}",
+        plotly_cdn=PLOTLY_CDN,
+        level_options=level_options,
+        tree=tree_html,
+        embedded_json=embedded,
+        palette_js=json.dumps(SOFT_COLORS),
+        enable_source_link_js="true" if url_pattern else "false",
+    )
+
+
+def _count_at(data: dict[str, Any], level: int) -> int:
+    return sum(1 for c in data["clusters"] if c["level"] == level)
+
+
+def _paragraph(text: str) -> str:
+    if not text:
+        return ""
+    paragraphs = [p.strip() for p in text.split("\n\n") if p.strip()]
+    return "\n".join(f"<p>{html.escape(p)}</p>" for p in paragraphs)
+
+
+def _render_tree(data: dict[str, Any]) -> str:
+    """Render the cluster hierarchy as nested ``<details>`` blocks.
+
+    Level 1 clusters are rendered as flat ``ClusterOverview``-style sections;
+    deeper levels live inside collapsible ``<details>``.
+    """
+    children_of: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for c in data["clusters"]:
+        if c["level"] > 0 and c.get("parent"):
+            children_of[c["parent"]].append(c)
+
+    args_in: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for a in data["arguments"]:
+        for cid in a.get("cluster_ids", []):
+            args_in[cid].append(a)
+
+    def render_children(parent_id: str) -> str:
+        kids = sorted(children_of.get(parent_id, []), key=lambda c: -c.get("value", 0))
+        if not kids:
+            return ""
+        items: list[str] = []
+        for k in kids:
+            cid = k["id"]
+            label = k.get("label", "")
+            value = k.get("value", 0)
+            inner: list[str] = [
+                f'<details class="sub-cluster" id="cluster-{html.escape(cid)}">',
+                "<summary>",
+                f'<span class="sub-label">{html.escape(label)}</span> ',
+                f'<span class="count-badge">{value:,} args</span>',
+                "</summary>",
+            ]
+            if k.get("takeaway"):
+                inner.append(f'<p class="sub-takeaway">{html.escape(k["takeaway"])}</p>')
+            grand = render_children(cid)
+            if grand:
+                inner.append(grand)
+            else:
+                members = args_in.get(cid, [])
+                if members:
+                    inner.append('<ul class="args">')
+                    for a in members:
+                        comment_id = html.escape(str(a.get("comment_id", "")))
+                        argument = html.escape(a.get("argument", ""))
+                        url = a.get("url")
+                        link = (
+                            f' <a href="{html.escape(url)}" target="_blank" rel="noopener" class="src-link">↗</a>'
+                            if url
+                            else ""
+                        )
+                        inner.append(
+                            f'<li><span class="comment-id">#{comment_id}</span> {argument}{link}</li>'
+                        )
+                    inner.append("</ul>")
+            inner.append("</details>")
+            items.append("\n".join(inner))
+        return '<div class="sub-clusters">\n' + "\n".join(items) + "\n</div>"
+
+    def render_level1(cluster: dict[str, Any]) -> str:
+        cid = cluster["id"]
+        parts: list[str] = [
+            f'<section class="cluster-overview" id="cluster-{html.escape(cid)}">',
+            f'<h3 class="cluster-heading">'
+            f'<a href="#cluster-{html.escape(cid)}" class="anchor">#</a> '
+            f'{html.escape(cluster.get("label", ""))}'
+            "</h3>",
+            f'<p class="cluster-count">💬 {cluster.get("value", 0):,} args</p>',
+        ]
+        if cluster.get("takeaway"):
+            parts.append(f'<p class="cluster-takeaway">{html.escape(cluster["takeaway"])}</p>')
+        parts.append(render_children(cid))
+        parts.append("</section>")
+        return "\n".join(parts)
+
+    level1 = sorted(
+        [c for c in data["clusters"] if c["level"] == 1],
+        key=lambda c: -c.get("value", 0),
+    )
+    return "\n".join(render_level1(c) for c in level1)
+
+
+_TEMPLATE = """<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{title}</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700&family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">
+<script src="{plotly_cdn}" defer></script>
+<style>
+  :root {{
+    --fg: #333;
+    --muted: #777;
+    --border: #e5e7eb;
+    --hover: #f3f4f6;
+    --accent: #2577b1;
+    --accent-soft: #e0eef7;
+  }}
+  * {{ box-sizing: border-box; }}
+  html, body {{
+    margin: 0; padding: 0;
+    font-family: "Roboto", "Noto Sans JP", -apple-system, BlinkMacSystemFont, sans-serif;
+    color: var(--fg);
+    background: #fff;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }}
+  .container {{ padding: 0 1.5rem 3rem; }}
+  .overview-section {{ max-width: 750px; margin: 40px auto 32px; }}
+  .label-small {{ font-size: 14px; font-weight: 700; margin-bottom: 12px; }}
+  h1.question {{
+    font-size: 28px; font-weight: 700; line-height: 1.4;
+    color: var(--accent); margin: 0 0 8px;
+  }}
+  .arg-count {{ font-size: 18px; font-weight: 700; margin: 8px 0 16px; display: flex; align-items: center; gap: 8px; }}
+  .arg-count .icon {{ font-size: 18px; }}
+  .arg-count .breakdown {{ font-size: 13px; color: var(--muted); font-weight: 400; }}
+  .overview-text p {{ margin: 8px 0; line-height: 1.7; }}
+
+  .chart-section {{ max-width: 1200px; margin: 32px auto 24px; }}
+  .chart-controls {{ display: flex; gap: 16px; align-items: center; margin: 0 auto 8px; max-width: 1200px; font-size: 13px; color: var(--muted); }}
+  .chart-controls label {{ display: inline-flex; align-items: center; gap: 6px; }}
+  .chart-controls select {{ font: inherit; padding: 4px 8px; border: 1px solid var(--border); border-radius: 4px; background: #fff; }}
+  #scatter {{
+    width: 100%; height: 600px;
+    border: 1px solid #ccc; border-radius: 4px; background: #fff;
+  }}
+
+  .clusters-section {{ max-width: 750px; margin: 48px auto 0; }}
+  .clusters-section h2 {{
+    text-align: center; font-size: 18px; font-weight: 700;
+    margin: 0 0 24px; padding-top: 24px; border-top: 1px solid var(--border);
+  }}
+  section.cluster-overview {{ margin: 0 0 48px; }}
+  .cluster-heading {{
+    font-size: 22px; font-weight: 700; color: var(--accent);
+    margin: 0 0 4px; position: relative;
+  }}
+  .cluster-heading .anchor {{
+    position: absolute; left: -1.4rem; color: var(--muted);
+    opacity: 0; transition: opacity 0.1s; text-decoration: none; font-weight: 400;
+  }}
+  .cluster-heading:hover .anchor {{ opacity: 1; }}
+  .cluster-count {{
+    font-size: 14px; font-weight: 700; margin: 0 0 12px; display: flex; align-items: center; gap: 6px;
+  }}
+  .cluster-takeaway {{ margin: 0 0 16px; line-height: 1.7; }}
+
+  .sub-clusters {{ margin: 16px 0 0; padding-left: 16px; border-left: 2px solid var(--border); }}
+  details.sub-cluster {{ margin: 10px 0; }}
+  details.sub-cluster > summary {{
+    cursor: pointer; padding: 6px 8px; border-radius: 4px;
+    list-style: none; font-size: 16px;
+  }}
+  details.sub-cluster > summary::-webkit-details-marker {{ display: none; }}
+  details.sub-cluster > summary:hover {{ background: var(--hover); }}
+  details.sub-cluster > summary::before {{ content: "▸ "; color: var(--muted); font-size: 12px; margin-right: 4px; }}
+  details.sub-cluster[open] > summary::before {{ content: "▾ "; color: var(--accent); }}
+  .sub-label {{ font-weight: 500; }}
+  .count-badge {{
+    display: inline-block; margin-left: 8px; padding: 2px 8px;
+    background: var(--accent-soft); color: var(--accent);
+    border-radius: 3px; font-size: 13px; font-weight: 500;
+  }}
+  .sub-takeaway {{ margin: 8px 0 8px 24px; color: var(--muted); font-size: 15px; line-height: 1.7; }}
+  ul.args {{ margin: 8px 0 12px 24px; padding-left: 20px; }}
+  ul.args li {{ margin: 4px 0; line-height: 1.7; font-size: 15px; }}
+  .comment-id {{ color: var(--muted); font-family: ui-monospace, Menlo, monospace; font-size: 12px; }}
+  .src-link {{ color: var(--accent); text-decoration: none; font-size: 13px; margin-left: 4px; }}
+  .src-link:hover {{ text-decoration: underline; }}
+
+  footer {{
+    max-width: 750px; margin: 64px auto 0; padding-top: 24px;
+    border-top: 1px solid var(--border); color: var(--muted); font-size: 12px;
+    text-align: center;
+  }}
+</style>
+</head>
+<body>
+<div class="container">
+
+<section class="overview-section">
+  <p class="label-small">Report</p>
+  <h1 class="question">{question}</h1>
+  <p class="arg-count">
+    <span class="icon">💬</span>
+    {n_args} arguments
+    <span class="breakdown">(from {n_comments} comments)</span>
+  </p>
+  <div class="overview-text">{overview}</div>
+</section>
+
+<section class="chart-section">
+  <div class="chart-controls">
+    <label>Color by level:
+      <select id="color-level">{level_options}</select>
+    </label>
+    <label>
+      <input type="checkbox" id="show-labels" checked> Show cluster labels
+    </label>
+    <span id="scatter-meta"></span>
+  </div>
+  <div id="scatter"></div>
+</section>
+
+<section class="clusters-section">
+  <h2>Clusters</h2>
+  {tree}
+</section>
+
+<footer>
+  Generated by analysis_core.steps.hierarchical_visualization
+</footer>
+
+</div>
+
+<script id="report-data" type="application/json">{embedded_json}</script>
+<script>
+(function() {{
+  const SOFT_COLORS = {palette_js};
+  const ENABLE_SOURCE_LINK = {enable_source_link_js};
+
+  function alpha(hex, a) {{
+    const aa = Math.floor(a * 255).toString(16).padStart(2, "0");
+    return hex + aa;
+  }}
+
+  // Mirrors apps/public-viewer wrapLabelText: ASCII chars take 0.6 width,
+  // full-width chars take 1.0 width relative to the font size.
+  function wrap(text, maxPx, fontPx) {{
+    let out = "", line = "", w = 0;
+    for (const ch of text) {{
+      const cw = /[!-~]/.test(ch) ? 0.6 : 1;
+      const px = cw * fontPx;
+      if (w + px > maxPx) {{
+        out += line + "<br>";
+        line = ch;
+        w = px;
+      }} else {{
+        line += ch;
+        w += px;
+      }}
+    }}
+    return out + line;
+  }}
+
+  function escapeHtml(s) {{
+    return String(s).replace(/[&<>"']/g, c => ({{
+      "&": "&amp;", "<": "&lt;", ">": "&gt;", "\\"": "&quot;", "'": "&#39;"
+    }}[c]));
+  }}
+
+  function init() {{
+    if (typeof Plotly === "undefined") {{ setTimeout(init, 50); return; }}
+    const data = JSON.parse(document.getElementById("report-data").textContent);
+    const byId = Object.fromEntries(data.clusters.map(c => [c.id, c]));
+
+    const select = document.getElementById("color-level");
+    const labelToggle = document.getElementById("show-labels");
+    const meta = document.getElementById("scatter-meta");
+
+    const ANNOTATION_WIDTH = 228, ANNOTATION_FONT = 14;
+
+    function build(level) {{
+      const clusters = data.clusters.filter(c => c.level === level);
+      const colorOf = {{}};
+      const colorOfA = {{}};
+      clusters.forEach((c, i) => {{
+        const base = SOFT_COLORS[i % SOFT_COLORS.length];
+        colorOf[c.id] = base;
+        colorOfA[c.id] = alpha(base, 0.8);
+      }});
+
+      const groups = {{}};
+      data.arguments.forEach(a => {{
+        const cid = a.cluster_ids.find(id => byId[id] && byId[id].level === level);
+        if (!cid) return;
+        if (!groups[cid]) groups[cid] = [];
+        groups[cid].push(a);
+      }});
+
+      const traces = clusters
+        .map(c => {{
+          const pts = groups[c.id] || [];
+          if (pts.length === 0) return null;
+          return {{
+            type: "scattergl",
+            mode: "markers",
+            name: c.label,
+            x: pts.map(a => a.x),
+            y: pts.map(a => a.y),
+            text: pts.map(a => {{
+              const body = "<b>" + escapeHtml(c.label) + "</b><br>" +
+                escapeHtml(a.argument).replace(/(.{{30}})/g, "$1<br>");
+              return ENABLE_SOURCE_LINK && a.url
+                ? body + "<br><b>🔗 Click to open source</b>"
+                : body;
+            }}),
+            customdata: pts.map(a => ({{ url: a.url || null, comment_id: a.comment_id }})),
+            hovertemplate: "%{{text}}<extra></extra>",
+            hoverlabel: {{
+              align: "left",
+              bgcolor: "white",
+              bordercolor: colorOf[c.id],
+              font: {{ size: 12, color: "#333" }},
+            }},
+            marker: ENABLE_SOURCE_LINK
+              ? {{ size: 10, color: colorOf[c.id], line: {{ width: 2, color: "#ffffff" }} }}
+              : {{ size: 7, color: colorOf[c.id] }},
+            showlegend: false,
+          }};
+        }})
+        .filter(Boolean);
+
+      const annotations = labelToggle.checked
+        ? clusters.map(c => {{
+            const pts = groups[c.id] || [];
+            if (pts.length === 0) return null;
+            const cx = pts.reduce((s, a) => s + a.x, 0) / pts.length;
+            const cy = pts.reduce((s, a) => s + a.y, 0) / pts.length;
+            return {{
+              x: cx, y: cy,
+              text: wrap(c.label, ANNOTATION_WIDTH, ANNOTATION_FONT),
+              showarrow: false,
+              font: {{ color: "white", size: ANNOTATION_FONT, weight: 700 }},
+              bgcolor: colorOfA[c.id],
+              borderpad: 10,
+              width: ANNOTATION_WIDTH,
+              align: "left",
+            }};
+          }}).filter(Boolean)
+        : [];
+
+      return {{ traces, annotations, clusters }};
+    }}
+
+    function redraw() {{
+      const lvl = parseInt(select.value, 10);
+      const {{ traces, annotations, clusters }} = build(lvl);
+      const layout = {{
+        uirevision: "scatter",
+        margin: {{ l: 0, r: 0, b: 0, t: 0 }},
+        xaxis: {{ zeroline: false, showticklabels: false, showgrid: false }},
+        yaxis: {{ zeroline: false, showticklabels: false, showgrid: false }},
+        hovermode: "closest",
+        dragmode: "pan",
+        annotations,
+        showlegend: false,
+      }};
+      const scatterEl = document.getElementById("scatter");
+      Plotly.react(scatterEl, traces, layout, {{
+        responsive: true,
+        displayModeBar: "hover",
+        scrollZoom: true,
+      }});
+      scatterEl.style.cursor = ENABLE_SOURCE_LINK ? "pointer" : "default";
+      if (ENABLE_SOURCE_LINK && !scatterEl._clickBound) {{
+        scatterEl.on("plotly_click", ev => {{
+          const pt = ev.points && ev.points[0];
+          const cd = pt && pt.customdata;
+          if (cd && cd.url) window.open(cd.url, "_blank", "noopener,noreferrer");
+        }});
+        scatterEl._clickBound = true;
+      }}
+      meta.textContent = clusters.length + " clusters / " + data.arguments.length + " args" +
+        (ENABLE_SOURCE_LINK ? " (click a point to open source)" : "");
+    }}
+
+    select.addEventListener("change", redraw);
+    labelToggle.addEventListener("change", redraw);
+
+    redraw();
+  }}
+  init();
+}})();
+</script>
+</body>
+</html>
+"""
+
+
+def _cli_main(argv: list[str] | None = None) -> int:
+    """Standalone CLI: render a hierarchical_result.json into a HTML file.
+
+    Useful when you already have a result JSON and only want the HTML view
+    (skips the orchestration / pipeline). For end-to-end CLI usage, prefer
+    ``kouchou-analyze --config X.json`` which now invokes this step.
+    """
+    parser = argparse.ArgumentParser(
+        prog="python -m analysis_core.steps.hierarchical_visualization",
+        description="Render hierarchical_result.json to a single-file HTML report.",
+    )
+    parser.add_argument("input", type=Path, help="path to hierarchical_result.json")
+    parser.add_argument("-o", "--output", type=Path, required=True, help="output HTML path")
+    parser.add_argument("--title", default=None, help="HTML <title> (defaults to config.name)")
+    parser.add_argument(
+        "--url-pattern",
+        default=None,
+        help='Python str.format template with {comment_id} (e.g. "https://example.com/r/{comment_id}"). '
+        "When set, scatter points become clickable and a 🔗 hint appears on hover.",
+    )
+    args = parser.parse_args(argv)
+
+    data = json.loads(args.input.read_text(encoding="utf-8"))
+    args.output.write_text(build_html(data, title=args.title, url_pattern=args.url_pattern), encoding="utf-8")
+    print(f"wrote {args.output} ({args.output.stat().st_size / 1024:.1f} KB)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_cli_main())

--- a/packages/analysis-core/tests/test_hierarchical_visualization.py
+++ b/packages/analysis-core/tests/test_hierarchical_visualization.py
@@ -95,6 +95,16 @@ class TestBuildHtml:
         # A representative color from the public-viewer-derived palette
         assert SOFT_COLORS[0] in out
 
+    def test_escapes_script_end_in_payload(self) -> None:
+        payload = _minimal_payload()
+        payload["overview"] = "first </script> second"
+        payload["arguments"][0]["argument"] = "alpha </script> beta"
+
+        out = build_html(payload)
+
+        assert "<\\/script>" in out
+        assert "</script> second" not in out
+
 
 class TestHierarchicalVisualizationStep:
     def test_writes_report_html_next_to_input(self, tmp_path: Path) -> None:

--- a/packages/analysis-core/tests/test_hierarchical_visualization.py
+++ b/packages/analysis-core/tests/test_hierarchical_visualization.py
@@ -1,0 +1,145 @@
+"""Tests for the self-contained HTML report visualization step."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from analysis_core.steps.hierarchical_visualization import (
+    SOFT_COLORS,
+    build_html,
+    hierarchical_visualization,
+)
+
+
+def _minimal_payload() -> dict:
+    """Smallest viable hierarchical_result.json shape used by the templates."""
+    return {
+        "config": {"name": "test report", "question": "what?"},
+        "overview": "first paragraph.\n\nsecond paragraph.",
+        "comment_num": 2,
+        "arguments": [
+            {
+                "arg_id": "A1_0",
+                "argument": "alpha",
+                "comment_id": "1",
+                "x": 0.1,
+                "y": 0.2,
+                "cluster_ids": ["0", "1_1"],
+                "url": None,
+            },
+            {
+                "arg_id": "A2_0",
+                "argument": "beta",
+                "comment_id": "2",
+                "x": -0.3,
+                "y": 0.4,
+                "cluster_ids": ["0", "1_2"],
+                "url": None,
+            },
+        ],
+        "clusters": [
+            {"id": "0", "level": 0, "label": "root", "value": 2, "parent": "", "takeaway": ""},
+            {"id": "1_1", "level": 1, "label": "alpha cluster", "value": 1, "parent": "0", "takeaway": "talk alpha"},
+            {"id": "1_2", "level": 1, "label": "beta cluster", "value": 1, "parent": "0", "takeaway": "talk beta"},
+        ],
+    }
+
+
+class TestBuildHtml:
+    def test_returns_full_html_document(self) -> None:
+        out = build_html(_minimal_payload())
+        assert out.startswith("<!DOCTYPE html>")
+        assert "</html>" in out
+        # The data payload is inlined verbatim
+        assert '<script id="report-data" type="application/json">' in out
+        # The Plotly bootstrap is included
+        assert "Plotly.react" in out
+
+    def test_title_defaults_to_config_name(self) -> None:
+        out = build_html(_minimal_payload())
+        assert "<title>test report</title>" in out
+
+    def test_explicit_title_overrides_config(self) -> None:
+        out = build_html(_minimal_payload(), title="override")
+        assert "<title>override</title>" in out
+
+    def test_question_and_overview_rendered(self) -> None:
+        out = build_html(_minimal_payload())
+        assert "what?" in out
+        # Multi-paragraph overview is split on blank lines
+        assert "<p>first paragraph.</p>" in out
+        assert "<p>second paragraph.</p>" in out
+
+    def test_cluster_labels_appear_in_tree(self) -> None:
+        out = build_html(_minimal_payload())
+        assert "alpha cluster" in out
+        assert "beta cluster" in out
+        # Level-1 cluster takeaways are rendered
+        assert "talk alpha" in out
+
+    def test_url_pattern_injects_per_argument_url(self) -> None:
+        out = build_html(_minimal_payload(), url_pattern="https://example.com/r/{comment_id}")
+        # URLs end up on the inlined JSON payload and in the sub-cluster <li> link
+        assert '"url":"https://example.com/r/1"' in out
+        assert '"url":"https://example.com/r/2"' in out
+        # The JS source-link flag is flipped on
+        assert "const ENABLE_SOURCE_LINK = true;" in out
+
+    def test_no_url_pattern_disables_source_link(self) -> None:
+        out = build_html(_minimal_payload())
+        assert "const ENABLE_SOURCE_LINK = false;" in out
+
+    def test_palette_is_inlined(self) -> None:
+        out = build_html(_minimal_payload())
+        # A representative color from the public-viewer-derived palette
+        assert SOFT_COLORS[0] in out
+
+
+class TestHierarchicalVisualizationStep:
+    def test_writes_report_html_next_to_input(self, tmp_path: Path) -> None:
+        # Arrange: synthesize the minimum file the step expects.
+        output_dir_name = "demo"
+        run_dir = tmp_path / output_dir_name
+        run_dir.mkdir()
+        (run_dir / "hierarchical_result.json").write_text(
+            json.dumps(_minimal_payload(), ensure_ascii=False), encoding="utf-8"
+        )
+
+        # Act: invoke the step the way the orchestrator does.
+        hierarchical_visualization({
+            "output_dir": output_dir_name,
+            "_output_base_dir": str(tmp_path),
+        })
+
+        # Assert: a single-file HTML report appears next to the input.
+        report_path = run_dir / "report.html"
+        assert report_path.exists()
+        html_text = report_path.read_text(encoding="utf-8")
+        assert html_text.startswith("<!DOCTYPE html>")
+        assert "test report" in html_text
+
+    def test_missing_input_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError, match="hierarchical_result.json"):
+            hierarchical_visualization({
+                "output_dir": "no-such-dir",
+                "_output_base_dir": str(tmp_path),
+            })
+
+    def test_url_pattern_from_config_is_honored(self, tmp_path: Path) -> None:
+        output_dir_name = "demo"
+        run_dir = tmp_path / output_dir_name
+        run_dir.mkdir()
+        (run_dir / "hierarchical_result.json").write_text(
+            json.dumps(_minimal_payload(), ensure_ascii=False), encoding="utf-8"
+        )
+
+        hierarchical_visualization({
+            "output_dir": output_dir_name,
+            "_output_base_dir": str(tmp_path),
+            "report_url_pattern": "https://example.com/r/{comment_id}",
+        })
+
+        html_text = (run_dir / "report.html").read_text(encoding="utf-8")
+        assert "https://example.com/r/1" in html_text
+        assert "const ENABLE_SOURCE_LINK = true;" in html_text


### PR DESCRIPTION
## 動機

CLI / Coding Agent ユーザーが `kouchou-analyze --config X.json` を走らせても、視覚的なレポートが出ない状態になっています。原因は 2 点:

1. **`packages/analysis-core/src/analysis_core/steps/hierarchical_visualization.py` が壊れている** — `subprocess.Popen("npm run build", cwd="../report")` を呼び出していますが、`../report` ディレクトリは新パッケージ構造には存在しません (リファクタで `apps/public-viewer/` 配下に移動)。step は黙って no-op になり、HTML は生成されません
2. **`--without-html` フラグが常に True** — `argparse` で `action="store_true", default=True` の組み合わせのため、フラグを渡しても渡さなくても True (= HTML スキップ)。`kouchou-analyze --dry-run` で `[SKIP] hierarchical_visualization: skipping html output` が必ず出る

CLI / Agent から散布図を見るには docker compose で admin UI + public-viewer + api をフルスタックで立ち上げて、admin にレポート登録 → public-viewer で閲覧、という重い経路しかありませんでした。

## 変更内容

### 1. `hierarchical_visualization` を Python self-contained HTML 生成に書き換え

`outputs/{run}/hierarchical_result.json` を読んで `outputs/{run}/report.html` を同じディレクトリに書く Python 実装に置換。

- **単一ファイル** (~500 KB for ~300 args)。Plotly は CDN 参照、JSON データは `<script id=\"report-data\" type=\"application/json\">` で inline。Node も pnpm も docker も api サーバも不要、`file://` でも動く
- **デザインは `apps/public-viewer` を踏襲**:
  - 750-px 1 カラムのヘッダー (質問 / argument 件数 / overview)
  - 散布図は軸無し + `apps/public-viewer/components/charts/ScatterChart.tsx` の `softColors` 40 色パレット + クラスタ重心アノテーション (per-character-width の `wrapLabelText` を JS に port)
  - クラスタ詳細リストは `apps/public-viewer/components/report/ClusterOverview.tsx` のスタイル踏襲、下層クラスタは折りたたみ `<details>` に
- **library API**: `build_html(data, title=None, url_pattern=None) -> str` を export。pipeline orchestrator を経由せず、既存の `hierarchical_result.json` から直接 HTML 文字列を得る用途で使える
- **`report_url_pattern` config キー (任意)** — `str.format` style の URL テンプレート (例: `\"https://example.com/r/{comment_id}\"`)。設定すると散布図の点クリックで元コメントが新タブで開き、ホバーに 🔗 ヒントが付く。public-viewer の `enable_source_link` 相当
- **standalone CLI**: `python -m analysis_core.steps.hierarchical_visualization hierarchical_result.json -o report.html [--url-pattern ...]`

### 2. `--without-html` の default を False に flip

`packages/analysis-core/src/analysis_core/__main__.py` で `action=\"store_true\", default=False` に変更。これで:

- デフォルトで HTML が生成される
- `--without-html` を明示的に渡したときだけスキップされる (= フラグが本来の opt-out として機能する)

`PipelineOrchestrator.from_config(without_html=True)` の library API 既定値は変えていないので library 利用者への影響なし。CLI のみの挙動変更です。

## テスト

新規 `packages/analysis-core/tests/test_hierarchical_visualization.py` (11 ケース):

- `build_html` の出力が valid HTML / `<title>` precedence / overview の paragraph 分割 / クラスタラベル埋め込み
- URL pattern の per-arg URL 注入と `ENABLE_SOURCE_LINK` フラグ切り替え
- 40 色パレットが inline されているか
- step 関数: 正常系 (`hierarchical_result.json` から `report.html` 生成) + missing input → `FileNotFoundError`
- step 関数: config の `report_url_pattern` が末端まで流れるか

```
$ pytest packages/analysis-core/tests/test_hierarchical_visualization.py -v
============================== 11 passed in 3.39s ==============================
```

`ruff check` も touched files で clean。

## 互換性

**破壊的変更なし**。

- 既存 `hierarchical_visualization` は `cwd=\"../report\"` を要求していたが、その path は新パッケージ構造には存在しないため事実上 **no-op** だった (HTML は出ていない)。本 PR の新実装は strict superset
- `--without-html` フラグはこれまでも値が常に True で flag を渡しても変化しなかった (= フラグが事実上機能していなかった) ため、観測される動作は「default が False で HTML が出るようになる」だけ
- `PipelineOrchestrator.from_config(without_html=...)` の library API default は維持

## スクリーンショット

300 件規模の `hierarchical_result.json` で生成した `report.html` の見た目:

- ヘッダー: 質問 + arguments 件数 + overview 段落
- 散布図: クラスタ重心に色付きアノテーション、ホバーで argument 本文 + クラスタ名
- クラスタ詳細: level 1 はフラットに列挙、下層は `<details>` で折りたたみ
- 階層レベル切替セレクター + クラスタラベル ON/OFF トグル
- `--url-pattern` ON 時: 点クリックで元コメントへ + マーカーが白枠 + ホバーに 🔗

(ローカルで `python -m analysis_core.steps.hierarchical_visualization /path/to/hierarchical_result.json -o report.html` で再現可能)

## 関連

なし (issue 化前に PR 提出)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Interactive HTML reports featuring scatter plots and hierarchical cluster visualizations
  * Clickable scatter points that open source code comments in the browser
  * Self-contained report files generated automatically with zero external dependencies

* **Improvements**
  * HTML report generation is now enabled by default; use `--without-html` to opt out

* **Documentation**
  * Updated CLI quickstart guide with instructions for viewing reports in the browser

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/digitaldemocracy2030/kouchou-ai/pull/825)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->