### PR TITLE
Add analysis-core CI and test fixes

### DIFF
--- a/.github/workflows/analysis-core-ci.yml
+++ b/.github/workflows/analysis-core-ci.yml
@@ -1,0 +1,69 @@
+name: Analysis Core CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "packages/analysis-core/**/*.py"
+      - "packages/analysis-core/pyproject.toml"
+      - "packages/analysis-core/requirements*.lock"
+      - ".github/workflows/analysis-core-ci.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "packages/analysis-core/**/*.py"
+      - "packages/analysis-core/pyproject.toml"
+      - "packages/analysis-core/requirements*.lock"
+      - ".github/workflows/analysis-core-ci.yml"
+  workflow_dispatch:
+
+jobs:
+  ruff:
+    name: Ruff
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./packages/analysis-core
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: "packages/analysis-core/requirements-dev.lock"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.lock
+
+      - name: Run Ruff
+        run: ruff check .
+
+  pytest:
+    name: Pytest
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./packages/analysis-core
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: "packages/analysis-core/requirements-dev.lock"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.lock
+
+      - name: Run pytest
+        run: pytest --cov=src --cov-report=term

--- a/.github/workflows/analysis-core-ci.yml
+++ b/.github/workflows/analysis-core-ci.yml
@@ -66,4 +66,7 @@ jobs:
           pip install -r requirements-dev.lock
 
       - name: Run pytest
+        env:
+          OPENAI_API_KEY: dummy
+          GEMINI_API_KEY: dummy
         run: pytest --cov=src --cov-report=term

--- a/packages/analysis-core/src/analysis_core/__main__.py
+++ b/packages/analysis-core/src/analysis_core/__main__.py
@@ -89,6 +89,7 @@ def main() -> int:
             skip_interaction=args.skip_interaction,
             without_html=args.without_html,
             validate_api_keys_early=not args.dry_run,
+            persist_status=not args.dry_run,
             output_base_dir=args.output_dir,
             input_base_dir=args.input_dir,
         )

--- a/packages/analysis-core/src/analysis_core/__main__.py
+++ b/packages/analysis-core/src/analysis_core/__main__.py
@@ -88,6 +88,7 @@ def main() -> int:
             only=args.only,
             skip_interaction=args.skip_interaction,
             without_html=args.without_html,
+            validate_api_keys_early=not args.dry_run,
             output_base_dir=args.output_dir,
             input_base_dir=args.input_dir,
         )

--- a/packages/analysis-core/src/analysis_core/core/orchestration.py
+++ b/packages/analysis-core/src/analysis_core/core/orchestration.py
@@ -374,6 +374,7 @@ def initialization(
     skip_interaction: bool = False,
     without_html: bool = True,
     validate_api_keys_early: bool = True,
+    persist_status: bool = True,
     output_base_dir: Path | None = None,
     input_base_dir: Path | None = None,
     specs_path: Path | None = None,
@@ -389,6 +390,7 @@ def initialization(
         skip_interaction: Skip interactive prompts
         without_html: Skip HTML visualization
         validate_api_keys_early: Validate provider credentials during initialization
+        persist_status: Persist running/completed status to hierarchical_status.json
         output_base_dir: Base directory for outputs (default: outputs/)
         input_base_dir: Base directory for inputs (default: inputs/)
         specs_path: Path to specs JSON file (default: package specs)
@@ -518,21 +520,22 @@ def initialization(
         input()
 
     # Ready to start - update status
-    update_status(
-        config,
-        {
-            "plan": plan,
-            "status": "running",
-            "start_time": datetime.now().isoformat(),
-            "completed_jobs": [],
-            "total_token_usage": 0,
-            "token_usage_input": 0,
-            "token_usage_output": 0,
-            "provider": config.get("provider"),
-            "model": config.get("model"),
-        },
-        output_base_dir,
-    )
+    if persist_status:
+        update_status(
+            config,
+            {
+                "plan": plan,
+                "status": "running",
+                "start_time": datetime.now().isoformat(),
+                "completed_jobs": [],
+                "total_token_usage": 0,
+                "token_usage_input": 0,
+                "token_usage_output": 0,
+                "provider": config.get("provider"),
+                "model": config.get("model"),
+            },
+            output_base_dir,
+        )
 
     return config
 

--- a/packages/analysis-core/src/analysis_core/core/orchestration.py
+++ b/packages/analysis-core/src/analysis_core/core/orchestration.py
@@ -373,6 +373,7 @@ def initialization(
     only: str | None = None,
     skip_interaction: bool = False,
     without_html: bool = True,
+    validate_api_keys_early: bool = True,
     output_base_dir: Path | None = None,
     input_base_dir: Path | None = None,
     specs_path: Path | None = None,
@@ -387,6 +388,7 @@ def initialization(
         only: Run only specified step
         skip_interaction: Skip interactive prompts
         without_html: Skip HTML visualization
+        validate_api_keys_early: Validate provider credentials during initialization
         output_base_dir: Base directory for outputs (default: outputs/)
         input_base_dir: Base directory for inputs (default: inputs/)
         specs_path: Path to specs JSON file (default: package specs)
@@ -419,7 +421,8 @@ def initialization(
     # Validate API keys early (fail-fast)
     # This ensures we catch missing API keys before starting any pipeline steps
     provider = config.get("provider", "openai")
-    validate_api_keys(provider)
+    if validate_api_keys_early:
+        validate_api_keys(provider)
 
     # Set output directory
     config["output_dir"] = job_name

--- a/packages/analysis-core/src/analysis_core/orchestrator.py
+++ b/packages/analysis-core/src/analysis_core/orchestrator.py
@@ -125,6 +125,7 @@ class PipelineOrchestrator:
         only: str | None = None,
         skip_interaction: bool = True,
         without_html: bool = True,
+        validate_api_keys_early: bool = True,
         output_base_dir: Path | None = None,
         input_base_dir: Path | None = None,
     ) -> "PipelineOrchestrator":
@@ -143,6 +144,7 @@ class PipelineOrchestrator:
             only: Run only specified step
             skip_interaction: Skip interactive prompts
             without_html: Skip HTML visualization
+            validate_api_keys_early: Validate provider credentials during initialization
             output_base_dir: Base directory for outputs
             input_base_dir: Base directory for inputs
 
@@ -157,6 +159,7 @@ class PipelineOrchestrator:
             only=only,
             skip_interaction=skip_interaction,
             without_html=without_html,
+            validate_api_keys_early=validate_api_keys_early,
             output_base_dir=output_base_dir,
             input_base_dir=input_base_dir,
             steps_module=steps_module,

--- a/packages/analysis-core/src/analysis_core/orchestrator.py
+++ b/packages/analysis-core/src/analysis_core/orchestrator.py
@@ -126,6 +126,7 @@ class PipelineOrchestrator:
         skip_interaction: bool = True,
         without_html: bool = True,
         validate_api_keys_early: bool = True,
+        persist_status: bool = True,
         output_base_dir: Path | None = None,
         input_base_dir: Path | None = None,
     ) -> "PipelineOrchestrator":
@@ -145,6 +146,7 @@ class PipelineOrchestrator:
             skip_interaction: Skip interactive prompts
             without_html: Skip HTML visualization
             validate_api_keys_early: Validate provider credentials during initialization
+            persist_status: Persist running/completed status to hierarchical_status.json
             output_base_dir: Base directory for outputs
             input_base_dir: Base directory for inputs
 
@@ -160,6 +162,7 @@ class PipelineOrchestrator:
             skip_interaction=skip_interaction,
             without_html=without_html,
             validate_api_keys_early=validate_api_keys_early,
+            persist_status=persist_status,
             output_base_dir=output_base_dir,
             input_base_dir=input_base_dir,
             steps_module=steps_module,

--- a/packages/analysis-core/src/analysis_core/steps/extraction.py
+++ b/packages/analysis-core/src/analysis_core/steps/extraction.py
@@ -32,8 +32,9 @@ def _filter_empty_comments(comments: pl.DataFrame) -> pl.DataFrame:
     Logs the number of filtered rows and raises RuntimeError if all comments are empty.
     """
     original_count = len(comments)
+    normalized_comment_body = pl.col("comment-body").cast(pl.String, strict=False).fill_null("")
     filtered = comments.filter(
-        pl.col("comment-body").is_not_null() & (pl.col("comment-body").str.strip_chars() != "")
+        normalized_comment_body.str.strip_chars() != ""
     )
     filtered_count = original_count - len(filtered)
     if filtered_count > 0:

--- a/packages/analysis-core/tests/e2e/test_pipeline_e2e.py
+++ b/packages/analysis-core/tests/e2e/test_pipeline_e2e.py
@@ -17,7 +17,6 @@ Usage:
 
 import json
 import shutil
-from pathlib import Path
 
 import polars as pl
 import pytest

--- a/packages/analysis-core/tests/test_cli.py
+++ b/packages/analysis-core/tests/test_cli.py
@@ -3,8 +3,9 @@
 import json
 import subprocess
 import sys
+from pathlib import Path
 
-import pytest
+PACKAGE_ROOT = Path(__file__).resolve().parents[1]
 
 
 class TestCLI:
@@ -16,7 +17,7 @@ class TestCLI:
             [sys.executable, "-m", "analysis_core", "--help"],
             capture_output=True,
             text=True,
-            cwd="/Users/nishio/kouchou-ai/packages/analysis-core",
+            cwd=PACKAGE_ROOT,
         )
         assert result.returncode == 0
         assert "kouchou-analyze" in result.stdout
@@ -31,7 +32,7 @@ class TestCLI:
             [sys.executable, "-m", "analysis_core", "--version"],
             capture_output=True,
             text=True,
-            cwd="/Users/nishio/kouchou-ai/packages/analysis-core",
+            cwd=PACKAGE_ROOT,
         )
         assert result.returncode == 0
         assert "kouchou-analyze" in result.stdout
@@ -43,7 +44,7 @@ class TestCLI:
             [sys.executable, "-m", "analysis_core", "--config", "nonexistent.json"],
             capture_output=True,
             text=True,
-            cwd="/Users/nishio/kouchou-ai/packages/analysis-core",
+            cwd=PACKAGE_ROOT,
         )
         assert result.returncode == 1
         assert "Config file not found" in result.stderr
@@ -84,7 +85,7 @@ class TestCLI:
             ],
             capture_output=True,
             text=True,
-            cwd="/Users/nishio/kouchou-ai/packages/analysis-core",
+            cwd=PACKAGE_ROOT,
         )
         assert result.returncode == 0
         assert "Execution Plan" in result.stdout

--- a/packages/analysis-core/tests/test_cli.py
+++ b/packages/analysis-core/tests/test_cli.py
@@ -91,3 +91,4 @@ class TestCLI:
         assert "Execution Plan" in result.stdout
         assert "extraction" in result.stdout
         assert "embedding" in result.stdout
+        assert not (output_dir / "test_config" / "hierarchical_status.json").exists()

--- a/packages/analysis-core/tests/test_compat.py
+++ b/packages/analysis-core/tests/test_compat.py
@@ -1,7 +1,5 @@
 """Tests for compatibility layer."""
 
-import pytest
-
 from analysis_core.compat import create_step_context_from_config, normalize_config
 
 

--- a/packages/analysis-core/tests/test_config.py
+++ b/packages/analysis-core/tests/test_config.py
@@ -1,10 +1,7 @@
 """Tests for configuration management."""
 
 import json
-import tempfile
 from pathlib import Path
-
-import pytest
 
 from analysis_core.config import PipelineConfig, load_config, save_config
 

--- a/packages/analysis-core/tests/test_imports.py
+++ b/packages/analysis-core/tests/test_imports.py
@@ -1,7 +1,5 @@
 """Test that all package modules can be imported correctly."""
 
-import pytest
-
 
 class TestCoreImports:
     """Test core module imports."""

--- a/packages/analysis-core/tests/test_integration.py
+++ b/packages/analysis-core/tests/test_integration.py
@@ -1,9 +1,7 @@
 """Integration tests for analysis-core pipeline."""
 
 import json
-from unittest.mock import MagicMock, patch
-
-import pytest
+from unittest.mock import patch
 
 from analysis_core import PipelineOrchestrator
 from analysis_core.orchestrator import PipelineResult

--- a/packages/analysis-core/tests/test_loader.py
+++ b/packages/analysis-core/tests/test_loader.py
@@ -9,13 +9,9 @@ from analysis_core.plugin import (
     PluginLoadError,
     PluginManifest,
     PluginRegistry,
-    StepContext,
-    StepInputs,
-    StepOutputs,
     load_manifest,
     load_plugin_from_directory,
     load_plugins_from_directory,
-    step_plugin,
 )
 
 

--- a/packages/analysis-core/tests/test_pipeline_paths_integration.py
+++ b/packages/analysis-core/tests/test_pipeline_paths_integration.py
@@ -8,8 +8,8 @@ This is a regression test for bugs where:
 - update_status/update_progress didn't read _output_base_dir from config
 """
 
-import pickle
 import json
+import pickle
 import tempfile
 from pathlib import Path
 from unittest.mock import patch

--- a/packages/analysis-core/tests/test_prompts.py
+++ b/packages/analysis-core/tests/test_prompts.py
@@ -3,8 +3,6 @@
 import json
 from pathlib import Path
 
-import pytest
-
 from analysis_core.prompts import (
     DEFAULT_PROMPTS,
     EXTRACTION_PROMPT,

--- a/packages/analysis-core/tests/test_steps_paths.py
+++ b/packages/analysis-core/tests/test_steps_paths.py
@@ -9,7 +9,6 @@ like f"outputs/{dataset}/..." instead of using config.get("_output_base_dir").
 
 import ast
 import inspect
-from pathlib import Path
 
 import pytest
 

--- a/packages/analysis-core/tests/test_workflow_engine.py
+++ b/packages/analysis-core/tests/test_workflow_engine.py
@@ -1,7 +1,6 @@
 """Tests for WorkflowEngine."""
 
 from pathlib import Path
-from typing import Any
 
 import pytest
 
@@ -19,7 +18,6 @@ from analysis_core.workflow import (
     WorkflowEngine,
     WorkflowStep,
 )
-from analysis_core.workflow.engine import WorkflowExecutionError
 
 
 @pytest.fixture


### PR DESCRIPTION
# Summary
- add a dedicated GitHub Actions workflow for `packages/analysis-core`
- fix `analysis_core` tests so they are CI-safe and path-independent
- allow CLI `--dry-run` to skip early API key validation and harden empty-comment filtering

# Background
- `analysis-core` had no package-specific CI even though it is published separately to PyPI
- `tests/test_cli.py` depended on a local absolute path and `--dry-run` still failed before plan display
- the extraction filter crashed on all-`None` comment bodies with a Polars schema error instead of the intended runtime error

# Verification
- `ruff check .`
- `OPENAI_API_KEY=dummy GEMINI_API_KEY=dummy .venv-ci/bin/pytest -q`
- result: `120 passed, 1 warning`

# Notes
- the remaining UMAP warning is known and currently acceptable; seed/parallelism can be revisited when that option is added

# Related
- no linked issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dry-run mode now skips early API key validation and avoids persisting run status, making plan-generation faster and side-effect free.

* **Chores**
  * Added continuous checks and test runs via a new CI workflow.
  * Cleaned and consolidated test imports for more reliable, portable tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/digitaldemocracy2030/kouchou-ai/pull/826?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->