### PR TITLE
[codex] fix public-viewer reporter API URL fallback

### DIFF
--- a/apps/public-viewer/app/utils/__tests__/api.test.ts
+++ b/apps/public-viewer/app/utils/__tests__/api.test.ts
@@ -1,4 +1,4 @@
-import { getApiBaseUrl } from "../api";
+import { getApiBaseUrl, getApiUrl } from "../api";
 
 describe("getApiBaseUrl", () => {
   const originalEnv = process.env;
@@ -45,5 +45,40 @@ describe("getApiBaseUrl", () => {
     process.env.NEXT_PUBLIC_API_BASEPATH = "https://example.com/api";
 
     expect(getApiBaseUrl()).toBe("https://example.com/api");
+  });
+
+  it("builds an API URL from API_BASEPATH on the server", () => {
+    Object.defineProperty(global, "window", {
+      value: undefined,
+      writable: true,
+    });
+
+    process.env.API_BASEPATH = "https://server-side.com/api/";
+
+    expect(getApiUrl("/meta/reporter.png")).toBe("https://server-side.com/meta/reporter.png");
+  });
+
+  it("falls back to NEXT_PUBLIC_API_BASEPATH when building an API URL on the server", () => {
+    Object.defineProperty(global, "window", {
+      value: undefined,
+      writable: true,
+    });
+
+    process.env.API_BASEPATH = undefined;
+    process.env.NEXT_PUBLIC_API_BASEPATH = "https://example.com/api";
+
+    expect(getApiUrl("/meta/reporter.png")).toBe("https://example.com/meta/reporter.png");
+  });
+
+  it("returns null when no API base URL is configured", () => {
+    Object.defineProperty(global, "window", {
+      value: undefined,
+      writable: true,
+    });
+
+    process.env.API_BASEPATH = undefined;
+    process.env.NEXT_PUBLIC_API_BASEPATH = undefined;
+
+    expect(getApiUrl("/meta/reporter.png")).toBeNull();
   });
 });

--- a/apps/public-viewer/app/utils/api.ts
+++ b/apps/public-viewer/app/utils/api.ts
@@ -20,3 +20,22 @@ export const getApiBaseUrl = (): string => {
   // それ以外の場合はNEXT_PUBLIC_API_BASEPATHを使用
   return process.env.NEXT_PUBLIC_API_BASEPATH || "";
 };
+
+/**
+ * APIのベースURLと相対パスから絶対URLを組み立てる
+ *
+ * @param path API配下の相対パス
+ * @returns 組み立てたURL。ベースURLが未設定または不正な場合はnull
+ */
+export const getApiUrl = (path: string): string | null => {
+  const baseUrl = getApiBaseUrl();
+  if (!baseUrl) {
+    return null;
+  }
+
+  try {
+    return new URL(path, baseUrl).toString();
+  } catch {
+    return null;
+  }
+};

--- a/apps/public-viewer/components/reporter/Reporter.tsx
+++ b/apps/public-viewer/components/reporter/Reporter.tsx
@@ -1,3 +1,4 @@
+import { getApiUrl } from "@/app/utils/api";
 import { getImageFromServerSrc } from "@/app/utils/image-src";
 import type { Meta } from "@/type";
 import { Image } from "@chakra-ui/react";
@@ -6,7 +7,11 @@ import { ReporterContent } from "./ReporterContent";
 const imagePath = "/meta/reporter.png";
 
 async function hasReporterImage() {
-  const url = new URL(imagePath, process.env.API_BASEPATH).toString();
+  const url = getApiUrl(imagePath);
+  if (!url) {
+    return false;
+  }
+
   try {
     const res = await fetch(url);
     return res.status === 200;


### PR DESCRIPTION
## What changed
- add `getApiUrl()` to `apps/public-viewer/app/utils/api.ts`
- switch `Reporter` image probing to use the same API base URL fallback as the rest of `public-viewer`
- add unit tests for server-side URL construction and missing-env handling

## Why
`Reporter` was using `process.env.API_BASEPATH` directly via `new URL(...)`, while the rest of `public-viewer` uses `getApiBaseUrl()` and falls back to `NEXT_PUBLIC_API_BASEPATH` when `API_BASEPATH` is unset.

That mismatch meant the root page could fail prerender with `ERR_INVALID_URL` even in environments where the app otherwise had a valid API base URL.

## Impact
- `public-viewer` build behavior is more predictable across CI and local environments
- root page prerender no longer has a stricter env requirement than the rest of the app
- missing or invalid API base URL now degrades to "reporter image absent" instead of throwing during prerender

## Validation
- `pnpm test -- --runInBand app/utils/__tests__/api.test.ts`
- `NEXT_PUBLIC_API_BASEPATH=http://127.0.0.1:18000 NEXT_PUBLIC_PUBLIC_API_KEY=test pnpm build` with a minimal mock API


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added improved API URL construction utility for better consistency across the application.

* **Bug Fixes**
  * Enhanced reporter image URL handling with more robust error management.
  * Better support for different server-side and client-side configuration scenarios.

* **Tests**
  * Added comprehensive test coverage for API URL construction with various environment configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/digitaldemocracy2030/kouchou-ai/pull/828?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->