### PR TITLE
Add analysis-core publish workflow

### DIFF
--- a/.github/workflows/publish-analysis-core.yml
+++ b/.github/workflows/publish-analysis-core.yml
@@ -1,0 +1,48 @@
+name: Publish analysis-core to PyPI
+
+on:
+  push:
+    tags:
+      - "analysis-core-v*"
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: "packages/analysis-core/requirements-dev.lock"
+
+      - name: Install dependencies
+        working-directory: ./packages/analysis-core
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.lock
+          pip install build
+
+      - name: Run Ruff
+        working-directory: ./packages/analysis-core
+        run: ruff check .
+
+      - name: Run pytest
+        working-directory: ./packages/analysis-core
+        env:
+          OPENAI_API_KEY: dummy
+          GEMINI_API_KEY: dummy
+        run: pytest --cov=src --cov-report=term
+
+      - name: Build package
+        run: python -m build packages/analysis-core
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: packages/analysis-core/dist/
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/docs/development/pypi-release.md
+++ b/docs/development/pypi-release.md
@@ -29,7 +29,7 @@ version = "0.1.1"  # ← ここを更新
 ```bash
 git add packages/analysis-core/pyproject.toml
 git commit -m "chore: Bump version to 0.1.1"
-git tag v0.1.1
+git tag analysis-core-v0.1.1
 git push && git push --tags
 ```
 
@@ -156,13 +156,13 @@ Homepage = "..."
 ## GitHub Actions での自動リリース（参考）
 
 ```yaml
-# .github/workflows/publish.yml
-name: Publish to PyPI
+# .github/workflows/publish-analysis-core.yml
+name: Publish analysis-core to PyPI
 
 on:
   push:
     tags:
-      - 'v*'
+      - 'analysis-core-v*'
 
 jobs:
   publish:
@@ -188,7 +188,7 @@ jobs:
 - [ ] テストが全てパス (`pytest`)
 - [ ] バージョン番号を更新
 - [ ] CHANGELOG/リリースノートを更新（必要に応じて）
-- [ ] コミット & タグ作成
+- [ ] コミット & `analysis-core-vX.Y.Z` タグ作成
 - [ ] ビルド成功
 - [ ] TestPyPI でテスト（オプション）
 - [ ] PyPI にアップロード


### PR DESCRIPTION
# Summary
- add `publish-analysis-core.yml` for PyPI release automation
- trigger publishes only on `analysis-core-v*` tags
- update the PyPI release playbook to match the new tag convention

# Background
- the package-specific CI is already in `main`, but the publish workflow was committed after the previous PR was merged
- `PYPI_API_TOKEN` is now configured in repository secrets
- release tags for this package should use the dedicated `analysis-core-v*` namespace rather than the repo-wide `v*`

# Verification
- workflow definition reviewed locally
- release docs updated to use `analysis-core-v0.1.1`

# Notes
- this workflow runs `ruff`, `pytest`, `build`, then `pypa/gh-action-pypi-publish`
- actual publish execution will occur only when an `analysis-core-v*` tag is pushed

# Related
- follow-up to the merged CI groundwork from #826