### PR TITLE
feat: auto-calculate cluster counts in analysis-core when omitted

### DIFF
--- a/docs/user-guide/cli-quickstart.md
+++ b/docs/user-guide/cli-quickstart.md
@@ -61,12 +61,11 @@ comment-id,comment-body,source
   "extraction": {
     "workers": 3,
     "limit": 100
-  },
-  "hierarchical_clustering": {
-    "cluster_nums": [3, 6]
   }
 }
 ```
+
+`hierarchical_clustering.cluster_nums` は省略可能です。省略した場合は、extraction 後の argument 数に基づいておすすめ値が自動計算されます。
 
 ### 設定項目の説明
 
@@ -80,7 +79,7 @@ comment-id,comment-body,source
 | `is_embedded_at_local` | ローカルでエンベディングを行うか |
 | `extraction.workers` | 並列処理数 |
 | `extraction.limit` | 処理するコメント数の上限 |
-| `hierarchical_clustering.cluster_nums` | 階層クラスタリングの各レベルのクラスター数 |
+| `hierarchical_clustering.cluster_nums` | 階層クラスタリングの各レベルのクラスター数。省略時は extraction 後の argument 数からおすすめ値を自動計算 |
 
 ## 4. 環境変数の設定
 

--- a/docs/user-guide/import-quickstart.md
+++ b/docs/user-guide/import-quickstart.md
@@ -37,9 +37,6 @@ config = {
         "workers": 3,
         "limit": 100,
     },
-    "hierarchical_clustering": {
-        "cluster_nums": [3, 6],
-    },
 }
 
 # パイプラインを実行
@@ -55,6 +52,8 @@ result = orchestrator.run()
 print(f"ステータス: {result['status']}")
 print(f"出力ディレクトリ: {result['output_dir']}")
 ```
+
+`hierarchical_clustering.cluster_nums` は省略可能です。省略した場合は、extraction 後の argument 数に基づいておすすめ値が自動計算されます。
 
 ### PipelineConfig クラスを使用する
 
@@ -378,7 +377,6 @@ config = {
     "provider": "openai",
     "is_embedded_at_local": False,
     "extraction": {"workers": 2, "limit": 50},
-    "hierarchical_clustering": {"cluster_nums": [3, 6]},
 }
 
 orchestrator = PipelineOrchestrator.from_config(config)

--- a/packages/analysis-core/src/analysis_core/compat/config_converter.py
+++ b/packages/analysis-core/src/analysis_core/compat/config_converter.py
@@ -97,7 +97,6 @@ def normalize_config(config: dict[str, Any], include_source_code: bool = True) -
 
     # Hierarchical clustering defaults
     clustering = result.setdefault("hierarchical_clustering", {})
-    clustering.setdefault("cluster_nums", [3, 6])
     if "hierarchical_clustering" in source_codes:
         clustering.setdefault("source_code", source_codes["hierarchical_clustering"])
 

--- a/packages/analysis-core/src/analysis_core/plugins/builtin/hierarchical_clustering.py
+++ b/packages/analysis-core/src/analysis_core/plugins/builtin/hierarchical_clustering.py
@@ -35,7 +35,7 @@ def hierarchical_clustering_plugin(
     merge for multi-level clustering.
 
     Config options:
-        - cluster_nums: Optional list of cluster counts for each level (e.g., [3, 6, 12])
+        - cluster_nums (optional): List of cluster counts for each level (e.g., [3, 6, 12])
     """
     from analysis_core.steps.hierarchical_clustering import (
         hierarchical_clustering as clustering_impl,

--- a/packages/analysis-core/src/analysis_core/plugins/builtin/hierarchical_clustering.py
+++ b/packages/analysis-core/src/analysis_core/plugins/builtin/hierarchical_clustering.py
@@ -35,7 +35,7 @@ def hierarchical_clustering_plugin(
     merge for multi-level clustering.
 
     Config options:
-        - cluster_nums: List of cluster counts for each level (e.g., [3, 6, 12])
+        - cluster_nums: Optional list of cluster counts for each level (e.g., [3, 6, 12])
     """
     from analysis_core.steps.hierarchical_clustering import (
         hierarchical_clustering as clustering_impl,
@@ -45,7 +45,7 @@ def hierarchical_clustering_plugin(
     legacy_config = {
         "output_dir": ctx.dataset,
         "hierarchical_clustering": {
-            "cluster_nums": step_config.get("cluster_nums", [3, 6]),
+            "cluster_nums": step_config.get("cluster_nums"),
         },
     }
 

--- a/packages/analysis-core/src/analysis_core/specs/hierarchical_specs.json
+++ b/packages/analysis-core/src/analysis_core/specs/hierarchical_specs.json
@@ -22,7 +22,7 @@
         "step": "hierarchical_clustering",
         "filename": "hierarchical_clusters.csv",
         "dependencies": {"params": ["cluster_nums"], "steps": ["embedding"]},
-        "options": {"cluster_nums": [3, 6]}
+        "options": {"cluster_nums": null}
     },
     {
         "step": "hierarchical_initial_labelling",

--- a/packages/analysis-core/src/analysis_core/steps/hierarchical_clustering.py
+++ b/packages/analysis-core/src/analysis_core/steps/hierarchical_clustering.py
@@ -9,6 +9,16 @@ import scipy.cluster.hierarchy as sch
 from sklearn.cluster import KMeans
 
 
+def calculate_recommended_cluster_nums(argument_count: int) -> list[int]:
+    """Calculate recommended cluster counts from extracted argument count."""
+    if argument_count < 2:
+        raise ValueError("argument_count must be at least 2")
+
+    lv1 = max(2, min(10, round(argument_count ** (1 / 3))))
+    lv2 = max(2, min(1000, lv1 * lv1))
+    return [lv1, lv2]
+
+
 def hierarchical_clustering(config):
     UMAP = import_module("umap").UMAP
 
@@ -44,7 +54,11 @@ def hierarchical_clustering(config):
             f"args.csv と embeddings.pkl の件数が一致しません: args={len(arg_ids)}, embeddings={embeddings_array.shape[0]}"
         )
 
-    cluster_nums = config["hierarchical_clustering"]["cluster_nums"]
+    cluster_nums = config["hierarchical_clustering"].get("cluster_nums")
+    if not cluster_nums:
+        cluster_nums = calculate_recommended_cluster_nums(len(arg_ids))
+        config["hierarchical_clustering"]["cluster_nums"] = cluster_nums
+        print(f"cluster_nums not provided; using recommended cluster counts based on arg count: {cluster_nums}")
 
     n_samples = embeddings_array.shape[0]
     # デフォルト設定は15

--- a/packages/analysis-core/src/analysis_core/steps/hierarchical_clustering.py
+++ b/packages/analysis-core/src/analysis_core/steps/hierarchical_clustering.py
@@ -10,7 +10,16 @@ from sklearn.cluster import KMeans
 
 
 def calculate_recommended_cluster_nums(argument_count: int) -> list[int]:
-    """Calculate recommended cluster counts from extracted argument count."""
+    """Calculate cluster counts with a cube-root rule.
+
+    The recommendation is derived from extracted argument count:
+    - lv1 = round(cuberoot(argument_count))
+    - lv2 = lv1^2
+
+    Examples:
+    - 1000 -> [10, 100]
+    - 125 -> [5, 25]
+    """
     if argument_count < 2:
         raise ValueError("argument_count must be at least 2")
 

--- a/packages/analysis-core/tests/test_cli.py
+++ b/packages/analysis-core/tests/test_cli.py
@@ -1,6 +1,7 @@
 """Tests for CLI entry point."""
 
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -28,6 +29,8 @@ class TestCLI:
 
     def test_cli_version(self):
         """Test CLI --version option."""
+        from analysis_core import __version__
+
         result = subprocess.run(
             [sys.executable, "-m", "analysis_core", "--version"],
             capture_output=True,
@@ -35,8 +38,8 @@ class TestCLI:
             cwd=PACKAGE_ROOT,
         )
         assert result.returncode == 0
-        assert "kouchou-analyze" in result.stdout
-        assert "0.1.0" in result.stdout
+        assert re.fullmatch(r"kouchou-analyze \S+\n", result.stdout)
+        assert result.stdout.strip() == f"kouchou-analyze {__version__}"
 
     def test_cli_missing_config(self):
         """Test CLI fails with missing config file."""

--- a/packages/analysis-core/tests/test_compat.py
+++ b/packages/analysis-core/tests/test_compat.py
@@ -42,7 +42,7 @@ class TestNormalizeConfig:
         result = normalize_config(config)
 
         assert "hierarchical_clustering" in result
-        assert result["hierarchical_clustering"]["cluster_nums"] == [3, 6]
+        assert "cluster_nums" not in result["hierarchical_clustering"]
 
     def test_fills_labelling_defaults(self):
         """Test that labelling defaults are filled in."""

--- a/packages/analysis-core/tests/test_hierarchical_clustering.py
+++ b/packages/analysis-core/tests/test_hierarchical_clustering.py
@@ -1,0 +1,20 @@
+"""Tests for hierarchical clustering helpers."""
+
+from analysis_core.steps.hierarchical_clustering import calculate_recommended_cluster_nums
+
+
+class TestCalculateRecommendedClusterNums:
+    """Tests for automatic cluster count recommendation."""
+
+    def test_returns_expected_counts_for_1000_arguments(self):
+        """1000 arguments should map to the issue's target recommendation."""
+        assert calculate_recommended_cluster_nums(1000) == [10, 100]
+
+    def test_uses_cube_root_based_scaling(self):
+        """Smaller datasets should follow the same scaling rule."""
+        assert calculate_recommended_cluster_nums(125) == [5, 25]
+        assert calculate_recommended_cluster_nums(400) == [7, 49]
+
+    def test_enforces_minimum_cluster_counts(self):
+        """Very small datasets should still get a valid two-level hierarchy."""
+        assert calculate_recommended_cluster_nums(2) == [2, 4]

--- a/packages/analysis-core/tests/test_imports.py
+++ b/packages/analysis-core/tests/test_imports.py
@@ -1,5 +1,7 @@
 """Test that all package modules can be imported correctly."""
 
+import re
+
 
 class TestCoreImports:
     """Test core module imports."""
@@ -8,7 +10,7 @@ class TestCoreImports:
         """Test main package exports."""
         from analysis_core import PipelineConfig, PipelineOrchestrator, __version__
 
-        assert __version__ == "0.1.0"
+        assert re.fullmatch(r"\d+\.\d+\.\d+", __version__)
         assert PipelineOrchestrator is not None
         assert PipelineConfig is not None
 

--- a/packages/analysis-core/tests/test_orchestration.py
+++ b/packages/analysis-core/tests/test_orchestration.py
@@ -113,7 +113,7 @@ class TestInitialization:
         assert config["extraction"]["workers"] == 1
 
         assert "hierarchical_clustering" in config
-        assert config["hierarchical_clustering"]["cluster_nums"] == [3, 6]
+        assert config["hierarchical_clustering"]["cluster_nums"] is None
 
     def test_initialization_force_flag(self, tmp_path):
         """Test that force flag is set in config."""

--- a/packages/analysis-core/tests/test_pipeline_paths_integration.py
+++ b/packages/analysis-core/tests/test_pipeline_paths_integration.py
@@ -244,6 +244,35 @@ class TestPipelinePathsIntegration:
         hardcoded_clusters = Path("outputs") / sample_config["output_dir"] / "hierarchical_clusters.csv"
         assert not hardcoded_clusters.exists(), "hierarchical_clusters.csv was created at hardcoded path!"
 
+    def test_hierarchical_clustering_auto_calculates_cluster_nums(self, temp_dirs, sample_config):
+        """Test that hierarchical_clustering fills recommended cluster counts when omitted."""
+        from analysis_core.steps.hierarchical_clustering import hierarchical_clustering
+
+        output_subdir = temp_dirs["output_dir"] / sample_config["output_dir"]
+        output_subdir.mkdir(parents=True)
+
+        import numpy as np
+
+        args_df = pl.DataFrame(
+            {
+                "arg-id": [f"arg{i}" for i in range(20)],
+                "argument": [f"Test argument {i}" for i in range(20)],
+            }
+        )
+        args_df.write_csv(output_subdir / "args.csv")
+
+        embeddings_data = [
+            {"arg-id": f"arg{i}", "embedding": np.random.rand(100).tolist()} for i in range(20)
+        ]
+        with open(output_subdir / "embeddings.pkl", "wb") as f:
+            pickle.dump(embeddings_data, f)
+
+        sample_config["hierarchical_clustering"] = {"cluster_nums": None}
+
+        hierarchical_clustering(sample_config)
+
+        assert sample_config["hierarchical_clustering"]["cluster_nums"] == [3, 9]
+
 
 class TestOrchestratorPathsIntegration:
     """Integration tests for PipelineOrchestrator path handling."""

--- a/packages/report-schema/src/index.ts
+++ b/packages/report-schema/src/index.ts
@@ -277,7 +277,7 @@ export type ExtractionConfig = {
  * クラスタリング設定
  */
 export type HierarchicalClusteringConfig = {
-  cluster_nums: number[];
+  cluster_nums?: number[] | null;
   source_code: string;
 };
 


### PR DESCRIPTION
## 概要
- `cluster_nums` 未指定時に、extraction 後の argument 数から推奨クラスタ数を自動計算するように変更
- 固定デフォルト `[3, 6]` を CLI / analysis-core の compat, specs, plugin fallback から除去
- quickstart と関連テストを新仕様へ更新

## 変更内容
- `analysis_core.steps.hierarchical_clustering` に推奨クラスタ数計算を追加
- 計算式は Admin 側の既存ロジックに合わせて `lv1 = round(cuberoot(argument_count))`, `lv2 = lv1^2` をベースに使用
- `argument_count=1000` で `[10, 100]` になることをテストで保証
- `cluster_nums` 省略時は実行ログに採用値を出力し、config にも反映
- `docs/user-guide/cli-quickstart.md` / `docs/user-guide/import-quickstart.md` から `[3, 6]` の例を削除

## テスト
- `packages/analysis-core/.venv-ci/bin/python -m pytest packages/analysis-core/tests/test_hierarchical_clustering.py packages/analysis-core/tests/test_compat.py packages/analysis-core/tests/test_orchestration.py packages/analysis-core/tests/test_pipeline_paths_integration.py -q`

## CLAへの同意
- [x] CLAの内容を読み、同意しました

Closes #830


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Hierarchical clustering `cluster_nums` parameter is now optional and automatically calculated based on extracted argument count when omitted.

* **Documentation**
  * Updated quickstart guides to reflect optional `cluster_nums` configuration and auto-calculation behavior.

* **Tests**
  * Added tests validating automatic cluster number calculation and updated existing tests for new optional parameter behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/digitaldemocracy2030/kouchou-ai/pull/832?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->