### PR TITLE
fix: validate public report payload before serving

### DIFF
--- a/apps/api/src/routers/report.py
+++ b/apps/api/src/routers/report.py
@@ -6,6 +6,7 @@ from fastapi.security.api_key import APIKeyHeader
 from pydantic import ValidationError
 
 from src.config import settings
+from src.schemas.public_report_result import PublicReportResult
 from src.schemas.report import Report, ReportStatus, ReportVisibility
 from src.schemas.visualization_config import DEFAULT_REPORT_DISPLAY_CONFIG, ReportDisplayConfig
 from src.services.report_status import load_status_as_reports
@@ -16,6 +17,21 @@ logger = logging.getLogger("uvicorn")
 router = APIRouter()
 
 api_key_header = APIKeyHeader(name="x-api-key", auto_error=False)
+
+
+def _load_validated_report_result(slug: str) -> dict:
+    report_path = settings.REPORT_DIR / slug / "hierarchical_result.json"
+
+    with open(report_path, encoding="utf-8") as f:
+        report_result = json.load(f)
+
+    try:
+        PublicReportResult.model_validate(report_result)
+    except ValidationError as e:
+        logger.warning(f"Invalid public report result for {slug}: {e}")
+        raise HTTPException(status_code=500, detail="Invalid report data") from e
+
+    return report_result
 
 
 async def verify_public_api_key(api_key: str = Security(api_key_header)):
@@ -49,8 +65,7 @@ async def report(slug: str, api_key: str = Depends(verify_public_api_key)) -> di
     if not report_path.exists():
         raise HTTPException(status_code=404, detail="Report not found")
 
-    with open(report_path) as f:
-        report_result = json.load(f)
+    report_result = _load_validated_report_result(slug)
 
     # レポートにvisibilityを追加
     report_result["visibility"] = target_report_status.visibility.value

--- a/apps/api/src/schemas/public_report_result.py
+++ b/apps/api/src/schemas/public_report_result.py
@@ -1,0 +1,12 @@
+from src.schemas.base import SchemaBaseModel
+
+
+class PublicReportConfig(SchemaBaseModel):
+    question: str
+
+
+class PublicReportResult(SchemaBaseModel):
+    overview: str
+    clusters: list
+    arguments: list
+    config: PublicReportConfig

--- a/apps/api/tests/routers/test_report.py
+++ b/apps/api/tests/routers/test_report.py
@@ -121,6 +121,30 @@ class TestReportEndpoint:
         assert response.status_code == 404
         assert "Report not found" in response.json()["detail"]
 
+    def test_get_report_without_config_returns_500(self, client: TestClient, temp_report_dir, test_settings):
+        """異常系：viewer 契約を満たさない report は 500 を返す"""
+        slug = "test-invalid-report"
+
+        report_dir = temp_report_dir / slug
+        report_dir.mkdir(parents=True, exist_ok=True)
+        report_file = report_dir / "hierarchical_result.json"
+        report_data = {"overview": "テスト概要", "clusters": [], "arguments": []}
+        with open(report_file, "w", encoding="utf-8") as f:
+            json.dump(report_data, f)
+
+        mock_reports = [
+            type("Report", (), {"slug": slug, "status": ReportStatus.READY, "visibility": ReportVisibility.PUBLIC})()
+        ]
+
+        with (
+            patch("src.routers.report.settings.REPORT_DIR", temp_report_dir),
+            patch("src.routers.report.load_status_as_reports", return_value=mock_reports),
+        ):
+            response = client.get(f"/reports/{slug}", headers={"x-api-key": test_settings.PUBLIC_API_KEY})
+
+        assert response.status_code == 500
+        assert response.json()["detail"] == "Invalid report data"
+
 
 class TestVisualizationConfigMerge:
     """Test cases for visualization config merge in /reports/{slug} endpoint."""


### PR DESCRIPTION
## 概要

`/reports/{slug}` が返す `hierarchical_result.json` について、public-viewer が前提にしている最小契約を API 側で検証するようにします。

- `config.question` を含まない壊れた report payload は返さず、`500 Invalid report data` を返す
- `config` 欠損 report に対する回帰テストを追加する

## なぜ `#802` では足りなかったか

`#800` の切り分けで、`config` を欠いた `hierarchical_result.json` を API が返すと viewer が落ちること自体は再現できました。

ただし根本原因は `Overview.tsx` の 1 箇所だけではありません。

- `PR #802` は `Overview.tsx` の `result.config.question` を optional chaining に変えるだけだった
- しかし current `public-viewer` では metadata 生成や OGP 画像生成など、他にも `result.config.*` を前提にしている箇所がある
- そのため `Overview` だけを null-safe にしても、壊れた payload が API から来る限り viewer 全体の契約不整合は残る

実際の問題は、`apps/api` の `/reports/{slug}` が保存済みの `hierarchical_result.json` を shape validation せず、そのまま public API として返している点にあります。

## この PR でやること

- `/reports/{slug}` の返却前に、public-viewer が最低限必要とする shape を検証する
- 具体的には `overview`, `clusters`, `arguments`, `config.question` を持たない payload を invalid として扱う
- invalid な report data は viewer に流さず、API 境界で失敗させる

これにより、viewer 側で個別に握りつぶすのではなく、契約違反を API 側で止められます。

## テスト

- `ADMIN_API_KEY=dummy PUBLIC_API_KEY=dummy OPENAI_API_KEY=dummy uv run python -m pytest tests/routers/test_report.py -q`
- `uv run ruff check src/routers/report.py src/schemas/public_report_result.py tests/routers/test_report.py`

Closes #800
Supersedes #802
