### PR TITLE
Improve static build error handling for public viewer

### DIFF
--- a/apps/public-viewer/app/[slug]/page.tsx
+++ b/apps/public-viewer/app/[slug]/page.tsx
@@ -12,6 +12,7 @@ import { Box, Separator } from "@chakra-ui/react";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { getApiBaseUrl } from "../utils/api";
+import { createStaticBuildFetchError, getStaticBuildReportSlugs, isStaticExportBuild } from "../utils/static-build";
 
 type PageProps = {
   params: Promise<{
@@ -23,7 +24,8 @@ type PageProps = {
 export const revalidate = 300;
 
 export async function generateStaticParams() {
-  const isStaticExport = process.env.NEXT_PUBLIC_OUTPUT_MODE === "export";
+  let reports: Report[];
+
   try {
     const response = await fetch(`${getApiBaseUrl()}/reports`, {
       headers: {
@@ -34,35 +36,16 @@ export async function generateStaticParams() {
     if (!response.ok) {
       throw new Error(`Failed to fetch reports: ${response.status} ${response.statusText}`);
     }
-    const reports: Report[] = await response.json();
-    let slugs = reports
-      .filter((report) => report.status === "ready")
-      .map((report) => ({
-        slug: report.slug,
-      }));
-
-    if (process.env.BUILD_SLUGS) {
-      const buildSlugs = process.env.BUILD_SLUGS.split(",").filter(Boolean);
-      slugs = slugs.filter((report) => buildSlugs.includes(report.slug));
+    reports = await response.json();
+  } catch (error) {
+    if (isStaticExportBuild()) {
+      throw createStaticBuildFetchError(error);
     }
 
-    if (isStaticExport && slugs.length === 0) {
-      console.error("\n❌ 静的HTML出力エラー: 公開状態のレポートが見つかりません。");
-      console.error("静的HTML出力を行うには、少なくとも1つのレポートを公開状態にしてください。\n");
-      process.exit(1);
-    }
-
-    return slugs;
-  } catch (_e) {
-    if (isStaticExport) {
-      console.error(_e);
-      console.error(
-        "\n❌ 静的HTML出力エラー: レポート一覧の取得に失敗しました。APIサーバーが起動しているか確認してください。\n",
-      );
-      process.exit(1);
-    }
     return [];
   }
+
+  return getStaticBuildReportSlugs(reports);
 }
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {

--- a/apps/public-viewer/app/utils/__tests__/static-build.test.ts
+++ b/apps/public-viewer/app/utils/__tests__/static-build.test.ts
@@ -1,0 +1,63 @@
+import type { Report } from "@/type";
+import { createStaticBuildFetchError, getStaticBuildReportSlugs, parseBuildSlugs } from "../static-build";
+
+const readyReport = (slug: string): Report => ({
+  slug,
+  status: "ready",
+  title: `${slug} title`,
+  description: `${slug} description`,
+  isPubcom: false,
+  visibility: "public" as Report["visibility"],
+});
+
+describe("static build helpers", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("returns ready report slugs", () => {
+    const result = getStaticBuildReportSlugs([readyReport("alpha"), { ...readyReport("draft"), status: "draft" }]);
+
+    expect(result).toEqual([{ slug: "alpha" }]);
+  });
+
+  it("filters by BUILD_SLUGS when matching ready reports exist", () => {
+    const result = getStaticBuildReportSlugs([readyReport("alpha"), readyReport("beta")], "beta");
+
+    expect(result).toEqual([{ slug: "beta" }]);
+  });
+
+  it("throws a clear error when no ready reports exist during static export", () => {
+    process.env.NEXT_PUBLIC_OUTPUT_MODE = "export";
+
+    expect(() => getStaticBuildReportSlugs([{ ...readyReport("draft"), status: "draft" }])).toThrow(
+      "静的HTML出力に必要な公開状態のレポートが見つかりませんでした。",
+    );
+  });
+
+  it("throws a distinct error when BUILD_SLUGS does not match any ready report during static export", () => {
+    process.env.NEXT_PUBLIC_OUTPUT_MODE = "export";
+
+    expect(() => getStaticBuildReportSlugs([readyReport("alpha")], "missing")).toThrow(
+      'BUILD_SLUGS で指定されたレポートが、公開状態（status: ready）の一覧に見つかりませんでした。 指定値: "missing" 公開状態の slug: "alpha"',
+    );
+  });
+
+  it("parses BUILD_SLUGS with trimming and empty entries removed", () => {
+    expect(parseBuildSlugs(" alpha, ,beta ,, gamma ")).toEqual(["alpha", "beta", "gamma"]);
+  });
+
+  it("formats fetch errors with troubleshooting guidance", () => {
+    expect(createStaticBuildFetchError(new Error("connect ECONNREFUSED"))).toThrow;
+
+    const error = createStaticBuildFetchError(new Error("connect ECONNREFUSED"));
+    expect(error.message).toContain("静的HTML出力の事前確認でレポート一覧の取得に失敗しました。");
+    expect(error.message).toContain("元エラー: connect ECONNREFUSED");
+  });
+});

--- a/apps/public-viewer/app/utils/static-build.ts
+++ b/apps/public-viewer/app/utils/static-build.ts
@@ -1,0 +1,60 @@
+import type { Report } from "@/type";
+
+type StaticBuildSlug = {
+  slug: string;
+};
+
+const formatBuildSlugList = (slugs: string[]) => slugs.map((slug) => `"${slug}"`).join(", ");
+
+export const isStaticExportBuild = () => process.env.NEXT_PUBLIC_OUTPUT_MODE === "export";
+
+export const parseBuildSlugs = (buildSlugs = process.env.BUILD_SLUGS): string[] =>
+  buildSlugs
+    ?.split(",")
+    .map((slug) => slug.trim())
+    .filter(Boolean) || [];
+
+export function getStaticBuildReportSlugs(reports: Report[], buildSlugs = process.env.BUILD_SLUGS): StaticBuildSlug[] {
+  const readyReports = reports.filter((report) => report.status === "ready");
+  const readySlugs = readyReports.map((report) => report.slug);
+  const requestedSlugs = parseBuildSlugs(buildSlugs);
+
+  if (isStaticExportBuild() && readySlugs.length === 0) {
+    throw new Error(
+      [
+        "静的HTML出力に必要な公開状態のレポートが見つかりませんでした。",
+        "少なくとも1件のレポートを公開状態（status: ready）にしてから再実行してください。",
+      ].join(" "),
+    );
+  }
+
+  if (requestedSlugs.length === 0) {
+    return readySlugs.map((slug) => ({ slug }));
+  }
+
+  const selectedReadySlugs = readySlugs.filter((slug) => requestedSlugs.includes(slug));
+
+  if (isStaticExportBuild() && selectedReadySlugs.length === 0) {
+    throw new Error(
+      [
+        "BUILD_SLUGS で指定されたレポートが、公開状態（status: ready）の一覧に見つかりませんでした。",
+        `指定値: ${formatBuildSlugList(requestedSlugs)}`,
+        `公開状態の slug: ${readySlugs.length > 0 ? formatBuildSlugList(readySlugs) : "なし"}`,
+      ].join(" "),
+    );
+  }
+
+  return selectedReadySlugs.map((slug) => ({ slug }));
+}
+
+export function createStaticBuildFetchError(error: unknown): Error {
+  const message = error instanceof Error ? error.message : String(error);
+
+  return new Error(
+    [
+      "静的HTML出力の事前確認でレポート一覧の取得に失敗しました。",
+      "APIサーバーが起動しているか、API_BASEPATH / NEXT_PUBLIC_API_BASEPATH の設定が正しいか確認してください。",
+      `元エラー: ${message}`,
+    ].join(" "),
+  );
+}


### PR DESCRIPTION
## Summary
- centralize static export report validation in a helper used by `generateStaticParams()`
- fail fast with a clear message when there are no ready reports for static export
- distinguish the `BUILD_SLUGS` mismatch case from the "no ready reports" case
- add unit tests for the static build validation helpers

## Verification
- `pnpm test -- --runInBand app/utils/__tests__/static-build.test.ts app/utils/__tests__/api.test.ts`
- `API_BASEPATH=http://127.0.0.1:8999 NEXT_PUBLIC_API_BASEPATH=http://127.0.0.1:8999 pnpm run build:static` and confirm it fails with the new ready-report error
- `API_BASEPATH=http://127.0.0.1:8002 NEXT_PUBLIC_API_BASEPATH=http://127.0.0.1:8002 NEXT_PUBLIC_PUBLIC_API_KEY=public pnpm run build:static` and confirm it succeeds against `utils/dummy-server`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for static build utilities.

* **Chores**
  * Refactored static build parameter generation with improved error handling for static exports.
  * Enhanced validation and error messages for missing or unmatched build configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/digitaldemocracy2030/kouchou-ai/pull/835?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->