### PR TITLE
[codex] ignore apps/api uv lockfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ site/
 # Python
 *.pyc
 __pycache__/
+apps/api/uv.lock
 
 # MkDocs auto-generated (copied from root by hooks)
 docs/development/contributing.md


### PR DESCRIPTION
## What changed
- ignore `apps/api/uv.lock` in the repo root `.gitignore`

## Why
- `apps/api` uses `requirements.lock` and `requirements-dev.lock` as the tracked lock artifacts
- `uv.lock` is a local byproduct in the current setup and was repeatedly dirtying worktrees

## Impact
- local `uv` usage in `apps/api` no longer creates accidental untracked noise
- no runtime or build behavior changes

## Validation
- confirmed the only code change is the `.gitignore` entry


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated git configuration to ignore additional build artifacts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/digitaldemocracy2030/kouchou-ai/pull/839?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->