### PR TITLE
[codex] legacy API step imports を Ruff に合わせる

### DIFF
--- a/apps/api/broadlistening/pipeline/steps/embedding.py
+++ b/apps/api/broadlistening/pipeline/steps/embedding.py
@@ -3,9 +3,8 @@ import pickle
 from pathlib import Path
 
 import polars as pl
-from tqdm import tqdm
-
 from services.llm import request_to_embed
+from tqdm import tqdm
 
 PIPELINE_DIR = Path(__file__).parent.parent
 

--- a/apps/api/broadlistening/pipeline/steps/extraction.py
+++ b/apps/api/broadlistening/pipeline/steps/extraction.py
@@ -7,10 +7,10 @@ from pathlib import Path
 
 import polars as pl
 from pydantic import BaseModel, Field
-from tqdm import tqdm
-
 from services.llm import request_to_chat_ai
 from services.parse_json_list import parse_extraction_response
+from tqdm import tqdm
+
 from utils import update_progress
 
 PIPELINE_DIR = Path(__file__).parent.parent

--- a/apps/api/broadlistening/pipeline/steps/hierarchical_initial_labelling.py
+++ b/apps/api/broadlistening/pipeline/steps/hierarchical_initial_labelling.py
@@ -7,7 +7,6 @@ from typing import TypedDict
 
 import polars as pl
 from pydantic import BaseModel, Field
-
 from services.llm import request_to_chat_ai
 
 PIPELINE_DIR = Path(__file__).parent.parent

--- a/apps/api/broadlistening/pipeline/steps/hierarchical_merge_labelling.py
+++ b/apps/api/broadlistening/pipeline/steps/hierarchical_merge_labelling.py
@@ -8,9 +8,8 @@ from pathlib import Path
 import numpy as np
 import polars as pl
 from pydantic import BaseModel, Field
-from tqdm import tqdm
-
 from services.llm import request_to_chat_ai
+from tqdm import tqdm
 
 PIPELINE_DIR = Path(__file__).parent.parent
 

--- a/apps/api/broadlistening/pipeline/steps/hierarchical_overview.py
+++ b/apps/api/broadlistening/pipeline/steps/hierarchical_overview.py
@@ -7,7 +7,6 @@ from pathlib import Path
 
 import polars as pl
 from pydantic import BaseModel, Field
-
 from services.llm import request_to_chat_ai
 
 PIPELINE_DIR = Path(__file__).parent.parent


### PR DESCRIPTION
# 変更内容

`apps/api/` の pre-push hook が legacy `broadlistening/pipeline/steps/` の import 並びだけで止まっていたので、Ruff の指摘に合わせて import block を整えます。

変更は import 順の修正のみで、実行ロジックには触れていません。

# 背景

workflow default 化の branch で push するたびに、今回の変更とは無関係な legacy step 群の `api-ruff-check` が失敗していました。

hook と同じコマンドを `apps/api/` ルートで再現すると、次の 5 ファイルだけが `I001` で止まっていました。

- `broadlistening/pipeline/steps/embedding.py`
- `broadlistening/pipeline/steps/extraction.py`
- `broadlistening/pipeline/steps/hierarchical_initial_labelling.py`
- `broadlistening/pipeline/steps/hierarchical_merge_labelling.py`
- `broadlistening/pipeline/steps/hierarchical_overview.py`

# 動作確認

```bash
cd apps/api
rye run ruff check .
rye run ruff format . --check
```

どちらも通過しています。
