### PR TITLE
analysis-core の optional dependency を extras に分離

### DIFF
--- a/docs/user-guide/cli-quickstart.md
+++ b/docs/user-guide/cli-quickstart.md
@@ -16,7 +16,7 @@ source .venv/bin/activate  # Linux/macOS
 # .venv\Scripts\activate  # Windows
 
 # パッケージのインストール
-pip install kouchou-ai-analysis-core
+pip install 'kouchou-ai-analysis-core[embeddings,clustering]'
 ```
 
 インストールの確認：
@@ -24,6 +24,8 @@ pip install kouchou-ai-analysis-core
 ```bash
 kouchou-analyze --version
 ```
+
+`kouchou-ai-analysis-core` の base install だけでも `import analysis_core` や dry-run は可能ですが、通常の分析パイプラインでは local embedding / clustering 関連 dependency が必要です。迷ったら `"[embeddings,clustering]"` 付きで入れるのが安全です。
 
 ## 2. 入力CSVの準備
 
@@ -299,7 +301,7 @@ export AZURE_OPENAI_DEPLOYMENT="your-deployment-name"
 ### Gemini を使用する
 
 ```bash
-pip install 'kouchou-ai-analysis-core[gemini]'
+pip install 'kouchou-ai-analysis-core[gemini,embeddings,clustering]'
 export GOOGLE_API_KEY="your-key"
 ```
 

--- a/docs/user-guide/import-quickstart.md
+++ b/docs/user-guide/import-quickstart.md
@@ -10,8 +10,10 @@
 ## 1. インストール
 
 ```bash
-pip install kouchou-ai-analysis-core
+pip install 'kouchou-ai-analysis-core[embeddings,clustering]'
 ```
+
+軽量な base install (`pip install kouchou-ai-analysis-core`) でも top-level import は可能ですが、local embedding や hierarchical clustering を使うには optional extras が必要です。
 
 ## 2. 基本的な使い方
 

--- a/packages/analysis-core/README.md
+++ b/packages/analysis-core/README.md
@@ -13,13 +13,20 @@
 ## インストール
 
 ```bash
-pip install kouchou-ai-analysis-core
+pip install 'kouchou-ai-analysis-core[embeddings,clustering]'
 ```
 
 Geminiサポートを含める場合:
 ```bash
-pip install kouchou-ai-analysis-core[gemini]
+pip install 'kouchou-ai-analysis-core[gemini,embeddings,clustering]'
 ```
+
+軽量な base install だけ欲しい場合:
+```bash
+pip install kouchou-ai-analysis-core
+```
+
+この場合でも `import analysis_core` や dry-run はできますが、local embedding や hierarchical clustering を実行するには対応する extras が必要です。
 
 ## 使用方法
 
@@ -83,7 +90,7 @@ plugins/analysis/
 
 ```bash
 # 依存関係のインストール
-pip install -e ".[dev]"
+pip install -e ".[dev,embeddings,clustering]"
 
 # テストの実行
 pytest

--- a/packages/analysis-core/pyproject.toml
+++ b/packages/analysis-core/pyproject.toml
@@ -20,11 +20,6 @@ dependencies = [
     "polars>=1.37.1",
     "numpy>=1.26.0",
     "openai>=1.77.0",
-    "sentence-transformers>=2.7.0",
-    "scikit-learn>=1.5.0",
-    "scipy>=1.15.1",
-    "umap-learn>=0.5.7",
-    "numba>=0.59.0",  # Ensure Python 3.12 compatible version
     "tqdm>=4.66.0",
     "pydantic>=2.0.0",
     "tenacity>=9.1.2",
@@ -34,6 +29,19 @@ dependencies = [
 
 [project.optional-dependencies]
 gemini = ["google-genai>=1.0.0"]
+embeddings = [
+    "sentence-transformers>=2.7.0",
+    "torch>=2.0.0",
+]
+clustering = [
+    "scikit-learn>=1.5.0",
+    "scipy>=1.15.1",
+    "umap-learn>=0.5.7",
+    "numba>=0.59.0",  # Ensure Python 3.12 compatible version
+]
+full = [
+    "kouchou-ai-analysis-core[gemini,embeddings,clustering]",
+]
 dev = [
     "pytest>=8.0.0",
     "pytest-cov>=4.0.0",

--- a/packages/analysis-core/requirements-dev.lock
+++ b/packages/analysis-core/requirements-dev.lock
@@ -164,6 +164,7 @@ threadpoolctl==3.6.0
 tokenizers==0.22.2
     # via transformers
 torch==2.9.1
+    # via kouchou-ai-analysis-core
     # via sentence-transformers
 tqdm==4.67.1
     # via huggingface-hub

--- a/packages/analysis-core/requirements.lock
+++ b/packages/analysis-core/requirements.lock
@@ -164,6 +164,7 @@ threadpoolctl==3.6.0
 tokenizers==0.22.2
     # via transformers
 torch==2.9.1
+    # via kouchou-ai-analysis-core
     # via sentence-transformers
 tqdm==4.67.1
     # via huggingface-hub

--- a/packages/analysis-core/src/analysis_core/orchestrator.py
+++ b/packages/analysis-core/src/analysis_core/orchestrator.py
@@ -10,6 +10,7 @@ import traceback
 import warnings
 from dataclasses import dataclass, field
 from datetime import datetime
+from importlib import import_module
 from pathlib import Path
 from typing import Any, Callable
 
@@ -19,16 +20,6 @@ from analysis_core.core.orchestration import (
     sync_without_html_keys,
     termination,
     update_status,
-)
-from analysis_core.steps import (
-    embedding,
-    extraction,
-    hierarchical_aggregation,
-    hierarchical_clustering,
-    hierarchical_initial_labelling,
-    hierarchical_merge_labelling,
-    hierarchical_overview,
-    hierarchical_visualization,
 )
 
 
@@ -55,17 +46,31 @@ class PipelineResult:
     output_dir: Path | None = None
 
 
-# Default step functions mapping
-DEFAULT_STEP_FUNCTIONS: dict[str, Callable[[dict[str, Any]], None]] = {
-    "extraction": extraction,
-    "embedding": embedding,
-    "hierarchical_clustering": hierarchical_clustering,
-    "hierarchical_initial_labelling": hierarchical_initial_labelling,
-    "hierarchical_merge_labelling": hierarchical_merge_labelling,
-    "hierarchical_overview": hierarchical_overview,
-    "hierarchical_aggregation": hierarchical_aggregation,
-    "hierarchical_visualization": hierarchical_visualization,
+DEFAULT_STEP_MODULES: dict[str, tuple[str, str]] = {
+    "extraction": ("analysis_core.steps.extraction", "extraction"),
+    "embedding": ("analysis_core.steps.embedding", "embedding"),
+    "hierarchical_clustering": ("analysis_core.steps.hierarchical_clustering", "hierarchical_clustering"),
+    "hierarchical_initial_labelling": (
+        "analysis_core.steps.hierarchical_initial_labelling",
+        "hierarchical_initial_labelling",
+    ),
+    "hierarchical_merge_labelling": (
+        "analysis_core.steps.hierarchical_merge_labelling",
+        "hierarchical_merge_labelling",
+    ),
+    "hierarchical_overview": ("analysis_core.steps.hierarchical_overview", "hierarchical_overview"),
+    "hierarchical_aggregation": ("analysis_core.steps.hierarchical_aggregation", "hierarchical_aggregation"),
+    "hierarchical_visualization": ("analysis_core.steps.hierarchical_visualization", "hierarchical_visualization"),
 }
+
+
+def load_default_step_functions() -> dict[str, Callable[[dict[str, Any]], None]]:
+    """Resolve built-in step functions lazily to keep optional deps optional."""
+    step_functions: dict[str, Callable[[dict[str, Any]], None]] = {}
+    for step_name, (module_path, attr_name) in DEFAULT_STEP_MODULES.items():
+        module = import_module(module_path)
+        step_functions[step_name] = getattr(module, attr_name)
+    return step_functions
 
 
 class PipelineOrchestrator:
@@ -120,7 +125,7 @@ class PipelineOrchestrator:
         self.output_base_dir = output_base_dir or Path(config.get("_output_base_dir", "outputs"))
         self.input_base_dir = input_base_dir or Path(config.get("_input_base_dir", "inputs"))
         self.steps = steps or self.DEFAULT_STEPS
-        self._step_functions: dict[str, Callable] = DEFAULT_STEP_FUNCTIONS.copy()
+        self._step_functions: dict[str, Callable] = load_default_step_functions()
 
     @classmethod
     def from_config(

--- a/packages/analysis-core/src/analysis_core/orchestrator.py
+++ b/packages/analysis-core/src/analysis_core/orchestrator.py
@@ -64,13 +64,11 @@ DEFAULT_STEP_MODULES: dict[str, tuple[str, str]] = {
 }
 
 
-def load_default_step_functions() -> dict[str, Callable[[dict[str, Any]], None]]:
-    """Resolve built-in step functions lazily to keep optional deps optional."""
-    step_functions: dict[str, Callable[[dict[str, Any]], None]] = {}
-    for step_name, (module_path, attr_name) in DEFAULT_STEP_MODULES.items():
-        module = import_module(module_path)
-        step_functions[step_name] = getattr(module, attr_name)
-    return step_functions
+def load_default_step_function(step_name: str) -> Callable[[dict[str, Any]], None]:
+    """Resolve a single built-in step function lazily."""
+    module_path, attr_name = DEFAULT_STEP_MODULES[step_name]
+    module = import_module(module_path)
+    return getattr(module, attr_name)
 
 
 class PipelineOrchestrator:
@@ -125,7 +123,7 @@ class PipelineOrchestrator:
         self.output_base_dir = output_base_dir or Path(config.get("_output_base_dir", "outputs"))
         self.input_base_dir = input_base_dir or Path(config.get("_input_base_dir", "inputs"))
         self.steps = steps or self.DEFAULT_STEPS
-        self._step_functions: dict[str, Callable] = load_default_step_functions()
+        self._step_functions: dict[str, Callable] = {}
 
     @classmethod
     def from_config(
@@ -214,6 +212,9 @@ class PipelineOrchestrator:
             # Execute each step
             for step_name in self.steps:
                 step_func = self._step_functions.get(step_name)
+                if step_func is None and step_name in DEFAULT_STEP_MODULES:
+                    step_func = load_default_step_function(step_name)
+                    self._step_functions[step_name] = step_func
                 if step_func is None:
                     raise ValueError(f"No function registered for step '{step_name}'")
 

--- a/packages/analysis-core/src/analysis_core/services/llm.py
+++ b/packages/analysis-core/src/analysis_core/services/llm.py
@@ -745,7 +745,13 @@ def request_to_local_embed(args):
     with __local_emb_model_loading_lock:
         # memo: スレッドセーフにするためにロックを使用
         if __local_emb_model is None:
-            from sentence_transformers import SentenceTransformer
+            try:
+                from sentence_transformers import SentenceTransformer
+            except ModuleNotFoundError as exc:  # pragma: no cover - depends on install profile
+                raise RuntimeError(
+                    "Local embedding requires the optional 'embeddings' dependencies. "
+                    "Install with: pip install 'kouchou-ai-analysis-core[embeddings]'"
+                ) from exc
 
             model_name = "sentence-transformers/paraphrase-multilingual-mpnet-base-v2"
             __local_emb_model = SentenceTransformer(model_name)

--- a/packages/analysis-core/src/analysis_core/steps/__init__.py
+++ b/packages/analysis-core/src/analysis_core/steps/__init__.py
@@ -1,17 +1,18 @@
-"""
-Pipeline step implementations.
+"""Pipeline step implementations."""
 
-Each step is a function that takes a config dict and performs a specific analysis task.
-"""
+from importlib import import_module
+from typing import Any
 
-from analysis_core.steps.embedding import embedding
-from analysis_core.steps.extraction import extraction
-from analysis_core.steps.hierarchical_aggregation import hierarchical_aggregation
-from analysis_core.steps.hierarchical_clustering import hierarchical_clustering
-from analysis_core.steps.hierarchical_initial_labelling import hierarchical_initial_labelling
-from analysis_core.steps.hierarchical_merge_labelling import hierarchical_merge_labelling
-from analysis_core.steps.hierarchical_overview import hierarchical_overview
-from analysis_core.steps.hierarchical_visualization import hierarchical_visualization
+_STEP_MODULES = {
+    "embedding": "analysis_core.steps.embedding",
+    "extraction": "analysis_core.steps.extraction",
+    "hierarchical_aggregation": "analysis_core.steps.hierarchical_aggregation",
+    "hierarchical_clustering": "analysis_core.steps.hierarchical_clustering",
+    "hierarchical_initial_labelling": "analysis_core.steps.hierarchical_initial_labelling",
+    "hierarchical_merge_labelling": "analysis_core.steps.hierarchical_merge_labelling",
+    "hierarchical_overview": "analysis_core.steps.hierarchical_overview",
+    "hierarchical_visualization": "analysis_core.steps.hierarchical_visualization",
+}
 
 __all__ = [
     "extraction",
@@ -23,3 +24,15 @@ __all__ = [
     "hierarchical_aggregation",
     "hierarchical_visualization",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily load step modules so base installs can import analysis_core."""
+    module_path = _STEP_MODULES.get(name)
+    if module_path is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    module = import_module(module_path)
+    value = getattr(module, name)
+    globals()[name] = value
+    return value

--- a/packages/analysis-core/src/analysis_core/steps/hierarchical_clustering.py
+++ b/packages/analysis-core/src/analysis_core/steps/hierarchical_clustering.py
@@ -8,23 +8,27 @@ import polars as pl
 
 
 def _load_clustering_dependencies():
+    error_message = (
+        "Hierarchical clustering requires the optional 'clustering' dependencies. "
+        "Install with: pip install 'kouchou-ai-analysis-core[clustering]'"
+    )
+
+    try:
+        UMAP = import_module("umap").UMAP
+    except ModuleNotFoundError as exc:  # pragma: no cover - depends on install profile
+        raise RuntimeError(error_message) from exc
+
     try:
         sch = import_module("scipy.cluster.hierarchy")
     except ModuleNotFoundError as exc:  # pragma: no cover - depends on install profile
-        raise RuntimeError(
-            "Hierarchical clustering requires the optional 'clustering' dependencies. "
-            "Install with: pip install 'kouchou-ai-analysis-core[clustering]'"
-        ) from exc
+        raise RuntimeError(error_message) from exc
 
     try:
         KMeans = import_module("sklearn.cluster").KMeans
     except ModuleNotFoundError as exc:  # pragma: no cover - depends on install profile
-        raise RuntimeError(
-            "Hierarchical clustering requires the optional 'clustering' dependencies. "
-            "Install with: pip install 'kouchou-ai-analysis-core[clustering]'"
-        ) from exc
+        raise RuntimeError(error_message) from exc
 
-    return sch, KMeans
+    return UMAP, sch, KMeans
 
 
 def calculate_recommended_cluster_nums(argument_count: int) -> list[int]:
@@ -47,8 +51,7 @@ def calculate_recommended_cluster_nums(argument_count: int) -> list[int]:
 
 
 def hierarchical_clustering(config):
-    UMAP = import_module("umap").UMAP
-    _, KMeans = _load_clustering_dependencies()
+    UMAP, _, KMeans = _load_clustering_dependencies()
 
     dataset = config["output_dir"]
     output_base_dir = config.get("_output_base_dir", "outputs")
@@ -163,7 +166,7 @@ def merge_clusters_with_hierarchy(
     umap_array: np.ndarray,
     n_cluster_cut: int,
 ):
-    sch, _ = _load_clustering_dependencies()
+    _, sch, _ = _load_clustering_dependencies()
     Z = sch.linkage(cluster_centers, method="ward")
     cluster_labels_merged = sch.fcluster(Z, t=n_cluster_cut, criterion="maxclust")
 
@@ -183,7 +186,7 @@ def hierarchical_clustering_embeddings(
     kmeans_class=None,
 ):
     if kmeans_class is None:
-        _, kmeans_class = _load_clustering_dependencies()
+        _, _, kmeans_class = _load_clustering_dependencies()
 
     # 最大分割数でクラスタリングを実施
     print("start initial clustering")

--- a/packages/analysis-core/src/analysis_core/steps/hierarchical_clustering.py
+++ b/packages/analysis-core/src/analysis_core/steps/hierarchical_clustering.py
@@ -5,8 +5,26 @@ from importlib import import_module
 
 import numpy as np
 import polars as pl
-import scipy.cluster.hierarchy as sch
-from sklearn.cluster import KMeans
+
+
+def _load_clustering_dependencies():
+    try:
+        sch = import_module("scipy.cluster.hierarchy")
+    except ModuleNotFoundError as exc:  # pragma: no cover - depends on install profile
+        raise RuntimeError(
+            "Hierarchical clustering requires the optional 'clustering' dependencies. "
+            "Install with: pip install 'kouchou-ai-analysis-core[clustering]'"
+        ) from exc
+
+    try:
+        KMeans = import_module("sklearn.cluster").KMeans
+    except ModuleNotFoundError as exc:  # pragma: no cover - depends on install profile
+        raise RuntimeError(
+            "Hierarchical clustering requires the optional 'clustering' dependencies. "
+            "Install with: pip install 'kouchou-ai-analysis-core[clustering]'"
+        ) from exc
+
+    return sch, KMeans
 
 
 def calculate_recommended_cluster_nums(argument_count: int) -> list[int]:
@@ -30,6 +48,7 @@ def calculate_recommended_cluster_nums(argument_count: int) -> list[int]:
 
 def hierarchical_clustering(config):
     UMAP = import_module("umap").UMAP
+    _, KMeans = _load_clustering_dependencies()
 
     dataset = config["output_dir"]
     output_base_dir = config.get("_output_base_dir", "outputs")
@@ -88,6 +107,7 @@ def hierarchical_clustering(config):
     cluster_results = hierarchical_clustering_embeddings(
         umap_embeds=umap_embeds,
         cluster_nums=cluster_nums,
+        kmeans_class=KMeans,
     )
     result_df = pl.DataFrame(
         {
@@ -143,6 +163,7 @@ def merge_clusters_with_hierarchy(
     umap_array: np.ndarray,
     n_cluster_cut: int,
 ):
+    sch, _ = _load_clustering_dependencies()
     Z = sch.linkage(cluster_centers, method="ward")
     cluster_labels_merged = sch.fcluster(Z, t=n_cluster_cut, criterion="maxclust")
 
@@ -159,11 +180,15 @@ def merge_clusters_with_hierarchy(
 def hierarchical_clustering_embeddings(
     umap_embeds,
     cluster_nums,
+    kmeans_class=None,
 ):
+    if kmeans_class is None:
+        _, kmeans_class = _load_clustering_dependencies()
+
     # 最大分割数でクラスタリングを実施
     print("start initial clustering")
     initial_cluster_num = cluster_nums[-1]
-    kmeans_model = KMeans(n_clusters=initial_cluster_num)
+    kmeans_model = kmeans_class(n_clusters=initial_cluster_num)
     kmeans_model.fit(umap_embeds)
     print("end initial clustering")
 

--- a/packages/analysis-core/tests/test_imports.py
+++ b/packages/analysis-core/tests/test_imports.py
@@ -87,6 +87,17 @@ class TestStepImports:
         assert steps_module.__name__ == "analysis_core.steps"
         assert "analysis_core.steps.hierarchical_clustering" not in sys.modules
 
+    def test_orchestrator_init_does_not_eagerly_import_optional_step_modules(self):
+        """PipelineOrchestrator construction should not resolve optional steps yet."""
+        from analysis_core.orchestrator import PipelineOrchestrator
+
+        sys.modules.pop("analysis_core.steps.hierarchical_clustering", None)
+
+        orchestrator = PipelineOrchestrator(config={"output_dir": "test"})
+
+        assert orchestrator is not None
+        assert "analysis_core.steps.hierarchical_clustering" not in sys.modules
+
     def test_extraction_step(self):
         """Test extraction step import."""
         from analysis_core.steps import extraction

--- a/packages/analysis-core/tests/test_imports.py
+++ b/packages/analysis-core/tests/test_imports.py
@@ -1,6 +1,7 @@
 """Test that all package modules can be imported correctly."""
 
 import re
+import sys
 
 
 class TestCoreImports:
@@ -75,6 +76,16 @@ class TestServiceImports:
 
 class TestStepImports:
     """Test pipeline step imports."""
+
+    def test_steps_package_import_does_not_eagerly_import_optional_modules(self):
+        """Base package import should not pull optional clustering deps immediately."""
+        sys.modules.pop("analysis_core.steps", None)
+        sys.modules.pop("analysis_core.steps.hierarchical_clustering", None)
+
+        import analysis_core.steps as steps_module
+
+        assert steps_module.__name__ == "analysis_core.steps"
+        assert "analysis_core.steps.hierarchical_clustering" not in sys.modules
 
     def test_extraction_step(self):
         """Test extraction step import."""


### PR DESCRIPTION
## 概要
- `analysis-core` の重い依存を base `dependencies` から `embeddings` / `clustering` extras に分離
- base install でも `import analysis_core` が落ちないように step / orchestrator の import を lazy 化
- README / quickstart を extras 前提の導線に更新

## 変更内容
- `packages/analysis-core/pyproject.toml` に `embeddings` / `clustering` / `full` extras を追加
- `analysis_core.steps` と `PipelineOrchestrator` の built-in step 解決を lazy import 化
- local embedding / hierarchical clustering 実行時に、optional dependency 不足なら説明的な `RuntimeError` を返すよう変更
- `README.md` と `docs/user-guide/*quickstart.md` の install コマンドを更新
- lockfile を再生成し、import 契約向けのテストを追加

## 背景
Task 2.5.6 で想定されていた extras 分割が未実施だったため、`analysis-core` の base install が不要に重くなっていました。
一方で単純に `pyproject.toml` だけ直すと、`analysis_core.steps` の eager import により base install でも import error が起きうるため、その部分をあわせて整理しています。

## 確認
- `./.venv/bin/ruff check src tests`
- `./.venv/bin/pytest tests/test_imports.py tests/test_hierarchical_clustering.py tests/test_cli.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified installation in CLI/import quickstarts and core README, recommending optional extras for embeddings, clustering, and Gemini support.

* **New Features**
  * Optional extras enable modular installs for embeddings, clustering, and full tooling; runtime errors now give actionable install guidance when extras are missing.

* **Refactor**
  * Core components now lazily load optional features to avoid importing optional dependencies at startup.

* **Tests**
  * Added tests verifying lazy-loading behavior and import-time cleanliness.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/digitaldemocracy2030/kouchou-ai/pull/843?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->