### PR TITLE
admin create/reuse flow の UUID fallback を追加

### DIFF
--- a/apps/admin/app/create/components/EnvironmentCheckDialog/EnvironmentCheckDialog.test.tsx
+++ b/apps/admin/app/create/components/EnvironmentCheckDialog/EnvironmentCheckDialog.test.tsx
@@ -1,3 +1,4 @@
+import { createUUID } from "@/app/utils/uuid";
 import { system } from "@/components/theme/system";
 import { ChakraProvider } from "@chakra-ui/react";
 import { render, screen, waitFor } from "@testing-library/react";
@@ -15,13 +16,13 @@ jest.mock("lucide-react", () => ({
 jest.mock("./verifyApiKey");
 const mockVerifyApiKey = verifyApiKey as jest.MockedFunction<typeof verifyApiKey>;
 
-// crypto.randomUUIDをモック化
+jest.mock("@/app/utils/uuid", () => ({
+  createUUID: jest.fn(),
+}));
+
+const mockCreateUUID = createUUID as jest.MockedFunction<typeof createUUID>;
+
 const mockUUID = "test-uuid-123";
-Object.defineProperty(global, "crypto", {
-  value: {
-    randomUUID: jest.fn(() => mockUUID),
-  },
-});
 
 // テスト用のChakraUIラッパーコンポーネント
 const TestWrapper = ({ children }: { children: React.ReactNode }) => (
@@ -38,6 +39,7 @@ const renderEnvironmentCheckDialog = (provider: Provider = "openai") =>
 describe("EnvironmentCheckDialog", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockCreateUUID.mockReturnValue(mockUUID);
   });
 
   it("初期状態でトリガーボタンが表示される", () => {
@@ -209,17 +211,17 @@ describe("EnvironmentCheckDialog", () => {
   });
 
   it("ダイアログを閉じるとUUIDがリセットされる", async () => {
+    const user = userEvent.setup();
     renderEnvironmentCheckDialog();
 
-    userEvent.click(screen.getByRole("button", { name: /API接続チェック/i }));
+    await user.click(screen.getByRole("button", { name: /API接続チェック/i }));
+
+    const closeButton = await screen.findByRole("button", { name: "Close" });
+    await user.click(closeButton);
 
     await waitFor(() => {
-      const closeButton = screen.getByRole("button", { name: "Close" });
-      userEvent.click(closeButton);
+      expect(mockCreateUUID).toHaveBeenCalledTimes(2);
     });
-
-    // crypto.randomUUIDが再度呼び出されることを確認
-    expect(global.crypto.randomUUID).toHaveBeenCalledTimes(1);
   });
 
   it("チェック中にローディング状態が表示される", async () => {

--- a/apps/admin/app/create/components/EnvironmentCheckDialog/EnvironmentCheckDialog.tsx
+++ b/apps/admin/app/create/components/EnvironmentCheckDialog/EnvironmentCheckDialog.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { createUUID } from "@/app/utils/uuid";
 import { Button } from "@/components/ui/button";
 import {
   DialogBackdrop,
@@ -145,7 +146,7 @@ function Dialog({ provider }: EnvironmentCheckDialogProps) {
 }
 
 export function EnvironmentCheckDialog({ provider }: EnvironmentCheckDialogProps) {
-  const [uuid, setUUID] = useState(crypto.randomUUID());
+  const [uuid, setUUID] = useState(() => createUUID());
 
   return (
     <DialogRoot
@@ -155,7 +156,7 @@ export function EnvironmentCheckDialog({ provider }: EnvironmentCheckDialogProps
       onOpenChange={(e) => {
         if (!e.open) {
           // Dialogが閉じられたときにkeyを更新して再レンダリングをトリガー
-          setUUID(crypto.randomUUID());
+          setUUID(createUUID());
         }
       }}
     >

--- a/apps/admin/app/create/hooks/useBasicInfo.test.ts
+++ b/apps/admin/app/create/hooks/useBasicInfo.test.ts
@@ -1,0 +1,37 @@
+import { createUUID } from "@/app/utils/uuid";
+import { act, renderHook } from "@testing-library/react";
+import { useBasicInfo } from "./useBasicInfo";
+
+jest.mock("@/app/utils/uuid", () => ({
+  createUUID: jest.fn(),
+}));
+
+const mockCreateUUID = createUUID as jest.MockedFunction<typeof createUUID>;
+
+describe("useBasicInfo", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("initializes the report id with createUUID", () => {
+    mockCreateUUID.mockReturnValue("generated-id");
+
+    const { result } = renderHook(() => useBasicInfo());
+
+    expect(result.current.input).toBe("generated-id");
+    expect(mockCreateUUID).toHaveBeenCalledTimes(1);
+  });
+
+  it("resets the report id with createUUID", () => {
+    mockCreateUUID.mockReturnValueOnce("initial-id").mockReturnValueOnce("reset-id");
+
+    const { result } = renderHook(() => useBasicInfo());
+
+    act(() => {
+      result.current.resetBasicInfo();
+    });
+
+    expect(result.current.input).toBe("reset-id");
+    expect(mockCreateUUID).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/admin/app/create/hooks/useBasicInfo.ts
+++ b/apps/admin/app/create/hooks/useBasicInfo.ts
@@ -1,3 +1,4 @@
+import { createUUID } from "@/app/utils/uuid";
 import { useState } from "react";
 import { validateReportId } from "../utils/validation";
 
@@ -6,7 +7,7 @@ import { validateReportId } from "../utils/validation";
  */
 export function useBasicInfo() {
   // 基本情報の状態
-  const [input, setInput] = useState<string>(crypto.randomUUID());
+  const [input, setInput] = useState<string>(() => createUUID());
   const [question, setQuestion] = useState<string>("");
   const [intro, setIntro] = useState<string>("");
   const [isReportIdValid, setIsReportIdValid] = useState<boolean>(true);
@@ -41,7 +42,7 @@ export function useBasicInfo() {
    * 基本情報をリセット
    */
   const resetBasicInfo = () => {
-    setInput(crypto.randomUUID());
+    setInput(createUUID());
     setQuestion("");
     setIntro("");
     setIsReportIdValid(true);

--- a/apps/admin/app/utils/__tests__/uuid.test.ts
+++ b/apps/admin/app/utils/__tests__/uuid.test.ts
@@ -1,0 +1,51 @@
+import { createUUID } from "../uuid";
+
+describe("createUUID", () => {
+  const originalCrypto = global.crypto;
+  const originalMathRandom = Math.random;
+
+  afterEach(() => {
+    Object.defineProperty(global, "crypto", {
+      configurable: true,
+      value: originalCrypto,
+    });
+    Math.random = originalMathRandom;
+  });
+
+  it("uses crypto.randomUUID when available", () => {
+    const randomUUID = jest.fn(() => "native-uuid");
+    Object.defineProperty(global, "crypto", {
+      configurable: true,
+      value: { randomUUID },
+    });
+
+    expect(createUUID()).toBe("native-uuid");
+    expect(randomUUID).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to crypto.getRandomValues when randomUUID is unavailable", () => {
+    const getRandomValues = jest.fn((bytes: Uint8Array) => {
+      bytes.set([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
+      return bytes;
+    });
+    Object.defineProperty(global, "crypto", {
+      configurable: true,
+      value: { getRandomValues },
+    });
+
+    expect(createUUID()).toBe("00010203-0405-4607-8809-0a0b0c0d0e0f");
+    expect(getRandomValues).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to Math.random when crypto is unavailable", () => {
+    const values = Array.from({ length: 16 }, (_, index) => index / 255);
+    let current = 0;
+    Math.random = jest.fn(() => values[current++] ?? 0);
+    Object.defineProperty(global, "crypto", {
+      configurable: true,
+      value: undefined,
+    });
+
+    expect(createUUID()).toBe("00010203-0405-4607-8809-0a0b0c0d0e0f");
+  });
+});

--- a/apps/admin/app/utils/uuid.ts
+++ b/apps/admin/app/utils/uuid.ts
@@ -1,0 +1,34 @@
+const formatUuidFromBytes = (bytes: Uint8Array): string => {
+  const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0"));
+
+  return [
+    hex.slice(0, 4).join(""),
+    hex.slice(4, 6).join(""),
+    hex.slice(6, 8).join(""),
+    hex.slice(8, 10).join(""),
+    hex.slice(10, 16).join(""),
+  ].join("-");
+};
+
+const randomByte = (): number => Math.floor(Math.random() * 256);
+
+export const createUUID = (): string => {
+  const cryptoApi = globalThis.crypto;
+  if (cryptoApi?.randomUUID) {
+    return cryptoApi.randomUUID();
+  }
+
+  const bytes = new Uint8Array(16);
+  if (cryptoApi?.getRandomValues) {
+    cryptoApi.getRandomValues(bytes);
+  } else {
+    bytes.forEach((_, index) => {
+      bytes[index] = randomByte();
+    });
+  }
+
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+  return formatUuidFromBytes(bytes);
+};


### PR DESCRIPTION
## 概要

public IP + HTTP など non-secure context で `crypto.randomUUID()` が使えない場合でも、admin の create / reuse 画面が即死しないように UUID fallback を追加します。

Closes #833

## 変更内容

- `apps/admin/app/utils/uuid.ts` に `createUUID()` helper を追加
- `crypto.randomUUID()` がある環境ではそれを優先使用
- 無い場合は `crypto.getRandomValues()`、さらに無ければ `Math.random()` で RFC4122 v4 形式 UUID を生成
- `useBasicInfo` と `EnvironmentCheckDialog` の直接 `crypto.randomUUID()` 呼び出しを helper 経由に置換
- helper / hook / dialog の targeted test を追加

## 確認

- `pnpm --filter @kouchou-ai/admin test -- --runInBand app/utils/__tests__/uuid.test.ts app/create/hooks/useBasicInfo.test.ts app/create/components/EnvironmentCheckDialog/EnvironmentCheckDialog.test.tsx`
- `pnpm exec biome check apps/admin/app/utils/uuid.ts apps/admin/app/utils/__tests__/uuid.test.ts apps/admin/app/create/hooks/useBasicInfo.ts apps/admin/app/create/hooks/useBasicInfo.test.ts apps/admin/app/create/components/EnvironmentCheckDialog/EnvironmentCheckDialog.tsx apps/admin/app/create/components/EnvironmentCheckDialog/EnvironmentCheckDialog.test.tsx`

## スコープ外

- CSP / remote asset policy: #846
- LocalLLM model auto-fetch UX: #845


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Implemented centralized UUID generation utility with fallback compatibility for environments where standard crypto APIs may be unavailable.
  * Migrated internal UUID generation across components and hooks to use the new centralized utility.

* **Tests**
  * Added comprehensive test coverage for UUID generation, including fallback scenarios.
  * Updated test suites to verify proper usage of centralized UUID generation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/digitaldemocracy2030/kouchou-ai/pull/847?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->