### PR TITLE
web apps に env-aware CSP header を追加

### DIFF
--- a/apps/admin/app/utils/__tests__/csp.test.ts
+++ b/apps/admin/app/utils/__tests__/csp.test.ts
@@ -1,0 +1,38 @@
+import { buildCspHeaderValue, extractAllowedOrigins } from "../../../../shared/csp";
+
+describe("CSP helpers", () => {
+  it("extracts unique http/https origins and ignores invalid values", () => {
+    expect(
+      extractAllowedOrigins([
+        "http://18.233.19.158:8000/meta/icon.png",
+        "https://example.com/api",
+        "https://example.com/other",
+        "ws://localhost:8000",
+        "not-a-url",
+        undefined,
+      ]),
+    ).toEqual(["http://18.233.19.158:8000", "https://example.com"]);
+  });
+
+  it("builds a CSP that allows configured API and site origins", () => {
+    const csp = buildCspHeaderValue({
+      apiBasePath: "http://18.233.19.158:8000",
+      publicApiBasePath: "http://18.233.19.158:8000/v1",
+      siteUrl: "http://18.233.19.158:4000",
+    });
+
+    expect(csp).toContain("img-src 'self' data: blob: http://18.233.19.158:8000 http://18.233.19.158:4000");
+    expect(csp).toContain("connect-src 'self' http://18.233.19.158:8000 http://18.233.19.158:4000");
+    expect(csp).toContain("style-src 'self' 'unsafe-inline' https://fonts.googleapis.com");
+    expect(csp).toContain("font-src 'self' data: https://fonts.gstatic.com");
+  });
+
+  it("adds Google Analytics origins only when enabled", () => {
+    const withoutGa = buildCspHeaderValue({});
+    const withGa = buildCspHeaderValue({ enableGoogleAnalytics: true });
+
+    expect(withoutGa).not.toContain("https://www.googletagmanager.com");
+    expect(withGa).toContain("script-src 'self' 'unsafe-inline' https://www.googletagmanager.com");
+    expect(withGa).toContain("connect-src 'self' https://www.googletagmanager.com https://www.google-analytics.com");
+  });
+});

--- a/apps/admin/next.config.ts
+++ b/apps/admin/next.config.ts
@@ -1,5 +1,15 @@
-import path from "path";
+import path from "node:path";
 import type { NextConfig } from "next";
+import { buildCspHeaderValue } from "../shared/csp";
+
+const enableGoogleAnalytics = Boolean(process.env.NEXT_PUBLIC_ADMIN_GA_MEASUREMENT_ID);
+const contentSecurityPolicy = buildCspHeaderValue({
+  apiBasePath: process.env.API_BASEPATH,
+  publicApiBasePath: process.env.NEXT_PUBLIC_API_BASEPATH,
+  siteUrl: process.env.NEXT_PUBLIC_SITE_URL,
+  enableGoogleAnalytics,
+  isDevelopment: process.env.NODE_ENV !== "production",
+});
 
 const nextConfig: NextConfig = {
   output: "standalone",
@@ -11,6 +21,19 @@ const nextConfig: NextConfig = {
     },
   },
   serverExternalPackages: ["fs", "path"],
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: [
+          {
+            key: "Content-Security-Policy",
+            value: contentSecurityPolicy,
+          },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/apps/public-viewer/next.config.ts
+++ b/apps/public-viewer/next.config.ts
@@ -1,9 +1,18 @@
+import path from "node:path";
 import type { NextConfig } from "next";
-import path from "path";
+import { buildCspHeaderValue } from "../shared/csp";
 
 const isStaticExport = process.env.NEXT_PUBLIC_OUTPUT_MODE === "export";
 const BASE_PATH = process.env.NEXT_PUBLIC_STATIC_EXPORT_BASE_PATH || "";
 const DIST_DIR = process.env.STATIC_EXPORT_DIST_DIR || ".next";
+const enableGoogleAnalytics = Boolean(process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID);
+const contentSecurityPolicy = buildCspHeaderValue({
+  apiBasePath: process.env.API_BASEPATH,
+  publicApiBasePath: process.env.NEXT_PUBLIC_API_BASEPATH,
+  siteUrl: process.env.NEXT_PUBLIC_SITE_URL,
+  enableGoogleAnalytics,
+  isDevelopment: process.env.NODE_ENV !== "production",
+});
 
 const nextConfig: NextConfig = {
   basePath: isStaticExport ? BASE_PATH : "",
@@ -17,6 +26,23 @@ const nextConfig: NextConfig = {
   },
   experimental: {
     optimizePackageImports: ["@chakra-ui/react"],
+  },
+  async headers() {
+    if (isStaticExport) {
+      return [];
+    }
+
+    return [
+      {
+        source: "/:path*",
+        headers: [
+          {
+            key: "Content-Security-Policy",
+            value: contentSecurityPolicy,
+          },
+        ],
+      },
+    ];
   },
 };
 

--- a/apps/shared/csp.ts
+++ b/apps/shared/csp.ts
@@ -33,6 +33,8 @@ type BuildCspOptions = {
   isDevelopment?: boolean;
 };
 
+type CspDirective = [directive: string, values: string[]];
+
 export const buildCspHeaderValue = ({
   apiBasePath,
   publicApiBasePath,
@@ -56,7 +58,7 @@ export const buildCspHeaderValue = ({
     connectSrc.push(GOOGLE_TAG_MANAGER_ORIGIN, GOOGLE_ANALYTICS_ORIGIN, GOOGLE_ANALYTICS_REGION_ORIGIN);
   }
 
-  return [
+  const directives: CspDirective[] = [
     ["default-src", ["'self'"]],
     ["base-uri", ["'self'"]],
     ["object-src", ["'none'"]],
@@ -66,7 +68,7 @@ export const buildCspHeaderValue = ({
     ["img-src", unique(imgSrc)],
     ["font-src", unique(fontSrc)],
     ["connect-src", unique(connectSrc)],
-  ]
-    .map(([directive, values]) => `${directive} ${values.join(" ")}`)
-    .join("; ");
+  ];
+
+  return directives.map(([directive, values]) => `${directive} ${values.join(" ")}`).join("; ");
 };

--- a/apps/shared/csp.ts
+++ b/apps/shared/csp.ts
@@ -1,0 +1,72 @@
+const GOOGLE_FONTS_STYLES_ORIGIN = "https://fonts.googleapis.com";
+const GOOGLE_FONTS_ASSETS_ORIGIN = "https://fonts.gstatic.com";
+const GOOGLE_TAG_MANAGER_ORIGIN = "https://www.googletagmanager.com";
+const GOOGLE_ANALYTICS_ORIGIN = "https://www.google-analytics.com";
+const GOOGLE_ANALYTICS_REGION_ORIGIN = "https://region1.google-analytics.com";
+
+const unique = <T>(values: T[]): T[] => Array.from(new Set(values));
+
+export const extractAllowedOrigins = (values: Array<string | undefined>): string[] =>
+  unique(
+    values.flatMap((value) => {
+      if (!value) {
+        return [];
+      }
+
+      try {
+        const url = new URL(value);
+        if (url.protocol !== "http:" && url.protocol !== "https:") {
+          return [];
+        }
+        return [url.origin];
+      } catch {
+        return [];
+      }
+    }),
+  );
+
+type BuildCspOptions = {
+  apiBasePath?: string;
+  publicApiBasePath?: string;
+  siteUrl?: string;
+  enableGoogleAnalytics?: boolean;
+  isDevelopment?: boolean;
+};
+
+export const buildCspHeaderValue = ({
+  apiBasePath,
+  publicApiBasePath,
+  siteUrl,
+  enableGoogleAnalytics = false,
+  isDevelopment = false,
+}: BuildCspOptions): string => {
+  const remoteOrigins = extractAllowedOrigins([apiBasePath, publicApiBasePath, siteUrl]);
+  const scriptSrc = ["'self'", "'unsafe-inline'"];
+  const styleSrc = ["'self'", "'unsafe-inline'", GOOGLE_FONTS_STYLES_ORIGIN];
+  const fontSrc = ["'self'", "data:", GOOGLE_FONTS_ASSETS_ORIGIN];
+  const imgSrc = ["'self'", "data:", "blob:", ...remoteOrigins];
+  const connectSrc = ["'self'", ...remoteOrigins];
+
+  if (isDevelopment) {
+    scriptSrc.push("'unsafe-eval'");
+  }
+
+  if (enableGoogleAnalytics) {
+    scriptSrc.push(GOOGLE_TAG_MANAGER_ORIGIN);
+    connectSrc.push(GOOGLE_TAG_MANAGER_ORIGIN, GOOGLE_ANALYTICS_ORIGIN, GOOGLE_ANALYTICS_REGION_ORIGIN);
+  }
+
+  return [
+    ["default-src", ["'self'"]],
+    ["base-uri", ["'self'"]],
+    ["object-src", ["'none'"]],
+    ["frame-ancestors", ["'self'"]],
+    ["script-src", unique(scriptSrc)],
+    ["style-src", unique(styleSrc)],
+    ["img-src", unique(imgSrc)],
+    ["font-src", unique(fontSrc)],
+    ["connect-src", unique(connectSrc)],
+  ]
+    .map(([directive, values]) => `${directive} ${values.join(" ")}`)
+    .join("; ");
+};


### PR DESCRIPTION
## 概要

public IP + HTTP の self-host 環境で、API / icon / reporter image などの remote asset を current config から安全に許可できるよう、`apps/admin` と `apps/public-viewer` に env-aware な CSP header を追加します。

Closes #846

## 変更内容

- `apps/shared/csp.ts` に共通の CSP helper を追加
- `API_BASEPATH` / `NEXT_PUBLIC_API_BASEPATH` / `NEXT_PUBLIC_SITE_URL` から許可 origin を抽出
- `apps/admin/next.config.ts` に動的 `Content-Security-Policy` header を追加
- `apps/public-viewer/next.config.ts` に動的 `Content-Security-Policy` header を追加
- Google Fonts と、GA が有効な場合の Google Analytics origin を許可
- `public-viewer` の static export (`output: export`) では header を配れないため、この経路では `headers()` を空にする
- helper の targeted test を追加

## 確認

- `pnpm --filter @kouchou-ai/admin test -- --runInBand app/utils/__tests__/csp.test.ts`
- `pnpm exec biome check apps/shared/csp.ts apps/admin/app/utils/__tests__/csp.test.ts apps/admin/next.config.ts apps/public-viewer/next.config.ts`

## スコープ外

- static export 配信先での CSP 設定ガイド: #820
- Plotly PNG download / `blob:` まわりの個別確認: #818
- LocalLLM model auto-fetch UX: #845


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented Content Security Policy headers across applications to enhance security and protect against code injection vulnerabilities.
  * Added conditional Google Analytics integration with configurable security policies.

* **Tests**
  * Added comprehensive test suite validating security policy configuration and header generation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/digitaldemocracy2030/kouchou-ai/pull/848?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->