### PR TITLE
LocalLLM モデル一覧の auto-fetch UX を改善

### DIFF
--- a/apps/admin/app/create/components/AISettingsSection.tsx
+++ b/apps/admin/app/create/components/AISettingsSection.tsx
@@ -135,7 +135,8 @@ export function AISettingsSection({
           </HStack>
           <Field.HelperText>
             OpenAI互換インターフェースで動作しているLLMサーバ（ollamaやLMStudio）のアドレスを指定してください。
-            広聴AIのdockerでollamaサーバを起動している場合は ollama:11434で接続できます。
+            LocalLLMを選択するとモデル一覧の自動取得を試みます。広聴AIのdockerでollamaサーバを起動している場合は
+            ollama:11434で接続でき、失敗時はモデル取得ボタンで再試行できます。
           </Field.HelperText>
         </Field.Root>
       )}

--- a/apps/admin/app/create/hooks/useAISettings.test.ts
+++ b/apps/admin/app/create/hooks/useAISettings.test.ts
@@ -1,0 +1,154 @@
+import { toaster } from "@/components/ui/toaster";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { useAISettings } from "./useAISettings";
+
+jest.mock("@/components/ui/toaster", () => ({
+  toaster: {
+    create: jest.fn(),
+  },
+}));
+
+global.fetch = jest.fn();
+
+const mockFetch = global.fetch as jest.MockedFunction<typeof fetch>;
+const mockToasterCreate = toaster.create as jest.MockedFunction<typeof toaster.create>;
+const originalEnv = process.env;
+
+describe("useAISettings", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+    window.localStorage.clear();
+    process.env = {
+      ...originalEnv,
+      NEXT_PUBLIC_API_BASEPATH: "http://localhost:8000",
+      NEXT_PUBLIC_ADMIN_API_KEY: "test-api-key",
+    };
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+    process.env = originalEnv;
+  });
+
+  it("LocalLLMを選択するとモデル一覧を自動取得する", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: jest.fn().mockResolvedValueOnce([
+        { value: "llama3.1", label: "Llama 3.1" },
+        { value: "gemma3", label: "Gemma 3" },
+      ]),
+    } as unknown as Response);
+
+    const { result } = renderHook(() => useAISettings());
+
+    act(() => {
+      result.current.handleProviderChange({ target: { value: "local" } } as React.ChangeEvent<HTMLSelectElement>);
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    await waitFor(() => {
+      expect(result.current.getCurrentModels()).toHaveLength(2);
+    });
+
+    expect(result.current.model).toBe("llama3.1");
+    expect(mockFetch).toHaveBeenCalledWith("http://localhost:8000/admin/models?provider=local&address=ollama%3A11434", {
+      method: "GET",
+      headers: {
+        "x-api-key": "test-api-key",
+        "Content-Type": "application/json",
+      },
+    });
+    expect(mockToasterCreate).not.toHaveBeenCalled();
+  });
+
+  it("LocalLLMアドレス変更後は debounce して自動再取得する", async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValueOnce([{ value: "llama3.1", label: "Llama 3.1" }]),
+      } as unknown as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValueOnce([{ value: "mistral", label: "Mistral" }]),
+      } as unknown as Response);
+
+    const { result } = renderHook(() => useAISettings());
+
+    act(() => {
+      result.current.handleProviderChange({ target: { value: "local" } } as React.ChangeEvent<HTMLSelectElement>);
+      jest.advanceTimersByTime(500);
+    });
+
+    await waitFor(() => {
+      expect(result.current.getCurrentModels()).toHaveLength(1);
+    });
+
+    act(() => {
+      result.current.setLocalLLMAddress("lmstudio:1234");
+      jest.advanceTimersByTime(499);
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    expect(mockFetch).toHaveBeenLastCalledWith(
+      "http://localhost:8000/admin/models?provider=local&address=lmstudio%3A1234",
+      {
+        method: "GET",
+        headers: {
+          "x-api-key": "test-api-key",
+          "Content-Type": "application/json",
+        },
+      },
+    );
+    expect(result.current.model).toBe("mistral");
+  });
+
+  it("手動取得では toaster を出して再試行できる", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: jest.fn().mockResolvedValueOnce([{ value: "llama3.1", label: "Llama 3.1" }]),
+    } as unknown as Response);
+
+    const { result } = renderHook(() => useAISettings());
+
+    act(() => {
+      result.current.handleProviderChange({ target: { value: "local" } } as React.ChangeEvent<HTMLSelectElement>);
+      result.current.setLocalLLMAddress("lmstudio:1234");
+    });
+
+    let fetched = false;
+    await act(async () => {
+      fetched = await result.current.fetchLocalLLMModels();
+    });
+
+    expect(fetched).toBe(true);
+    expect(mockToasterCreate).toHaveBeenCalledWith({
+      type: "success",
+      title: "モデルリスト取得成功",
+      description: "1個のモデルを取得しました",
+    });
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://localhost:8000/admin/models?provider=local&address=lmstudio%3A1234",
+      {
+        method: "GET",
+        headers: {
+          "x-api-key": "test-api-key",
+          "Content-Type": "application/json",
+        },
+      },
+    );
+  });
+});

--- a/apps/admin/app/create/hooks/useAISettings.ts
+++ b/apps/admin/app/create/hooks/useAISettings.ts
@@ -1,5 +1,5 @@
 import { toaster } from "@/components/ui/toaster";
-import { type ChangeEvent, useEffect, useState } from "react";
+import { type ChangeEvent, useEffect, useRef, useState } from "react";
 
 export type Provider = "openai" | "azure" | "openrouter" | "gemini" | "local";
 
@@ -48,6 +48,8 @@ const GEMINI_MODELS: ModelOption[] = [
   { value: "gemini-1.5-flash", label: "Gemini 1.5 Flash" },
   { value: "gemini-1.5-pro", label: "Gemini 1.5 Pro" },
 ];
+
+const LOCAL_LLM_AUTO_FETCH_DELAY_MS = 500;
 
 /**
  * サーバーからモデルリストを取得する関数
@@ -116,7 +118,9 @@ function saveToStorage<T>(key: string, value: T): void {
  * AIモデル設定を管理するカスタムフック
  */
 export function useAISettings() {
-  const [provider, setProvider] = useState<Provider>(() => getFromStorage<Provider>(STORAGE_KEYS.PROVIDER, DEFAULT_PROVIDER));
+  const [provider, setProvider] = useState<Provider>(() =>
+    getFromStorage<Provider>(STORAGE_KEYS.PROVIDER, DEFAULT_PROVIDER),
+  );
   const [model, setModel] = useState<string>(() => getFromStorage<string>(STORAGE_KEYS.MODEL, "gpt-4o-mini"));
   const [workers, setWorkers] = useState<number>(() => getFromStorage<number>(STORAGE_KEYS.WORKERS, 30));
   const [isPubcomMode, setIsPubcomMode] = useState<boolean>(true);
@@ -135,6 +139,7 @@ export function useAISettings() {
 
   const [openRouterModels, setOpenRouterModels] = useState<ModelOption[]>([]);
   const [localLLMModels, setLocalLLMModels] = useState<ModelOption[]>([]);
+  const lastAutoFetchedLocalLLMAddressRef = useRef<string | null>(null);
 
   useEffect(() => {
     saveToStorage(STORAGE_KEYS.PROVIDER, provider);
@@ -173,38 +178,97 @@ export function useAISettings() {
     }
   }, [provider]);
 
-  /**
-   * LocalLLMのモデルリストを手動で取得
-   */
-  const fetchLocalLLMModels = async () => {
-    if (provider === "local" && localLLMAddress) {
-      try {
-        const models = await fetchModelsFromServer("local", localLLMAddress);
-        setLocalLLMModels(models);
-        if (models.length > 0) {
-          setModel(models[0].value);
-          toaster.create({
-            type: "success",
-            title: "モデルリスト取得成功",
-            description: `${models.length}個のモデルを取得しました`,
-          });
-        } else {
-          toaster.create({
-            type: "warning",
-            title: "モデルリスト取得警告",
-            description: "モデルリストが空です。LocalLLMサーバーの設定を確認してください。",
-          });
-        }
-        return true;
-      } catch (error) {
-        console.error("LocalLLMモデルの取得に失敗しました:", error);
+  const applyLocalLLMModels = (models: ModelOption[]) => {
+    setLocalLLMModels(models);
+    if (models.length === 0) return;
+    setModel((currentModel) =>
+      models.some((candidate) => candidate.value === currentModel) ? currentModel : models[0].value,
+    );
+  };
+
+  const loadLocalLLMModels = async ({
+    address,
+    showSuccessToast,
+    showEmptyToast,
+    showErrorToast,
+  }: {
+    address: string;
+    showSuccessToast: boolean;
+    showEmptyToast: boolean;
+    showErrorToast: boolean;
+  }) => {
+    try {
+      const models = await fetchModelsFromServer("local", address);
+      applyLocalLLMModels(models);
+      if (models.length > 0 && showSuccessToast) {
+        toaster.create({
+          type: "success",
+          title: "モデルリスト取得成功",
+          description: `${models.length}個のモデルを取得しました`,
+        });
+      }
+      if (models.length === 0 && showEmptyToast) {
+        toaster.create({
+          type: "warning",
+          title: "モデルリスト取得警告",
+          description: "モデルリストが空です。LocalLLMサーバーの設定を確認してください。",
+        });
+      }
+      return true;
+    } catch (error) {
+      console.error("LocalLLMモデルの取得に失敗しました:", error);
+      if (showErrorToast) {
         toaster.create({
           type: "error",
           title: "モデルリスト取得失敗",
           description: "LocalLLMからモデルリストの取得に失敗しました。接続設定とサーバーの状態を確認してください。",
         });
-        return false;
       }
+      return false;
+    }
+  };
+
+  useEffect(() => {
+    if (provider !== "local") {
+      lastAutoFetchedLocalLLMAddressRef.current = null;
+      return;
+    }
+
+    const trimmedAddress = localLLMAddress.trim();
+    if (!trimmedAddress || lastAutoFetchedLocalLLMAddressRef.current === trimmedAddress) {
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      lastAutoFetchedLocalLLMAddressRef.current = trimmedAddress;
+      void fetchModelsFromServer("local", trimmedAddress)
+        .then((models) => {
+          setLocalLLMModels(models);
+          if (models.length === 0) return;
+          setModel((currentModel) =>
+            models.some((candidate) => candidate.value === currentModel) ? currentModel : models[0].value,
+          );
+        })
+        .catch((error) => {
+          console.error("LocalLLMモデルの自動取得に失敗しました:", error);
+        });
+    }, LOCAL_LLM_AUTO_FETCH_DELAY_MS);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [provider, localLLMAddress]);
+
+  /**
+   * LocalLLMのモデルリストを手動で取得
+   */
+  const fetchLocalLLMModels = async () => {
+    if (provider === "local" && localLLMAddress) {
+      lastAutoFetchedLocalLLMAddressRef.current = localLLMAddress.trim();
+      return loadLocalLLMModels({
+        address: localLLMAddress.trim(),
+        showSuccessToast: true,
+        showEmptyToast: true,
+        showErrorToast: true,
+      });
     }
     return false;
   };

--- a/apps/admin/app/create/utils/validation.test.ts
+++ b/apps/admin/app/create/utils/validation.test.ts
@@ -1,4 +1,4 @@
-import { isValidId, validateReportId } from "./validation";
+import { isValidId, validateFormValues, validateReportId } from "./validation";
 
 describe("isValidId", () => {
   test("有効なIDの場合はtrueを返す", () => {
@@ -132,6 +132,34 @@ describe("validateReportId", () => {
         isValid: false,
         errorMessage: "IDはハイフンで終わることができません",
       });
+    });
+  });
+});
+
+describe("validateFormValues", () => {
+  test("LocalLLMのモデル自動取得失敗時の再試行案内を返す", () => {
+    const result = validateFormValues({
+      input: "test-report",
+      question: "",
+      intro: "",
+      clusterLv1: 5,
+      clusterLv2: 10,
+      model: "llama3.1",
+      extractionPrompt: "extract",
+      inputType: "file",
+      csv: new File(["id,comment\n1,test"], "test.csv", { type: "text/csv" }),
+      spreadsheetImported: false,
+      selectedCommentColumn: "comment",
+      csvColumns: ["id", "comment"],
+      provider: "local",
+      modelOptions: [],
+      pluginImported: false,
+      pluginSelectedCommentColumn: "",
+    });
+
+    expect(result).toEqual({
+      isValid: false,
+      errorMessage: "LocalLLMのモデルリストが空です。自動取得に失敗した場合はモデル取得ボタンで再試行してください。",
     });
   });
 });

--- a/apps/admin/app/create/utils/validation.ts
+++ b/apps/admin/app/create/utils/validation.ts
@@ -128,7 +128,7 @@ export function validateFormValues({
   if (provider === "local" && modelOptions && modelOptions.length === 0) {
     return {
       isValid: false,
-      errorMessage: "LocalLLMのモデルリストが空です。モデル取得ボタンを押してモデルリストを取得してください。",
+      errorMessage: "LocalLLMのモデルリストが空です。自動取得に失敗した場合はモデル取得ボタンで再試行してください。",
     };
   }
 


### PR DESCRIPTION
## 概要
- LocalLLM を選択した時にモデル一覧の自動取得を試みるようにしました
- LocalLLM アドレス変更時も debounce 付きで自動再取得し、失敗時は既存の手動ボタンで再試行できます
- create flow の案内文と validation 文言を、自動取得前提の UX に合わせて更新しました

## 変更内容
- `useAISettings` に LocalLLM モデル一覧の debounce 付き auto-fetch を追加
- 手動の `モデル取得` は retry 用に残し、成功時 toast は従来どおり維持
- `validation.test.ts` と `useAISettings.test.ts` を追加し、auto-fetch / manual retry を検証

## 確認
- `pnpm --filter @kouchou-ai/admin test -- --runInBand app/create/hooks/useAISettings.test.ts app/create/utils/validation.test.ts`
- `pnpm exec biome check apps/admin/app/create/hooks/useAISettings.ts apps/admin/app/create/hooks/useAISettings.test.ts apps/admin/app/create/components/AISettingsSection.tsx apps/admin/app/create/utils/validation.ts apps/admin/app/create/utils/validation.test.ts`

Closes #845


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * LocalLLM models are now automatically fetched when you select the LocalLLM provider, streamlining the setup process.

* **Bug Fixes**
  * Improved error messaging when LocalLLM model retrieval fails, providing clearer guidance to retry model fetching via the dedicated button.

* **Documentation**
  * Updated LocalLLM connection settings helper text for better clarity and improved user guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/digitaldemocracy2030/kouchou-ai/pull/850?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->