### PR TITLE
Azure deploy で shared CSP helper を取り込む

### DIFF
--- a/apps/admin/Dockerfile
+++ b/apps/admin/Dockerfile
@@ -26,6 +26,7 @@ COPY apps/static-site-builder/package.json apps/static-site-builder/
 RUN pnpm install --frozen-lockfile
 
 COPY packages/report-schema packages/report-schema
+COPY apps/shared apps/shared
 COPY apps/admin apps/admin
 
 ENV NEXT_DISABLE_FETCH_DURING_BUILD=true

--- a/apps/public-viewer/Dockerfile
+++ b/apps/public-viewer/Dockerfile
@@ -17,6 +17,7 @@ COPY apps/public-viewer/package.json apps/public-viewer/
 RUN pnpm install --frozen-lockfile
 
 COPY packages/report-schema packages/report-schema
+COPY apps/shared apps/shared
 COPY apps/public-viewer apps/public-viewer
 
 RUN node_modules/.bin/tsc --project packages/report-schema/tsconfig.json


### PR DESCRIPTION
## 概要

`Azure Deployment` が `main` push で失敗していたため、web app Docker build に `apps/shared` を含めるようにします。

## 原因

`#848` で `apps/admin/next.config.ts` と `apps/public-viewer/next.config.ts` が `../shared/csp` を import するようになりましたが、各 Dockerfile の builder stage が `apps/shared` を copy していませんでした。

そのため Azure deploy の admin image build 中に `next build` が `Cannot find module ../shared/csp` で落ちていました。

## 変更内容

- `apps/admin/Dockerfile` に `COPY apps/shared apps/shared` を追加
- `apps/public-viewer/Dockerfile` に `COPY apps/shared apps/shared` を追加

## 確認

この環境では Docker daemon が起動しておらず `docker build` 自体は実行できませんでした。
代わりに、host 側で次を実行し、少なくとも `next.config.ts` の `../shared/csp` import 解決で落ちないことを確認しました。

- `pnpm --filter @kouchou-ai/admin build`
- `pnpm --filter @kouchou-ai/public-viewer build`

どちらも `MODULE_NOT_FOUND: ../shared/csp` では落ちていません。

## 関連

- failing workflow: `Azure Deployment`
- failing run example: `26230264389`
- failing step: `Azure環境のデプロイ`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build configurations for the admin and public viewer applications to properly include shared resources in the build context, improving dependency management during the deployment process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/digitaldemocracy2030/kouchou-ai/pull/851?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->