### PR TITLE
管理画面でレポート生成失敗時のエラーログを確認できるようにする

### DIFF
--- a/apps/admin/app/_components/ReportCard/ProgressSteps/ProgressSteps.tsx
+++ b/apps/admin/app/_components/ReportCard/ProgressSteps/ProgressSteps.tsx
@@ -80,7 +80,7 @@ export const ProgressSteps = ({ slug }: Props) => {
         </Steps.List>
       </Steps.Root>
       {isError && (errorMessage || errorLogExcerpt) && (
-        <Box bg="bg.error" borderRadius="md" px="4" py="3">
+        <Box bg="bg.error" borderRadius="md" px="4" py="3" role="alert" aria-live="assertive">
           {errorMessage && (
             <Text textStyle="body/sm/bold" color="font.error">
               {errorMessage}

--- a/apps/admin/app/_components/ReportCard/ProgressSteps/ProgressSteps.tsx
+++ b/apps/admin/app/_components/ReportCard/ProgressSteps/ProgressSteps.tsx
@@ -3,20 +3,8 @@ import { Check, TriangleAlert } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useEffect } from "react";
 import { Processing } from "./Processing";
+import { stepKeys, steps } from "./progressStepsConfig";
 import { useReportProgressPoll } from "./useReportProgressPolling";
-
-const steps = [
-  { key: "extraction", title: "抽出" },
-  { key: "embedding", title: "埋め込み" },
-  { key: "hierarchical_clustering", title: "意見グループ化" },
-  { key: "hierarchical_initial_labelling", title: "初期ラベリング" },
-  { key: "hierarchical_merge_labelling", title: "統合ラベリング" },
-  { key: "hierarchical_overview", title: "概要生成" },
-  { key: "hierarchical_aggregation", title: "集約" },
-  { key: "hierarchical_visualization", title: "可視化" },
-] as const;
-
-export const stepKeys = steps.map(({ key }) => key);
 
 const stepItemstyle = {
   error: {

--- a/apps/admin/app/_components/ReportCard/ProgressSteps/ProgressSteps.tsx
+++ b/apps/admin/app/_components/ReportCard/ProgressSteps/ProgressSteps.tsx
@@ -1,4 +1,4 @@
-import { Box, Center, Steps } from "@chakra-ui/react";
+import { Box, Center, Code, Steps, Text, VStack } from "@chakra-ui/react";
 import { Check, TriangleAlert } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useEffect } from "react";
@@ -36,11 +36,12 @@ type Props = {
 };
 
 export const ProgressSteps = ({ slug }: Props) => {
-  const { progress, isError } = useReportProgressPoll(slug);
+  const { progress, isError, errorMessage, errorLogExcerpt } = useReportProgressPoll(slug);
 
   const isLoading = progress === "loading";
   const isCompleted = progress === "completed";
-  const currentStepIndex = isCompleted ? steps.length : isLoading ? 0 : stepKeys.indexOf(progress);
+  const resolvedStepIndex = isLoading || isCompleted ? -1 : stepKeys.indexOf(progress);
+  const currentStepIndex = isCompleted ? steps.length : Math.max(resolvedStepIndex, 0);
   const status = isError ? "error" : "processing";
   const router = useRouter();
 
@@ -53,41 +54,57 @@ export const ProgressSteps = ({ slug }: Props) => {
   }, [isCompleted, isError, router]);
 
   return (
-    <Steps.Root step={currentStepIndex} count={steps.length} bg={stepItemstyle[status].processing} mt="2" p="6">
-      <Steps.List gap="2">
-        {steps.map((step, index) => (
-          <Steps.Item key={step.key} index={index} gap="2" flex="auto" textStyle="body/sm">
-            {index < currentStepIndex ? (
-              <>
-                <Center w="6" h="6" bg={stepItemstyle[status].completed} borderRadius="full">
-                  <Check size="16" color="white" />
-                </Center>
-                <Steps.Title textStyle="body/sm" color="font.primary">
-                  {step.title}
-                </Steps.Title>
-              </>
-            ) : index === currentStepIndex ? (
-              <>
-                <Box color={stepItemstyle[status].completed}>{stepItemstyle[status].currentStepIcon}</Box>
-                <Steps.Title
-                  textStyle={isError ? "body/sm/bold" : "body/sm"}
-                  color={isError ? "font.error" : "font.primary"}
-                >
-                  {step.title}
-                </Steps.Title>
-              </>
-            ) : (
-              <>
-                <Center w="6" h="6" bg={stepItemstyle[status].completed} opacity="0.16" borderRadius="full" />
-                <Steps.Title textStyle="body/sm" color={isError ? "font.secondary" : "font.primary"}>
-                  {step.title}
-                </Steps.Title>
-              </>
-            )}
-            <Steps.Separator m="0" bg="blackAlpha.500" h="1px" />
-          </Steps.Item>
-        ))}
-      </Steps.List>
-    </Steps.Root>
+    <VStack align="stretch" gap="3">
+      <Steps.Root step={currentStepIndex} count={steps.length} bg={stepItemstyle[status].processing} mt="2" p="6">
+        <Steps.List gap="2">
+          {steps.map((step, index) => (
+            <Steps.Item key={step.key} index={index} gap="2" flex="auto" textStyle="body/sm">
+              {index < currentStepIndex ? (
+                <>
+                  <Center w="6" h="6" bg={stepItemstyle[status].completed} borderRadius="full">
+                    <Check size="16" color="white" />
+                  </Center>
+                  <Steps.Title textStyle="body/sm" color="font.primary">
+                    {step.title}
+                  </Steps.Title>
+                </>
+              ) : index === currentStepIndex ? (
+                <>
+                  <Box color={stepItemstyle[status].completed}>{stepItemstyle[status].currentStepIcon}</Box>
+                  <Steps.Title
+                    textStyle={isError ? "body/sm/bold" : "body/sm"}
+                    color={isError ? "font.error" : "font.primary"}
+                  >
+                    {step.title}
+                  </Steps.Title>
+                </>
+              ) : (
+                <>
+                  <Center w="6" h="6" bg={stepItemstyle[status].completed} opacity="0.16" borderRadius="full" />
+                  <Steps.Title textStyle="body/sm" color={isError ? "font.secondary" : "font.primary"}>
+                    {step.title}
+                  </Steps.Title>
+                </>
+              )}
+              <Steps.Separator m="0" bg="blackAlpha.500" h="1px" />
+            </Steps.Item>
+          ))}
+        </Steps.List>
+      </Steps.Root>
+      {isError && (errorMessage || errorLogExcerpt) && (
+        <Box bg="bg.error" borderRadius="md" px="4" py="3">
+          {errorMessage && (
+            <Text textStyle="body/sm/bold" color="font.error">
+              {errorMessage}
+            </Text>
+          )}
+          {errorLogExcerpt && (
+            <Code display="block" mt="3" p="3" whiteSpace="pre-wrap" fontSize="xs" colorPalette="red" overflowX="auto">
+              {errorLogExcerpt}
+            </Code>
+          )}
+        </Box>
+      )}
+    </VStack>
   );
 };

--- a/apps/admin/app/_components/ReportCard/ProgressSteps/ProgressSteps.tsx
+++ b/apps/admin/app/_components/ReportCard/ProgressSteps/ProgressSteps.tsx
@@ -40,7 +40,7 @@ export const ProgressSteps = ({ slug }: Props) => {
 
   const isLoading = progress === "loading";
   const isCompleted = progress === "completed";
-  const resolvedStepIndex = isLoading || isCompleted ? -1 : stepKeys.indexOf(progress);
+  const resolvedStepIndex = isLoading || isCompleted || progress === "error" ? -1 : stepKeys.indexOf(progress);
   const currentStepIndex = isCompleted ? steps.length : Math.max(resolvedStepIndex, 0);
   const status = isError ? "error" : "processing";
   const router = useRouter();

--- a/apps/admin/app/_components/ReportCard/ProgressSteps/progressStepsConfig.ts
+++ b/apps/admin/app/_components/ReportCard/ProgressSteps/progressStepsConfig.ts
@@ -1,0 +1,12 @@
+export const steps = [
+  { key: "extraction", title: "抽出" },
+  { key: "embedding", title: "埋め込み" },
+  { key: "hierarchical_clustering", title: "意見グループ化" },
+  { key: "hierarchical_initial_labelling", title: "初期ラベリング" },
+  { key: "hierarchical_merge_labelling", title: "統合ラベリング" },
+  { key: "hierarchical_overview", title: "概要生成" },
+  { key: "hierarchical_aggregation", title: "集約" },
+  { key: "hierarchical_visualization", title: "可視化" },
+] as const;
+
+export const stepKeys = steps.map(({ key }) => key);

--- a/apps/admin/app/_components/ReportCard/ProgressSteps/useReportProgressPolling.test.ts
+++ b/apps/admin/app/_components/ReportCard/ProgressSteps/useReportProgressPolling.test.ts
@@ -74,13 +74,13 @@ describe("useReportProgressPoll", () => {
   it("APIからcurrent_stepが返された時にprogressが更新される", async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
-      json: async () => ({ current_step: "processing" }),
+      json: async () => ({ current_step: "extraction" }),
     } as Response);
 
     const { result } = renderHook(() => useReportProgressPoll("test-slug"));
 
     await waitFor(() => {
-      expect(result.current.progress).toBe("processing");
+      expect(result.current.progress).toBe("extraction");
     });
   });
 
@@ -132,7 +132,7 @@ describe("useReportProgressPoll", () => {
       } as Response)
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ current_step: "processing" }),
+        json: async () => ({ current_step: "extraction" }),
       } as Response);
 
     const { result } = renderHook(() => useReportProgressPoll("test-slug"));
@@ -147,7 +147,7 @@ describe("useReportProgressPoll", () => {
 
     await waitFor(() => {
       expect(mockFetch).toHaveBeenCalledTimes(2);
-      expect(result.current.progress).toBe("processing");
+      expect(result.current.progress).toBe("extraction");
     });
   });
 
@@ -157,7 +157,7 @@ describe("useReportProgressPoll", () => {
       .mockRejectedValueOnce(new Error("Network error"))
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ current_step: "processing" }),
+        json: async () => ({ current_step: "extraction" }),
       } as Response);
 
     const { result } = renderHook(() => useReportProgressPoll("test-slug"));
@@ -179,7 +179,7 @@ describe("useReportProgressPoll", () => {
 
     await waitFor(() => {
       expect(mockFetch).toHaveBeenCalledTimes(3);
-      expect(result.current.progress).toBe("processing");
+      expect(result.current.progress).toBe("extraction");
     });
   });
 
@@ -240,7 +240,7 @@ describe("useReportProgressPoll", () => {
       } as Response)
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ current_step: "processing" }),
+        json: async () => ({ current_step: "extraction" }),
       } as Response);
 
     const { result } = renderHook(() => useReportProgressPoll("test-slug"));
@@ -264,7 +264,7 @@ describe("useReportProgressPoll", () => {
 
     await waitFor(() => {
       expect(mockFetch).toHaveBeenCalledTimes(3);
-      expect(result.current.progress).toBe("processing");
+      expect(result.current.progress).toBe("extraction");
     });
   });
 
@@ -275,7 +275,7 @@ describe("useReportProgressPoll", () => {
           setTimeout(() => {
             resolve({
               ok: true,
-              json: async () => ({ current_step: "processing" }),
+              json: async () => ({ current_step: "extraction" }),
             } as Response);
           }, 1000);
         }),

--- a/apps/admin/app/_components/ReportCard/ProgressSteps/useReportProgressPolling.test.ts
+++ b/apps/admin/app/_components/ReportCard/ProgressSteps/useReportProgressPolling.test.ts
@@ -106,13 +106,21 @@ describe("useReportProgressPoll", () => {
   it("current_stepがerrorの時にprogressがerrorに設定される", async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
-      json: async () => ({ current_step: "error" }),
+      json: async () => ({
+        current_step: "error",
+        status: "error",
+        error_message: "Step failed",
+        error_log_excerpt: "trace line",
+      }),
     } as Response);
 
     const { result } = renderHook(() => useReportProgressPoll("test-slug"));
 
     await waitFor(() => {
       expect(result.current.progress).toBe("error");
+      expect(result.current.isError).toBe(true);
+      expect(result.current.errorMessage).toBe("Step failed");
+      expect(result.current.errorLogExcerpt).toBe("trace line");
     });
   });
 
@@ -195,6 +203,7 @@ describe("useReportProgressPoll", () => {
     await waitFor(() => {
       expect(result.current.progress).toBe("loading");
       expect(result.current.isError).toBe(true);
+      expect(result.current.errorMessage).toBe("レポート生成状況の取得に失敗しました。");
     });
   });
 
@@ -215,6 +224,7 @@ describe("useReportProgressPoll", () => {
     await waitFor(() => {
       expect(result.current.progress).toBe("loading");
       expect(result.current.isError).toBe(true);
+      expect(result.current.errorMessage).toBe("レポート生成状況の取得に失敗しました。");
     });
   });
 

--- a/apps/admin/app/_components/ReportCard/ProgressSteps/useReportProgressPolling.ts
+++ b/apps/admin/app/_components/ReportCard/ProgressSteps/useReportProgressPolling.ts
@@ -1,12 +1,20 @@
 import { useEffect, useState } from "react";
 import type { stepKeys } from "./ProgressSteps";
 
-type Progress = (typeof stepKeys)[number] | "loading" | "completed";
+type Progress = (typeof stepKeys)[number] | "loading" | "completed" | "error";
+type StepJsonResponse = {
+  status?: string;
+  current_step?: string;
+  error_message?: string | null;
+  error_log_excerpt?: string | null;
+};
 
 export function useReportProgressPoll(slug: string) {
   const [progress, setProgress] = useState<Progress>("loading");
   const [isError, setIsError] = useState<boolean>(false);
   const [isPolling, setIsPolling] = useState<boolean>(true);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [errorLogExcerpt, setErrorLogExcerpt] = useState<string | null>(null);
 
   useEffect(() => {
     if (!isPolling) return;
@@ -30,7 +38,7 @@ export function useReportProgressPoll(slug: string) {
         });
 
         if (response.ok) {
-          const data = await response.json();
+          const data = (await response.json()) as StepJsonResponse;
 
           if (!data.current_step || data.current_step === "loading") {
             retryCount = 0;
@@ -41,6 +49,8 @@ export function useReportProgressPoll(slug: string) {
           setProgress(data.current_step);
 
           if (data.status === "error") {
+            setErrorMessage(data.error_message || "レポート生成に失敗しました。");
+            setErrorLogExcerpt(data.error_log_excerpt || null);
             setIsError(true);
             setIsPolling(false);
             return;
@@ -57,6 +67,7 @@ export function useReportProgressPoll(slug: string) {
           retryCount++;
           if (retryCount >= maxRetries) {
             console.error("Maximum retry attempts reached");
+            setErrorMessage("レポート生成状況の取得に失敗しました。");
             setIsError(true);
             setIsPolling(false);
             return;
@@ -68,6 +79,7 @@ export function useReportProgressPoll(slug: string) {
         console.error("Polling error:", error);
         retryCount++;
         if (retryCount >= maxRetries) {
+          setErrorMessage("レポート生成状況の取得に失敗しました。");
           setIsError(true);
           setIsPolling(false);
           return;
@@ -83,5 +95,5 @@ export function useReportProgressPoll(slug: string) {
     };
   }, [slug, isPolling]);
 
-  return { progress, isError };
+  return { progress, isError, errorMessage, errorLogExcerpt };
 }

--- a/apps/admin/app/_components/ReportCard/ProgressSteps/useReportProgressPolling.ts
+++ b/apps/admin/app/_components/ReportCard/ProgressSteps/useReportProgressPolling.ts
@@ -10,7 +10,12 @@ type StepJsonResponse = {
 };
 
 function isProgress(value: string): value is Progress {
-  return value === "loading" || value === "completed" || value === "error" || stepKeys.includes(value as (typeof stepKeys)[number]);
+  return (
+    value === "loading" ||
+    value === "completed" ||
+    value === "error" ||
+    stepKeys.includes(value as (typeof stepKeys)[number])
+  );
 }
 
 export function useReportProgressPoll(slug: string) {

--- a/apps/admin/app/_components/ReportCard/ProgressSteps/useReportProgressPolling.ts
+++ b/apps/admin/app/_components/ReportCard/ProgressSteps/useReportProgressPolling.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import type { stepKeys } from "./ProgressSteps";
+import { stepKeys } from "./progressStepsConfig";
 
 type Progress = (typeof stepKeys)[number] | "loading" | "completed" | "error";
 type StepJsonResponse = {

--- a/apps/admin/app/_components/ReportCard/ProgressSteps/useReportProgressPolling.ts
+++ b/apps/admin/app/_components/ReportCard/ProgressSteps/useReportProgressPolling.ts
@@ -9,6 +9,10 @@ type StepJsonResponse = {
   error_log_excerpt?: string | null;
 };
 
+function isProgress(value: string): value is Progress {
+  return value === "loading" || value === "completed" || value === "error" || stepKeys.includes(value as (typeof stepKeys)[number]);
+}
+
 export function useReportProgressPoll(slug: string) {
   const [progress, setProgress] = useState<Progress>("loading");
   const [isError, setIsError] = useState<boolean>(false);
@@ -46,7 +50,9 @@ export function useReportProgressPoll(slug: string) {
             return;
           }
 
-          setProgress(data.current_step);
+          if (isProgress(data.current_step)) {
+            setProgress(data.current_step);
+          }
 
           if (data.status === "error") {
             setErrorMessage(data.error_message || "レポート生成に失敗しました。");

--- a/apps/api/src/routers/admin_report.py
+++ b/apps/api/src/routers/admin_report.py
@@ -208,7 +208,9 @@ async def get_current_step(slug: str) -> dict:
         }
 
         if response["status"] == "error" and not response["error_log_excerpt"] and response["error_log_path"]:
-            log_path = settings.REPORT_DIR / slug / response["error_log_path"]
+            log_filename = Path(str(response["error_log_path"])).name
+            log_path = settings.REPORT_DIR / slug / log_filename
+            validate_path_within_report_dir(log_path)
             response["error_log_excerpt"] = _read_error_log_excerpt(log_path)
 
         # 全体のステータスが "completed" なら、current_step も "completed" とする

--- a/apps/api/src/routers/admin_report.py
+++ b/apps/api/src/routers/admin_report.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 
 import openai
 
@@ -42,6 +43,7 @@ from src.utils.slug_utils import validate_slug
 
 slogger = setup_logger()
 router = APIRouter()
+MAX_ERROR_LOG_CHARS = 4000
 
 api_key_header = APIKeyHeader(name="x-api-key", auto_error=False)
 
@@ -165,6 +167,20 @@ async def download_report_json(slug: str, api_key: str = Depends(verify_admin_ap
     return FileResponse(path=str(json_path), media_type="application/json", filename=f"kouchou_{slug}.json")
 
 
+def _read_error_log_excerpt(log_path: Path) -> str | None:
+    if not log_path.exists():
+        return None
+    try:
+        content = log_path.read_text(encoding="utf-8", errors="replace").strip()
+    except Exception:
+        return None
+    if not content:
+        return None
+    if len(content) <= MAX_ERROR_LOG_CHARS:
+        return content
+    return content[-MAX_ERROR_LOG_CHARS:]
+
+
 @router.get("/admin/reports/{slug}/status/step-json", dependencies=[Depends(verify_admin_api_key)])
 async def get_current_step(slug: str) -> dict:
     validate_slug(slug)
@@ -186,7 +202,14 @@ async def get_current_step(slug: str) -> dict:
             "estimated_cost": status.get("estimated_cost", 0.0),
             "provider": status.get("provider"),
             "model": status.get("model"),
+            "error_message": status.get("error"),
+            "error_log_path": status.get("error_log_path"),
+            "error_log_excerpt": status.get("error_log_excerpt"),
         }
+
+        if response["status"] == "error" and not response["error_log_excerpt"] and response["error_log_path"]:
+            log_path = settings.REPORT_DIR / slug / response["error_log_path"]
+            response["error_log_excerpt"] = _read_error_log_excerpt(log_path)
 
         # 全体のステータスが "completed" なら、current_step も "completed" とする
         if status.get("status") == "completed":
@@ -205,12 +228,16 @@ async def get_current_step(slug: str) -> dict:
         slogger.error(f"Error in get_current_step: {e}")
         return {
             "current_step": "error",
+            "status": "error",
             "token_usage": 0,
             "token_usage_input": 0,
             "token_usage_output": 0,
             "estimated_cost": 0.0,
             "provider": None,
             "model": None,
+            "error_message": None,
+            "error_log_path": None,
+            "error_log_excerpt": None,
         }
 
 

--- a/apps/api/src/services/report_launcher.py
+++ b/apps/api/src/services/report_launcher.py
@@ -14,6 +14,8 @@ from src.services.report_sync import ReportSyncService
 from src.utils.logger import setup_logger
 
 logger = setup_logger()
+ANALYSIS_LOG_FILENAME = "analysis.log"
+MAX_ERROR_LOG_CHARS = 4000
 
 
 def _build_config(report_input: ReportInput) -> dict[str, Any]:
@@ -127,7 +129,57 @@ def save_input_file(report_input: ReportInput) -> Path:
     return input_path
 
 
-def _monitor_process(process: subprocess.Popen, slug: str) -> None:
+def _analysis_log_path(slug: str) -> Path:
+    return settings.REPORT_DIR / slug / ANALYSIS_LOG_FILENAME
+
+
+def _read_log_excerpt(log_path: Path, max_chars: int = MAX_ERROR_LOG_CHARS) -> str | None:
+    if not log_path.exists():
+        return None
+
+    try:
+        content = log_path.read_text(encoding="utf-8", errors="replace").strip()
+    except Exception as exc:
+        logger.warning(f"Failed to read analysis log for {log_path}: {exc}")
+        return None
+
+    if not content:
+        return None
+
+    if len(content) <= max_chars:
+        return content
+
+    return content[-max_chars:]
+
+
+def _ensure_error_status_payload(slug: str) -> None:
+    status_file = settings.REPORT_DIR / slug / "hierarchical_status.json"
+    log_path = _analysis_log_path(slug)
+    log_excerpt = _read_log_excerpt(log_path)
+
+    status_data: dict[str, Any]
+    if status_file.exists():
+        try:
+            with open(status_file, encoding="utf-8") as f:
+                status_data = json.load(f)
+        except Exception as exc:
+            logger.warning(f"Failed to load status file for {slug}: {exc}")
+            status_data = {}
+    else:
+        status_data = {}
+
+    status_data["status"] = "error"
+    status_data["current_job"] = status_data.get("current_job") or "error"
+    status_data["error"] = status_data.get("error") or log_excerpt or "analysis-core exited with a non-zero status"
+    status_data["error_log_path"] = ANALYSIS_LOG_FILENAME
+    status_data["error_log_excerpt"] = log_excerpt
+
+    status_file.parent.mkdir(parents=True, exist_ok=True)
+    with open(status_file, "w", encoding="utf-8") as f:
+        json.dump(status_data, f, indent=2, ensure_ascii=False)
+
+
+def _monitor_process(process: subprocess.Popen, slug: str, log_file: Any | None = None) -> None:
     """
     サブプロセスの実行を監視し、完了時にステータスを更新する
 
@@ -135,51 +187,65 @@ def _monitor_process(process: subprocess.Popen, slug: str) -> None:
         process: 監視対象のサブプロセス
         slug: レポートのスラッグ
     """
-    retcode = process.wait()
-    if retcode == 0:
-        # レポート生成成功時、ステータスを更新
-        try:
-            status_file = settings.REPORT_DIR / slug / "hierarchical_status.json"
-            if status_file.exists():
-                with open(status_file) as f:
-                    status_data = json.load(f)
-                    total_token_usage = status_data.get("total_token_usage", 0)
-                    token_usage_input = status_data.get("token_usage_input", 0)
-                    token_usage_output = status_data.get("token_usage_output", 0)
+    try:
+        retcode = process.wait()
+        if retcode == 0:
+            # レポート生成成功時、ステータスを更新
+            try:
+                status_file = settings.REPORT_DIR / slug / "hierarchical_status.json"
+                if status_file.exists():
+                    with open(status_file, encoding="utf-8") as f:
+                        status_data = json.load(f)
+                        total_token_usage = status_data.get("total_token_usage", 0)
+                        token_usage_input = status_data.get("token_usage_input", 0)
+                        token_usage_output = status_data.get("token_usage_output", 0)
 
-                    config_file = settings.CONFIG_DIR / f"{slug}.json"
-                    provider = None
-                    model = None
-                    if config_file.exists():
-                        with open(config_file) as f:
-                            config_data = json.load(f)
-                            provider = config_data.get("provider")
-                            model = config_data.get("model")
+                        config_file = settings.CONFIG_DIR / f"{slug}.json"
+                        provider = None
+                        model = None
+                        if config_file.exists():
+                            with open(config_file, encoding="utf-8") as f:
+                                config_data = json.load(f)
+                                provider = config_data.get("provider")
+                                model = config_data.get("model")
 
-                    logger.info(
-                        f"Found token usage in status file for {slug}: total={total_token_usage}, input={token_usage_input}, output={token_usage_output}, provider={provider}, model={model}"
-                    )
-                    update_token_usage(
-                        slug, total_token_usage, token_usage_input, token_usage_output, provider or None, model or None
-                    )
-        except Exception as e:
-            logger.error(f"Error updating token usage for {slug}: {e}")
+                        logger.info(
+                            f"Found token usage in status file for {slug}: total={total_token_usage}, input={token_usage_input}, output={token_usage_output}, provider={provider}, model={model}"
+                        )
+                        update_token_usage(
+                            slug, total_token_usage, token_usage_input, token_usage_output, provider or None, model or None
+                        )
+            except Exception as e:
+                logger.error(f"Error updating token usage for {slug}: {e}")
 
-        set_status(slug, "ready")
+            set_status(slug, "ready")
 
-        logger.info(f"Syncing files for {slug} to storage")
-        report_sync_service = ReportSyncService()
-        # レポートファイルをストレージに同期し、JSONファイル以外を削除
-        report_sync_service.sync_report_files_to_storage(slug)
-        # 入力ファイルをストレージに同期し、ローカルファイルを削除
-        report_sync_service.sync_input_file_to_storage(slug)
-        # 設定ファイルをストレージに同期
-        report_sync_service.sync_config_file_to_storage(slug)
-        # ステータスファイルをストレージに同期
-        report_sync_service.sync_status_file_to_storage()
+            logger.info(f"Syncing files for {slug} to storage")
+            report_sync_service = ReportSyncService()
+            # レポートファイルをストレージに同期し、JSONファイル以外を削除
+            report_sync_service.sync_report_files_to_storage(slug)
+            # 入力ファイルをストレージに同期し、ローカルファイルを削除
+            report_sync_service.sync_input_file_to_storage(slug)
+            # 設定ファイルをストレージに同期
+            report_sync_service.sync_config_file_to_storage(slug)
+            # ステータスファイルをストレージに同期
+            report_sync_service.sync_status_file_to_storage()
 
-    else:
-        set_status(slug, "error")
+        else:
+            _ensure_error_status_payload(slug)
+            set_status(slug, "error")
+    finally:
+        if log_file is not None:
+            log_file.close()
+
+
+def _launch_analysis_process(cmd: list[str], slug: str, env: dict[str, str]) -> subprocess.Popen:
+    report_dir = settings.REPORT_DIR / slug
+    report_dir.mkdir(parents=True, exist_ok=True)
+    log_file = _analysis_log_path(slug).open("a", encoding="utf-8")
+    process = subprocess.Popen(cmd, env=env, stdout=log_file, stderr=subprocess.STDOUT)
+    threading.Thread(target=_monitor_process, args=(process, slug, log_file), daemon=True).start()
+    return process
 
 
 def launch_report_generation(report_input: ReportInput, user_api_key: str | None = None) -> None:
@@ -196,8 +262,7 @@ def launch_report_generation(report_input: ReportInput, user_api_key: str | None
         if user_api_key:
             env["USER_API_KEY"] = user_api_key
 
-        process = subprocess.Popen(cmd, env=env)
-        threading.Thread(target=_monitor_process, args=(process, report_input.input), daemon=True).start()
+        _launch_analysis_process(cmd, report_input.input, env)
     except Exception as e:
         set_status(report_input.input, "error")
         logger.error(f"Error launching report generation: {e}")
@@ -215,8 +280,7 @@ def launch_report_generation_from_config(config_path: Path, slug: str, user_api_
         if user_api_key:
             env["USER_API_KEY"] = user_api_key
 
-        process = subprocess.Popen(cmd, env=env)
-        threading.Thread(target=_monitor_process, args=(process, slug), daemon=True).start()
+        _launch_analysis_process(cmd, slug, env)
     except Exception as e:
         set_status(slug, "error")
         logger.error(f"Error launching report generation from config: {e}")
@@ -235,8 +299,7 @@ def execute_aggregation(slug: str, user_api_key: str | None = None) -> bool:
         if user_api_key:
             env["USER_API_KEY"] = user_api_key
 
-        process = subprocess.Popen(cmd, env=env)
-        threading.Thread(target=_monitor_process, args=(process, slug), daemon=True).start()
+        _launch_analysis_process(cmd, slug, env)
         return True
     except Exception as e:
         logger.error(f"Error executing aggregation: {e}")

--- a/apps/api/src/services/report_launcher.py
+++ b/apps/api/src/services/report_launcher.py
@@ -152,7 +152,7 @@ def _read_log_excerpt(log_path: Path, max_chars: int = MAX_ERROR_LOG_CHARS) -> s
     return content[-max_chars:]
 
 
-def _ensure_error_status_payload(slug: str) -> None:
+def _ensure_error_status_payload(slug: str, error_override: str | None = None) -> None:
     status_file = settings.REPORT_DIR / slug / "hierarchical_status.json"
     log_path = _analysis_log_path(slug)
     log_excerpt = _read_log_excerpt(log_path)
@@ -171,7 +171,9 @@ def _ensure_error_status_payload(slug: str) -> None:
     status_data["status"] = "error"
     status_data["current_job"] = status_data.get("current_job") or "error"
     status_data["error"] = (
-        status_data.get("error") or "analysis-core exited with a non-zero status; see error_log_excerpt"
+        error_override
+        or status_data.get("error")
+        or "analysis-core exited with a non-zero status; see error_log_excerpt"
     )
     status_data["error_log_path"] = ANALYSIS_LOG_FILENAME
     status_data["error_log_excerpt"] = log_excerpt
@@ -260,6 +262,13 @@ def _launch_analysis_process(cmd: list[str], slug: str, env: dict[str, str]) -> 
     return process
 
 
+def _set_report_status_if_present(slug: str, status: str) -> None:
+    try:
+        set_status(slug, status)
+    except ValueError:
+        logger.info(f"Skip status update for {slug}: report status entry not found")
+
+
 def launch_report_generation(report_input: ReportInput, user_api_key: str | None = None) -> None:
     """
     analysis-core パッケージを subprocess で呼び出してレポート生成処理を開始する関数。
@@ -276,7 +285,8 @@ def launch_report_generation(report_input: ReportInput, user_api_key: str | None
 
         _launch_analysis_process(cmd, report_input.input, env)
     except Exception as e:
-        set_status(report_input.input, "error")
+        _ensure_error_status_payload(report_input.input, error_override=f"Failed to launch analysis-core: {e}")
+        _set_report_status_if_present(report_input.input, "error")
         logger.error(f"Error launching report generation: {e}")
         raise e
 
@@ -294,7 +304,8 @@ def launch_report_generation_from_config(config_path: Path, slug: str, user_api_
 
         _launch_analysis_process(cmd, slug, env)
     except Exception as e:
-        set_status(slug, "error")
+        _ensure_error_status_payload(slug, error_override=f"Failed to launch analysis-core: {e}")
+        _set_report_status_if_present(slug, "error")
         logger.error(f"Error launching report generation from config: {e}")
         raise e
 
@@ -314,5 +325,7 @@ def execute_aggregation(slug: str, user_api_key: str | None = None) -> bool:
         _launch_analysis_process(cmd, slug, env)
         return True
     except Exception as e:
+        _ensure_error_status_payload(slug, error_override=f"Failed to launch analysis-core: {e}")
+        _set_report_status_if_present(slug, "error")
         logger.error(f"Error executing aggregation: {e}")
         return False

--- a/apps/api/src/services/report_launcher.py
+++ b/apps/api/src/services/report_launcher.py
@@ -213,7 +213,12 @@ def _monitor_process(process: subprocess.Popen, slug: str, log_file: Any | None 
                             f"Found token usage in status file for {slug}: total={total_token_usage}, input={token_usage_input}, output={token_usage_output}, provider={provider}, model={model}"
                         )
                         update_token_usage(
-                            slug, total_token_usage, token_usage_input, token_usage_output, provider or None, model or None
+                            slug,
+                            total_token_usage,
+                            token_usage_input,
+                            token_usage_output,
+                            provider or None,
+                            model or None,
                         )
             except Exception as e:
                 logger.error(f"Error updating token usage for {slug}: {e}")

--- a/apps/api/src/services/report_launcher.py
+++ b/apps/api/src/services/report_launcher.py
@@ -170,7 +170,7 @@ def _ensure_error_status_payload(slug: str) -> None:
 
     status_data["status"] = "error"
     status_data["current_job"] = status_data.get("current_job") or "error"
-    status_data["error"] = status_data.get("error") or log_excerpt or "analysis-core exited with a non-zero status"
+    status_data["error"] = status_data.get("error") or "analysis-core exited with a non-zero status; see error_log_excerpt"
     status_data["error_log_path"] = ANALYSIS_LOG_FILENAME
     status_data["error_log_excerpt"] = log_excerpt
 
@@ -186,6 +186,7 @@ def _monitor_process(process: subprocess.Popen, slug: str, log_file: Any | None 
     Args:
         process: 監視対象のサブプロセス
         slug: レポートのスラッグ
+        log_file: subprocess の stdout/stderr を書き込んでいるログファイルハンドル。完了時にクローズされる。
     """
     try:
         retcode = process.wait()
@@ -217,8 +218,8 @@ def _monitor_process(process: subprocess.Popen, slug: str, log_file: Any | None 
                             total_token_usage,
                             token_usage_input,
                             token_usage_output,
-                            provider or None,
-                            model or None,
+                            provider,
+                            model,
                         )
             except Exception as e:
                 logger.error(f"Error updating token usage for {slug}: {e}")
@@ -247,8 +248,12 @@ def _monitor_process(process: subprocess.Popen, slug: str, log_file: Any | None 
 def _launch_analysis_process(cmd: list[str], slug: str, env: dict[str, str]) -> subprocess.Popen:
     report_dir = settings.REPORT_DIR / slug
     report_dir.mkdir(parents=True, exist_ok=True)
-    log_file = _analysis_log_path(slug).open("a", encoding="utf-8")
-    process = subprocess.Popen(cmd, env=env, stdout=log_file, stderr=subprocess.STDOUT)
+    log_file = _analysis_log_path(slug).open("w", encoding="utf-8")
+    try:
+        process = subprocess.Popen(cmd, env=env, stdout=log_file, stderr=subprocess.STDOUT)
+    except Exception:
+        log_file.close()
+        raise
     threading.Thread(target=_monitor_process, args=(process, slug, log_file), daemon=True).start()
     return process
 

--- a/apps/api/src/services/report_launcher.py
+++ b/apps/api/src/services/report_launcher.py
@@ -170,7 +170,9 @@ def _ensure_error_status_payload(slug: str) -> None:
 
     status_data["status"] = "error"
     status_data["current_job"] = status_data.get("current_job") or "error"
-    status_data["error"] = status_data.get("error") or "analysis-core exited with a non-zero status; see error_log_excerpt"
+    status_data["error"] = (
+        status_data.get("error") or "analysis-core exited with a non-zero status; see error_log_excerpt"
+    )
     status_data["error_log_path"] = ANALYSIS_LOG_FILENAME
     status_data["error_log_excerpt"] = log_excerpt
 

--- a/apps/api/tests/routers/test_get_current_step.py
+++ b/apps/api/tests/routers/test_get_current_step.py
@@ -187,6 +187,34 @@ async def test_get_current_step_with_failed_workflow_step(async_client, test_slu
                 assert data["token_usage_output"] == 198
                 assert data["provider"] == "openai"
                 assert data["model"] == "gpt-4o-mini"
+                assert data["error_message"] == "Step 'embedding' failed: boom"
+
+
+@pytest.mark.asyncio
+async def test_get_current_step_with_error_log_excerpt(async_client, test_slug, tmp_path):
+    status_data = {
+        "status": "error",
+        "current_job": "embedding",
+        "error": "Step 'embedding' failed: boom",
+        "error_log_path": "analysis.log",
+    }
+
+    report_dir = tmp_path / "reports"
+    log_dir = report_dir / test_slug
+    log_dir.mkdir(parents=True)
+    (log_dir / "hierarchical_status.json").write_text(json.dumps(status_data), encoding="utf-8")
+    (log_dir / "analysis.log").write_text("trace line 1\ntrace line 2", encoding="utf-8")
+
+    mock_status_file = MagicMock(spec=Path)
+    mock_status_file.exists.return_value = True
+
+    with patch("src.routers.admin_report.settings") as mock_settings:
+        mock_settings.REPORT_DIR = report_dir
+        response = await async_client.get(f"/admin/reports/{test_slug}/status/step-json")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["error_log_path"] == "analysis.log"
+        assert data["error_log_excerpt"] == "trace line 1\ntrace line 2"
 
 
 @pytest.mark.asyncio
@@ -221,3 +249,4 @@ async def test_get_current_step_exception(async_client, test_slug):
         assert data["token_usage"] == 0
         assert data["token_usage_input"] == 0
         assert data["token_usage_output"] == 0
+        assert data["error_message"] is None

--- a/apps/api/tests/routers/test_get_current_step.py
+++ b/apps/api/tests/routers/test_get_current_step.py
@@ -205,9 +205,6 @@ async def test_get_current_step_with_error_log_excerpt(async_client, test_slug, 
     (log_dir / "hierarchical_status.json").write_text(json.dumps(status_data), encoding="utf-8")
     (log_dir / "analysis.log").write_text("trace line 1\ntrace line 2", encoding="utf-8")
 
-    mock_status_file = MagicMock(spec=Path)
-    mock_status_file.exists.return_value = True
-
     with patch("src.routers.admin_report.settings") as mock_settings:
         mock_settings.REPORT_DIR = report_dir
         response = await async_client.get(f"/admin/reports/{test_slug}/status/step-json")

--- a/apps/api/tests/services/test_report_launcher.py
+++ b/apps/api/tests/services/test_report_launcher.py
@@ -674,6 +674,44 @@ def test_monitor_process_preserves_existing_report_status_during_aggregation_rer
     ]
 
 
+def test_monitor_process_persists_error_log_excerpt_when_process_fails(monkeypatch, tmp_path):
+    import json
+
+    from src.services import report_launcher
+
+    slug = "demo"
+    report_dir = tmp_path / "reports"
+    config_dir = tmp_path / "configs"
+    (report_dir / slug).mkdir(parents=True)
+    config_dir.mkdir(parents=True)
+
+    log_path = report_dir / slug / report_launcher.ANALYSIS_LOG_FILENAME
+    log_path.write_text("line 1\nline 2\nRuntimeError: boom", encoding="utf-8")
+
+    monkeypatch.setattr(report_launcher.settings, "REPORT_DIR", report_dir)
+    monkeypatch.setattr(report_launcher.settings, "CONFIG_DIR", config_dir)
+
+    calls = {"statuses": []}
+
+    class DummyProcess:
+        def wait(self):
+            return 1
+
+    monkeypatch.setattr(
+        report_launcher, "set_status", lambda current_slug, status: calls["statuses"].append((current_slug, status))
+    )
+
+    report_launcher._monitor_process(DummyProcess(), slug)
+
+    status_data = json.loads((report_dir / slug / "hierarchical_status.json").read_text(encoding="utf-8"))
+    assert status_data["status"] == "error"
+    assert status_data["current_job"] == "error"
+    assert status_data["error"] == "line 1\nline 2\nRuntimeError: boom"
+    assert status_data["error_log_path"] == report_launcher.ANALYSIS_LOG_FILENAME
+    assert status_data["error_log_excerpt"] == "line 1\nline 2\nRuntimeError: boom"
+    assert calls["statuses"] == [(slug, "error")]
+
+
 def test_execute_aggregation_runs_monitor_flow_and_preserves_existing_status(monkeypatch, tmp_path):
     import json
     import subprocess

--- a/apps/api/tests/services/test_report_launcher.py
+++ b/apps/api/tests/services/test_report_launcher.py
@@ -706,7 +706,7 @@ def test_monitor_process_persists_error_log_excerpt_when_process_fails(monkeypat
     status_data = json.loads((report_dir / slug / "hierarchical_status.json").read_text(encoding="utf-8"))
     assert status_data["status"] == "error"
     assert status_data["current_job"] == "error"
-    assert status_data["error"] == "line 1\nline 2\nRuntimeError: boom"
+    assert status_data["error"] == "analysis-core exited with a non-zero status; see error_log_excerpt"
     assert status_data["error_log_path"] == report_launcher.ANALYSIS_LOG_FILENAME
     assert status_data["error_log_excerpt"] == "line 1\nline 2\nRuntimeError: boom"
     assert calls["statuses"] == [(slug, "error")]

--- a/apps/api/tests/services/test_report_launcher.py
+++ b/apps/api/tests/services/test_report_launcher.py
@@ -498,6 +498,60 @@ def test_launch_report_generation_runs_full_service_flow(monkeypatch, tmp_path):
     ]
 
 
+def test_launch_report_generation_records_launch_error_payload(monkeypatch, tmp_path):
+    import json
+
+    import pytest
+
+    from src.schemas.admin_report import Prompt, ReportInput
+    from src.services import report_launcher
+
+    slug = "launch-error"
+    report_dir = tmp_path / "reports"
+    config_dir = tmp_path / "configs"
+    input_dir = tmp_path / "inputs"
+    data_dir = tmp_path / "data"
+    report_dir.mkdir(parents=True)
+    config_dir.mkdir(parents=True)
+    input_dir.mkdir(parents=True)
+    data_dir.mkdir(parents=True)
+
+    monkeypatch.setattr(report_launcher.settings, "REPORT_DIR", report_dir)
+    monkeypatch.setattr(report_launcher.settings, "CONFIG_DIR", config_dir)
+    monkeypatch.setattr(report_launcher.settings, "INPUT_DIR", input_dir)
+
+    def raise_launch_error(*args, **kwargs):
+        raise FileNotFoundError("python not found")
+
+    monkeypatch.setattr(report_launcher, "_launch_analysis_process", raise_launch_error)
+
+    report_input = ReportInput(
+        input=slug,
+        question="q",
+        intro="i",
+        model="m",
+        provider="p",
+        is_pubcom=False,
+        is_embedded_at_local=False,
+        local_llm_address=None,
+        prompt=Prompt(extraction="", initial_labelling="", merge_labelling="", overview=""),
+        workers=1,
+        cluster=[1],
+        enable_source_link=False,
+        comments=[],
+    )
+
+    with pytest.raises(FileNotFoundError):
+        report_launcher.launch_report_generation(report_input)
+
+    status_data = json.loads((report_dir / slug / "hierarchical_status.json").read_text(encoding="utf-8"))
+    assert status_data["status"] == "error"
+    assert status_data["current_job"] == "error"
+    assert status_data["error"] == "Failed to launch analysis-core: python not found"
+    assert status_data["error_log_path"] == "analysis.log"
+    assert status_data["error_log_excerpt"] is None
+
+
 def test_monitor_process_reads_workflow_status_and_syncs_outputs(monkeypatch, tmp_path):
     import json
 
@@ -830,3 +884,34 @@ def test_execute_aggregation_runs_monitor_flow_and_preserves_existing_status(mon
         ("config", slug),
         ("status", None),
     ]
+
+
+def test_execute_aggregation_records_launch_error_payload(monkeypatch, tmp_path):
+    import json
+
+    from src.services import report_launcher
+
+    slug = "aggregation-error"
+    report_dir = tmp_path / "reports"
+    config_dir = tmp_path / "configs"
+    (report_dir / slug).mkdir(parents=True)
+    config_dir.mkdir(parents=True)
+    (config_dir / f"{slug}.json").write_text("{}", encoding="utf-8")
+
+    monkeypatch.setattr(report_launcher.settings, "REPORT_DIR", report_dir)
+    monkeypatch.setattr(report_launcher.settings, "CONFIG_DIR", config_dir)
+
+    def raise_launch_error(*args, **kwargs):
+        raise PermissionError("spawn blocked")
+
+    monkeypatch.setattr(report_launcher, "_launch_analysis_process", raise_launch_error)
+
+    result = report_launcher.execute_aggregation(slug)
+
+    assert result is False
+    status_data = json.loads((report_dir / slug / "hierarchical_status.json").read_text(encoding="utf-8"))
+    assert status_data["status"] == "error"
+    assert status_data["current_job"] == "error"
+    assert status_data["error"] == "Failed to launch analysis-core: spawn blocked"
+    assert status_data["error_log_path"] == "analysis.log"
+    assert status_data["error_log_excerpt"] is None


### PR DESCRIPTION
## 概要
- closes #716
- レポート生成失敗時に、管理画面から失敗理由と実行ログの抜粋を確認できるようにします
- analysis-core 実行ログを各レポート配下に保存し、API 経由で admin UI に表示します

## 変更内容
- `apps/api/src/services/report_launcher.py`
  - `analysis.log` を各レポート配下に保存するよう変更
  - subprocess が non-zero exit した時に `hierarchical_status.json` へ `error` / `error_log_path` / `error_log_excerpt` を補完
- `apps/api/src/routers/admin_report.py`
  - `/admin/reports/{slug}/status/step-json` が `error_message` と `error_log_excerpt` を返すよう変更
- `apps/admin/app/_components/ReportCard/ProgressSteps/*`
  - polling hook で error detail を保持
  - 進捗表示の下にエラーメッセージとログ抜粋を表示

## 確認
- `pnpm --filter @kouchou-ai/admin test -- --runInBand apps/admin/app/_components/ReportCard/ProgressSteps/useReportProgressPolling.test.ts`
- `cd apps/api && set -a && source .env.test && set +a && .venv/bin/python -m pytest tests/routers/test_get_current_step.py tests/services/test_report_launcher.py`
- `cd apps/api && uv run ruff check src/routers/admin_report.py src/services/report_launcher.py tests/routers/test_get_current_step.py tests/services/test_report_launcher.py`
- `pnpm exec biome check apps/admin/app/_components/ReportCard/ProgressSteps/ProgressSteps.tsx apps/admin/app/_components/ReportCard/ProgressSteps/useReportProgressPolling.ts apps/admin/app/_components/ReportCard/ProgressSteps/useReportProgressPolling.test.ts`

## 補足
- まずは失敗時にユーザーが状況を把握できることを優先し、Web UI ではログ全文ではなく抜粋を表示しています
- reviewer request はまだ送っていません


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced error reporting: user-facing error messages and truncated log excerpts are shown when report generation fails.
  * Improved progress UI: progress tracker displays a clearer error panel with message and log snippet when applicable.
  * Consistent failure messaging: a clearer user-facing error text is shown after retries are exhausted.

* **Tests**
  * Extended test coverage for error response fields, log excerpt handling, and error UI/display.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/digitaldemocracy2030/kouchou-ai/pull/852?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->