### PR TITLE
ユーザー入力 API キーでも接続チェックできるようにする

### DIFF
--- a/apps/admin/app/create/components/EnvironmentCheckDialog/EnvironmentCheckDialog.test.tsx
+++ b/apps/admin/app/create/components/EnvironmentCheckDialog/EnvironmentCheckDialog.test.tsx
@@ -29,10 +29,10 @@ const TestWrapper = ({ children }: { children: React.ReactNode }) => (
   <ChakraProvider value={system}>{children}</ChakraProvider>
 );
 
-const renderEnvironmentCheckDialog = (provider: Provider = "openai") =>
+const renderEnvironmentCheckDialog = (provider: Provider = "openai", userApiKey?: string) =>
   render(
     <TestWrapper>
-      <EnvironmentCheckDialog provider={provider} />
+      <EnvironmentCheckDialog provider={provider} userApiKey={userApiKey} />
     </TestWrapper>,
   );
 
@@ -90,6 +90,23 @@ describe("EnvironmentCheckDialog", () => {
     });
 
     expect(mockVerifyApiKey.mock.calls[0]?.[0]).toBe("gemini");
+  });
+
+  it("ユーザー入力APIキーがある場合、それを渡して接続チェックを呼び出す", async () => {
+    mockVerifyApiKey.mockResolvedValue({ result: null, error: false });
+    renderEnvironmentCheckDialog("openai", "user-test-key");
+
+    userEvent.click(screen.getByRole("button", { name: /API接続チェック/i }));
+
+    const checkButton = await screen.findByRole("button", { name: "チェックする" });
+    userEvent.click(checkButton);
+
+    await waitFor(() => {
+      expect(mockVerifyApiKey).toHaveBeenCalled();
+    });
+
+    expect(mockVerifyApiKey.mock.calls[0]?.[0]).toBe("openai");
+    expect(mockVerifyApiKey.mock.calls[0]?.[1]).toBe("user-test-key");
   });
 
   it("API接続が成功した場合に成功メッセージが表示される", async () => {

--- a/apps/admin/app/create/components/EnvironmentCheckDialog/EnvironmentCheckDialog.tsx
+++ b/apps/admin/app/create/components/EnvironmentCheckDialog/EnvironmentCheckDialog.tsx
@@ -22,10 +22,11 @@ import { verifyApiKey } from "./verifyApiKey";
 
 type EnvironmentCheckDialogProps = {
   provider: Provider;
+  userApiKey?: string;
 };
 
-function Dialog({ provider }: EnvironmentCheckDialogProps) {
-  const [state, action, isPending] = useActionState(verifyApiKey.bind(null, provider), {
+function Dialog({ provider, userApiKey }: EnvironmentCheckDialogProps) {
+  const [state, action, isPending] = useActionState(verifyApiKey.bind(null, provider, userApiKey), {
     result: null,
     error: false,
   });
@@ -145,7 +146,7 @@ function Dialog({ provider }: EnvironmentCheckDialogProps) {
   );
 }
 
-export function EnvironmentCheckDialog({ provider }: EnvironmentCheckDialogProps) {
+export function EnvironmentCheckDialog({ provider, userApiKey }: EnvironmentCheckDialogProps) {
   const [uuid, setUUID] = useState(() => createUUID());
 
   return (
@@ -172,7 +173,7 @@ export function EnvironmentCheckDialog({ provider }: EnvironmentCheckDialogProps
           API接続チェック <SquareArrowOutUpRight />
         </Button>
       </DialogTrigger>
-      <Dialog provider={provider} />
+      <Dialog provider={provider} userApiKey={userApiKey} />
     </DialogRoot>
   );
 }

--- a/apps/admin/app/create/components/EnvironmentCheckDialog/verifyApiKey.test.ts
+++ b/apps/admin/app/create/components/EnvironmentCheckDialog/verifyApiKey.test.ts
@@ -80,4 +80,26 @@ describe("verifyApiKey", () => {
       expect.any(Object),
     );
   });
+
+  it("ユーザー入力APIキーがある場合は x-user-api-key ヘッダーで送るべき", async () => {
+    const mockResponse = {
+      success: true,
+      message: "API key verified successfully",
+    };
+
+    (fetch as jest.Mock).mockResolvedValueOnce({
+      json: jest.fn().mockResolvedValueOnce(mockResponse),
+    });
+
+    await verifyApiKey("openai", "user-test-key");
+
+    expect(fetch).toHaveBeenCalledWith("http://localhost:8000/admin/environment/verify?provider=openai", {
+      method: "GET",
+      headers: {
+        "x-api-key": "test-api-key",
+        "x-user-api-key": "user-test-key",
+        "Content-Type": "application/json",
+      },
+    });
+  });
 });

--- a/apps/admin/app/create/components/EnvironmentCheckDialog/verifyApiKey.ts
+++ b/apps/admin/app/create/components/EnvironmentCheckDialog/verifyApiKey.ts
@@ -12,14 +12,20 @@ type VerificationResult = {
   error_detail?: string;
 };
 
-export const verifyApiKey = async (provider: string) => {
+export const verifyApiKey = async (provider: string, userApiKey?: string) => {
   try {
+    const headers: Record<string, string> = {
+      "x-api-key": process.env.NEXT_PUBLIC_ADMIN_API_KEY || "",
+      "Content-Type": "application/json",
+    };
+
+    if (userApiKey) {
+      headers["x-user-api-key"] = userApiKey;
+    }
+
     const response = await fetch(`${getApiBaseUrl()}/admin/environment/verify?provider=${provider}`, {
       method: "GET",
-      headers: {
-        "x-api-key": process.env.NEXT_PUBLIC_ADMIN_API_KEY || "",
-        "Content-Type": "application/json",
-      },
+      headers,
     });
 
     const result = (await response.json()) as VerificationResult;

--- a/apps/admin/app/create/page.tsx
+++ b/apps/admin/app/create/page.tsx
@@ -431,7 +431,10 @@ export default function Page() {
           <WarningSection />
 
           <VStack mt="11" gap="6">
-            <EnvironmentCheckDialog provider={aiSettings.provider} />
+            <EnvironmentCheckDialog
+              provider={aiSettings.provider}
+              userApiKey={aiSettings.userApiKey.trim() || undefined}
+            />
             {/* 送信ボタン */}
             <HStack gap="4">
               <Button variant="outline" size={"2xl"} w={"140px"} asChild>

--- a/apps/admin/app/reuse/[slug]/page.tsx
+++ b/apps/admin/app/reuse/[slug]/page.tsx
@@ -1,18 +1,18 @@
 "use client";
 
-import { Header } from "@/components/Header";
-import { toaster } from "@/components/ui/toaster";
-import { Box, Button, Field, HStack, Heading, Input, Presence, Text, VStack, useDisclosure } from "@chakra-ui/react";
-import { useRouter } from "next/navigation";
-import { type ChangeEvent, useEffect, useMemo, useState } from "react";
-import { ClusterSettingsSection } from "@/app/create/components/ClusterSettingsSection";
+import { duplicateReport } from "@/app/_components/ReportCard/DuplicateReportDialog/actions";
 import { AISettingsSection } from "@/app/create/components/AISettingsSection";
+import { ClusterSettingsSection } from "@/app/create/components/ClusterSettingsSection";
 import { EnvironmentCheckDialog } from "@/app/create/components/EnvironmentCheckDialog/EnvironmentCheckDialog";
 import { useAISettings } from "@/app/create/hooks/useAISettings";
 import { useClusterSettings } from "@/app/create/hooks/useClusterSettings";
 import { usePromptSettings } from "@/app/create/hooks/usePromptSettings";
 import { validateReportId } from "@/app/create/utils/validation";
-import { duplicateReport } from "@/app/_components/ReportCard/DuplicateReportDialog/actions";
+import { Header } from "@/components/Header";
+import { toaster } from "@/components/ui/toaster";
+import { Box, Button, Field, HStack, Heading, Input, Presence, Text, VStack, useDisclosure } from "@chakra-ui/react";
+import { useRouter } from "next/navigation";
+import { type ChangeEvent, useEffect, useMemo, useState } from "react";
 
 type PageProps = {
   params: Promise<{
@@ -433,7 +433,10 @@ export default function Page({ params }: PageProps) {
           </Text>
 
           <VStack mt="8" gap="6">
-            <EnvironmentCheckDialog provider={aiSettings.provider} />
+            <EnvironmentCheckDialog
+              provider={aiSettings.provider}
+              userApiKey={aiSettings.userApiKey.trim() || undefined}
+            />
             <Button
               className={"gradientBg shadow"}
               size={"2xl"}

--- a/apps/api/src/routers/admin_report.py
+++ b/apps/api/src/routers/admin_report.py
@@ -484,6 +484,7 @@ async def get_models(
 
 @router.get("/admin/environment/verify")
 async def verify_api_key(
+    request: Request,
     provider: str = Query("openai"),
     api_key: str = Depends(verify_admin_api_key),
 ) -> dict:
@@ -504,11 +505,13 @@ async def verify_api_key(
             "gemini": "gemini-2.5-flash",
         }
         model = model_map.get(provider, "gpt-4o-mini")
+        user_api_key = request.headers.get("x-user-api-key")
 
         _ = request_to_chat_ai(
             messages=test_messages,
             model=model,
             provider=provider,
+            user_api_key=user_api_key or None,
         )
 
         return {

--- a/apps/api/tests/routers/test_admin_report.py
+++ b/apps/api/tests/routers/test_admin_report.py
@@ -153,6 +153,21 @@ class TestVerifyApiKey:
             assert kwargs["provider"] == "gemini"
             assert kwargs["model"] == "gemini-2.5-flash"
 
+    def test_verify_api_key_uses_user_provided_key_header(self, client):
+        with patch("broadlistening.pipeline.services.llm.request_to_chat_ai") as mock_request:
+            mock_request.return_value = ("ok", 0, 0, 0)
+
+            response = client.get(
+                "/admin/environment/verify?provider=openai",
+                headers={"x-api-key": "test-api-key", "x-user-api-key": "user-test-key"},
+            )
+            assert response.status_code == 200
+            assert response.json()["success"] is True
+
+            mock_request.assert_called_once()
+            _, kwargs = mock_request.call_args
+            assert kwargs["user_api_key"] == "user-test-key"
+
 
 class TestDownloadReportJson:
     def test_download_report_json_success(self, client, tmp_path):


### PR DESCRIPTION
## 概要
- 環境確認ダイアログの API 接続チェックでも、ユーザーが入力した API キーを使えるようにしました
- `x-user-api-key` を `/admin/environment/verify` へ渡し、backend 側で `request_to_chat_ai(..., user_api_key=...)` に接続しました
- create / reuse の両画面から同じ挙動になるように揃えました

## 背景
Issue #681 の通り、現状の API 接続チェックはサーバー側の環境変数に入っている API キーしか確認できず、画面上で入力した独自 API キーの有効性は事前確認できませんでした。

この PR では、実際のレポート生成時と同じ `x-user-api-key` 経路を環境確認ダイアログにも通し、ユーザー入力 API キーの接続チェックができるようにしています。

Closes #681

## 変更内容
- `apps/api/src/routers/admin_report.py`
  - `/admin/environment/verify` で `x-user-api-key` を受け取り、LLM verify 呼び出しへ渡す
- `apps/admin/app/create/components/EnvironmentCheckDialog/*`
  - `verifyApiKey()` が `x-user-api-key` を送れるように変更
  - `EnvironmentCheckDialog` に `userApiKey` prop を追加
- `apps/admin/app/create/page.tsx`
- `apps/admin/app/reuse/[slug]/page.tsx`
  - AI 設定で入力した API キーを接続チェックダイアログへ渡す

## 動作確認
- `pnpm --filter @kouchou-ai/admin test -- --runInBand app/create/components/EnvironmentCheckDialog/verifyApiKey.test.ts app/create/components/EnvironmentCheckDialog/EnvironmentCheckDialog.test.tsx`
- `ADMIN_API_KEY=test PUBLIC_API_KEY=test OPENAI_API_KEY=test apps/api/.venv/bin/python -m pytest apps/api/tests/routers/test_admin_report.py`
- `pnpm exec biome check apps/admin/app/create/components/EnvironmentCheckDialog/verifyApiKey.ts apps/admin/app/create/components/EnvironmentCheckDialog/EnvironmentCheckDialog.tsx apps/admin/app/create/components/EnvironmentCheckDialog/verifyApiKey.test.ts apps/admin/app/create/components/EnvironmentCheckDialog/EnvironmentCheckDialog.test.tsx apps/admin/app/create/page.tsx`

## 補足
- `apps/admin/app/reuse/[slug]/page.tsx` には今回差分と無関係の既存 `useExhaustiveDependencies` 警告があるため、この PR ではそこまでは解消していません

## CLAへの同意
- [x] CLAの内容を読み、同意しました


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom API key verification. Users can now provide their own API keys during environment verification in report creation and management workflows, enabling validation with user-specific credentials instead of relying solely on provider defaults.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/digitaldemocracy2030/kouchou-ai/pull/853?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->