### PR TITLE
API テストの重複 mock/fixture を整理する

### DIFF
--- a/apps/api/tests/routers/test_get_current_step.py
+++ b/apps/api/tests/routers/test_get_current_step.py
@@ -1,4 +1,5 @@
 import json
+from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -38,16 +39,29 @@ async def async_client(app):
         yield client
 
 
-def create_mock_path(exists: bool, read_data: str | None = None):
+def create_mock_path(exists: bool):
     """モックPathオブジェクトを作成するヘルパー"""
     mock_path = MagicMock(spec=Path)
     mock_path.exists.return_value = exists
-    if read_data is not None:
-        mock_path.__truediv__ = lambda self, other: mock_path
-        mock_open = MagicMock()
-        mock_open.__enter__ = MagicMock(return_value=MagicMock(read=lambda: read_data))
-        mock_open.__exit__ = MagicMock(return_value=False)
     return mock_path
+
+
+@contextmanager
+def mock_status_response(status_data: dict):
+    mock_status_file = create_mock_path(exists=True)
+
+    with patch("src.routers.admin_report.settings") as mock_settings:
+        mock_settings.REPORT_DIR.__truediv__ = MagicMock(return_value=MagicMock())
+        mock_settings.REPORT_DIR.__truediv__.return_value.__truediv__ = MagicMock(return_value=mock_status_file)
+        with patch(
+            "builtins.open",
+            return_value=MagicMock(
+                __enter__=MagicMock(return_value=MagicMock(read=lambda: json.dumps(status_data))),
+                __exit__=MagicMock(return_value=False),
+            ),
+        ):
+            with patch("json.load", return_value=status_data):
+                yield
 
 
 @pytest.mark.asyncio
@@ -61,28 +75,14 @@ async def test_get_current_step_with_token_usage(async_client, test_slug):
         "token_usage_output": 500,
     }
 
-    # Mock the Path operations
-    mock_status_file = MagicMock(spec=Path)
-    mock_status_file.exists.return_value = True
-
-    with patch("src.routers.admin_report.settings") as mock_settings:
-        mock_settings.REPORT_DIR.__truediv__ = MagicMock(return_value=MagicMock())
-        mock_settings.REPORT_DIR.__truediv__.return_value.__truediv__ = MagicMock(return_value=mock_status_file)
-        with patch(
-            "builtins.open",
-            return_value=MagicMock(
-                __enter__=MagicMock(return_value=MagicMock(read=lambda: json.dumps(status_data))),
-                __exit__=MagicMock(return_value=False),
-            ),
-        ):
-            with patch("json.load", return_value=status_data):
-                response = await async_client.get(f"/admin/reports/{test_slug}/status/step-json")
-                assert response.status_code == 200
-                data = response.json()
-                assert data["current_step"] == "extraction"
-                assert data["token_usage"] == 1500
-                assert data["token_usage_input"] == 1000
-                assert data["token_usage_output"] == 500
+    with mock_status_response(status_data):
+        response = await async_client.get(f"/admin/reports/{test_slug}/status/step-json")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["current_step"] == "extraction"
+        assert data["token_usage"] == 1500
+        assert data["token_usage_input"] == 1000
+        assert data["token_usage_output"] == 500
 
 
 @pytest.mark.asyncio
@@ -90,27 +90,14 @@ async def test_get_current_step_with_no_token_usage(async_client, test_slug):
     """get_current_stepエンドポイントがトークン使用量情報がない場合でも適切に動作することをテスト"""
     status_data = {"status": "in_progress", "current_job": "extraction"}
 
-    mock_status_file = MagicMock(spec=Path)
-    mock_status_file.exists.return_value = True
-
-    with patch("src.routers.admin_report.settings") as mock_settings:
-        mock_settings.REPORT_DIR.__truediv__ = MagicMock(return_value=MagicMock())
-        mock_settings.REPORT_DIR.__truediv__.return_value.__truediv__ = MagicMock(return_value=mock_status_file)
-        with patch(
-            "builtins.open",
-            return_value=MagicMock(
-                __enter__=MagicMock(return_value=MagicMock(read=lambda: json.dumps(status_data))),
-                __exit__=MagicMock(return_value=False),
-            ),
-        ):
-            with patch("json.load", return_value=status_data):
-                response = await async_client.get(f"/admin/reports/{test_slug}/status/step-json")
-                assert response.status_code == 200
-                data = response.json()
-                assert data["current_step"] == "extraction"
-                assert data["token_usage"] == 0
-                assert data["token_usage_input"] == 0
-                assert data["token_usage_output"] == 0
+    with mock_status_response(status_data):
+        response = await async_client.get(f"/admin/reports/{test_slug}/status/step-json")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["current_step"] == "extraction"
+        assert data["token_usage"] == 0
+        assert data["token_usage_input"] == 0
+        assert data["token_usage_output"] == 0
 
 
 @pytest.mark.asyncio
@@ -125,28 +112,15 @@ async def test_get_current_step_with_error(async_client, test_slug):
         "token_usage_output": 30,
     }
 
-    mock_status_file = MagicMock(spec=Path)
-    mock_status_file.exists.return_value = True
-
-    with patch("src.routers.admin_report.settings") as mock_settings:
-        mock_settings.REPORT_DIR.__truediv__ = MagicMock(return_value=MagicMock())
-        mock_settings.REPORT_DIR.__truediv__.return_value.__truediv__ = MagicMock(return_value=mock_status_file)
-        with patch(
-            "builtins.open",
-            return_value=MagicMock(
-                __enter__=MagicMock(return_value=MagicMock(read=lambda: json.dumps(status_data))),
-                __exit__=MagicMock(return_value=False),
-            ),
-        ):
-            with patch("json.load", return_value=status_data):
-                response = await async_client.get(f"/admin/reports/{test_slug}/status/step-json")
-                assert response.status_code == 200
-                data = response.json()
-                # status が error の場合、current_job も error なので "error" が返る
-                assert data["current_step"] == "error"
-                assert data["token_usage"] == 100
-                assert data["token_usage_input"] == 70
-                assert data["token_usage_output"] == 30
+    with mock_status_response(status_data):
+        response = await async_client.get(f"/admin/reports/{test_slug}/status/step-json")
+        assert response.status_code == 200
+        data = response.json()
+        # status が error の場合、current_job も error なので "error" が返る
+        assert data["current_step"] == "error"
+        assert data["token_usage"] == 100
+        assert data["token_usage_input"] == 70
+        assert data["token_usage_output"] == 30
 
 
 @pytest.mark.asyncio
@@ -163,31 +137,18 @@ async def test_get_current_step_with_failed_workflow_step(async_client, test_slu
         "model": "gpt-4o-mini",
     }
 
-    mock_status_file = MagicMock(spec=Path)
-    mock_status_file.exists.return_value = True
-
-    with patch("src.routers.admin_report.settings") as mock_settings:
-        mock_settings.REPORT_DIR.__truediv__ = MagicMock(return_value=MagicMock())
-        mock_settings.REPORT_DIR.__truediv__.return_value.__truediv__ = MagicMock(return_value=mock_status_file)
-        with patch(
-            "builtins.open",
-            return_value=MagicMock(
-                __enter__=MagicMock(return_value=MagicMock(read=lambda: json.dumps(status_data))),
-                __exit__=MagicMock(return_value=False),
-            ),
-        ):
-            with patch("json.load", return_value=status_data):
-                response = await async_client.get(f"/admin/reports/{test_slug}/status/step-json")
-                assert response.status_code == 200
-                data = response.json()
-                assert data["status"] == "error"
-                assert data["current_step"] == "embedding"
-                assert data["token_usage"] == 321
-                assert data["token_usage_input"] == 123
-                assert data["token_usage_output"] == 198
-                assert data["provider"] == "openai"
-                assert data["model"] == "gpt-4o-mini"
-                assert data["error_message"] == "Step 'embedding' failed: boom"
+    with mock_status_response(status_data):
+        response = await async_client.get(f"/admin/reports/{test_slug}/status/step-json")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "error"
+        assert data["current_step"] == "embedding"
+        assert data["token_usage"] == 321
+        assert data["token_usage_input"] == 123
+        assert data["token_usage_output"] == 198
+        assert data["provider"] == "openai"
+        assert data["model"] == "gpt-4o-mini"
+        assert data["error_message"] == "Step 'embedding' failed: boom"
 
 
 @pytest.mark.asyncio

--- a/apps/api/tests/services/test_report_launcher.py
+++ b/apps/api/tests/services/test_report_launcher.py
@@ -1,11 +1,38 @@
-def test_user_api_key_propagation_to_env(monkeypatch):
-    # user_api_keyが指定された場合、その値が環境変数USER_API_KEYにセットされてサブプロセスに渡ることを確認
-    import subprocess
-    import threading
+import subprocess
+import threading
 
-    from src.schemas.admin_report import Prompt, ReportInput
-    from src.services import report_launcher
+from src.schemas.admin_report import Prompt, ReportInput
 
+
+class DummyThread:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def start(self):
+        pass
+
+
+def make_report_input(**overrides) -> ReportInput:
+    base = {
+        "input": "dummy",
+        "question": "q",
+        "intro": "i",
+        "model": "m",
+        "provider": "p",
+        "is_pubcom": False,
+        "is_embedded_at_local": False,
+        "local_llm_address": None,
+        "prompt": Prompt(extraction="", initial_labelling="", merge_labelling="", overview=""),
+        "workers": 1,
+        "cluster": [1],
+        "enable_source_link": False,
+        "comments": [],
+    }
+    base.update(overrides)
+    return ReportInput(**base)
+
+
+def patch_subprocess_launch(monkeypatch):
     called = {}
 
     class DummyPopen:
@@ -16,30 +43,17 @@ def test_user_api_key_propagation_to_env(monkeypatch):
         def wait(self):
             return 0
 
-    class DummyThread:
-        def __init__(self, *args, **kwargs):
-            pass
-
-        def start(self):
-            pass  # Don't actually start the thread
-
     monkeypatch.setattr(subprocess, "Popen", DummyPopen)
     monkeypatch.setattr(threading, "Thread", DummyThread)
-    report_input = ReportInput(
-        input="dummy",
-        question="q",
-        intro="i",
-        model="m",
-        provider="p",
-        is_pubcom=False,
-        is_embedded_at_local=False,
-        local_llm_address=None,
-        prompt=Prompt(extraction="", initial_labelling="", merge_labelling="", overview=""),
-        workers=1,
-        cluster=[1],
-        enable_source_link=False,
-        comments=[],
-    )
+    return called
+
+
+def test_user_api_key_propagation_to_env(monkeypatch):
+    # user_api_keyが指定された場合、その値が環境変数USER_API_KEYにセットされてサブプロセスに渡ることを確認
+    from src.services import report_launcher
+
+    called = patch_subprocess_launch(monkeypatch)
+    report_input = make_report_input()
     report_launcher.launch_report_generation(report_input, user_api_key="test-key")
     assert called["env"]["USER_API_KEY"] == "test-key"
     assert called["args"][:3] == ["python", "-m", "analysis_core"]
@@ -48,46 +62,10 @@ def test_user_api_key_propagation_to_env(monkeypatch):
 
 def test_env_user_api_key_not_set_when_user_api_key_not_provided(monkeypatch):
     # user_api_keyが指定されない場合、USER_API_KEYが環境変数にセットされずサブプロセスに渡らないことを確認
-    import subprocess
-    import threading
-
-    from src.schemas.admin_report import Prompt, ReportInput
     from src.services import report_launcher
 
-    called = {}
-
-    class DummyPopen:
-        def __init__(self, *args, **kwargs):
-            called["args"] = args[0]
-            called["env"] = kwargs.get("env", {})
-
-        def wait(self):
-            return 0
-
-    class DummyThread:
-        def __init__(self, *args, **kwargs):
-            pass
-
-        def start(self):
-            pass  # Don't actually start the thread
-
-    monkeypatch.setattr(subprocess, "Popen", DummyPopen)
-    monkeypatch.setattr(threading, "Thread", DummyThread)
-    report_input = ReportInput(
-        input="dummy",
-        question="q",
-        intro="i",
-        model="m",
-        provider="p",
-        is_pubcom=False,
-        is_embedded_at_local=False,
-        local_llm_address=None,
-        prompt=Prompt(extraction="", initial_labelling="", merge_labelling="", overview=""),
-        workers=1,
-        cluster=[1],
-        enable_source_link=False,
-        comments=[],
-    )
+    called = patch_subprocess_launch(monkeypatch)
+    report_input = make_report_input()
     report_launcher.launch_report_generation(report_input)
     assert "USER_API_KEY" not in called["env"]
     assert "--without-html" in called["args"]
@@ -95,46 +73,10 @@ def test_env_user_api_key_not_set_when_user_api_key_not_provided(monkeypatch):
 
 def test_env_user_api_key_not_set_when_user_api_key_empty(monkeypatch):
     # user_api_keyが空文字列の場合、USER_API_KEYが環境変数にセットされずサブプロセスに渡らないことを確認
-    import subprocess
-    import threading
-
-    from src.schemas.admin_report import Prompt, ReportInput
     from src.services import report_launcher
 
-    called = {}
-
-    class DummyPopen:
-        def __init__(self, *args, **kwargs):
-            called["args"] = args[0]
-            called["env"] = kwargs.get("env", {})
-
-        def wait(self):
-            return 0
-
-    class DummyThread:
-        def __init__(self, *args, **kwargs):
-            pass
-
-        def start(self):
-            pass  # Don't actually start the thread
-
-    monkeypatch.setattr(subprocess, "Popen", DummyPopen)
-    monkeypatch.setattr(threading, "Thread", DummyThread)
-    report_input = ReportInput(
-        input="dummy",
-        question="q",
-        intro="i",
-        model="m",
-        provider="p",
-        is_pubcom=False,
-        is_embedded_at_local=False,
-        local_llm_address=None,
-        prompt=Prompt(extraction="", initial_labelling="", merge_labelling="", overview=""),
-        workers=1,
-        cluster=[1],
-        enable_source_link=False,
-        comments=[],
-    )
+    called = patch_subprocess_launch(monkeypatch)
+    report_input = make_report_input()
     report_launcher.launch_report_generation(report_input, user_api_key="")
     assert "USER_API_KEY" not in called["env"]
     assert "--without-html" in called["args"]
@@ -142,30 +84,9 @@ def test_env_user_api_key_not_set_when_user_api_key_empty(monkeypatch):
 
 def test_user_api_key_propagation_to_env_in_aggregation(monkeypatch):
     # user_api_keyが指定された場合、その値が環境変数USER_API_KEYにセットされてサブプロセスに渡ることを確認（集約処理）
-    import subprocess
-    import threading
-
     from src.services import report_launcher
 
-    called = {}
-
-    class DummyPopen:
-        def __init__(self, *args, **kwargs):
-            called["args"] = args[0]
-            called["env"] = kwargs.get("env", {})
-
-        def wait(self):
-            return 0
-
-    class DummyThread:
-        def __init__(self, *args, **kwargs):
-            pass
-
-        def start(self):
-            pass  # Don't actually start the thread
-
-    monkeypatch.setattr(subprocess, "Popen", DummyPopen)
-    monkeypatch.setattr(threading, "Thread", DummyThread)
+    called = patch_subprocess_launch(monkeypatch)
     result = report_launcher.execute_aggregation("slug", user_api_key="test-key")
     assert called["env"]["USER_API_KEY"] == "test-key"
     assert called["args"][-2:] == ["--only", "hierarchical_aggregation"]
@@ -174,30 +95,9 @@ def test_user_api_key_propagation_to_env_in_aggregation(monkeypatch):
 
 def test_env_user_api_key_not_set_in_aggregation_when_user_api_key_not_provided(monkeypatch):
     # user_api_keyが指定されない場合、USER_API_KEYが環境変数にセットされずサブプロセスに渡らないことを確認（集約処理）
-    import subprocess
-    import threading
-
     from src.services import report_launcher
 
-    called = {}
-
-    class DummyPopen:
-        def __init__(self, *args, **kwargs):
-            called["args"] = args[0]
-            called["env"] = kwargs.get("env", {})
-
-        def wait(self):
-            return 0
-
-    class DummyThread:
-        def __init__(self, *args, **kwargs):
-            pass
-
-        def start(self):
-            pass  # Don't actually start the thread
-
-    monkeypatch.setattr(subprocess, "Popen", DummyPopen)
-    monkeypatch.setattr(threading, "Thread", DummyThread)
+    called = patch_subprocess_launch(monkeypatch)
     result = report_launcher.execute_aggregation("slug")
     assert "USER_API_KEY" not in called["env"]
     assert called["args"][-2:] == ["--only", "hierarchical_aggregation"]
@@ -205,32 +105,11 @@ def test_env_user_api_key_not_set_in_aggregation_when_user_api_key_not_provided(
 
 
 def test_launch_report_generation_from_config_uses_shared_command(monkeypatch, tmp_path):
-    import subprocess
-    import threading
-
     from src.services import report_launcher
 
-    called = {}
+    called = patch_subprocess_launch(monkeypatch)
     config_path = tmp_path / "demo.json"
     config_path.write_text("{}", encoding="utf-8")
-
-    class DummyPopen:
-        def __init__(self, *args, **kwargs):
-            called["args"] = args[0]
-            called["env"] = kwargs.get("env", {})
-
-        def wait(self):
-            return 0
-
-    class DummyThread:
-        def __init__(self, *args, **kwargs):
-            pass
-
-        def start(self):
-            pass  # Don't actually start the thread
-
-    monkeypatch.setattr(subprocess, "Popen", DummyPopen)
-    monkeypatch.setattr(threading, "Thread", DummyThread)
 
     report_launcher.launch_report_generation_from_config(config_path, "demo")
 


### PR DESCRIPTION
## 概要
API テストで繰り返していた subprocess / status JSON のモックを共通 helper に寄せ、fixture 重複を減らします。

## 変更内容
- `test_report_launcher.py` に `make_report_input()` と `patch_subprocess_launch()` を追加
- report launcher 系テストで重複していた `DummyPopen` / `DummyThread` / `ReportInput` 構築を共通化
- `test_get_current_step.py` に `mock_status_response()` を追加
- status JSON 読み出しテストで重複していた `Path` / `open` / `json.load` モックを共通化

## 確認
- `ADMIN_API_KEY=test PUBLIC_API_KEY=test OPENAI_API_KEY=test apps/api/.venv/bin/python -m pytest apps/api/tests/services/test_report_launcher.py apps/api/tests/routers/test_get_current_step.py`
- `uv run --project apps/api ruff check apps/api/tests/services/test_report_launcher.py apps/api/tests/routers/test_get_current_step.py`

Closes #842


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test infrastructure with reusable mocking utilities to reduce code duplication and enhance test maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/digitaldemocracy2030/kouchou-ai/pull/854?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->