### PR TITLE
reuse画面の Biome warning を解消する

### DIFF
--- a/apps/admin/app/reuse/[slug]/page.tsx
+++ b/apps/admin/app/reuse/[slug]/page.tsx
@@ -12,7 +12,7 @@ import { Header } from "@/components/Header";
 import { toaster } from "@/components/ui/toaster";
 import { Box, Button, Field, HStack, Heading, Input, Presence, Text, VStack, useDisclosure } from "@chakra-ui/react";
 import { useRouter } from "next/navigation";
-import { type ChangeEvent, useEffect, useMemo, useState } from "react";
+import { type ChangeEvent, useEffect, useMemo, useRef, useState } from "react";
 
 type PageProps = {
   params: Promise<{
@@ -103,6 +103,45 @@ export default function Page({ params }: PageProps) {
   const aiSettings = useAISettings();
 
   const modelDescription = useMemo(() => aiSettings.getModelDescription(), [aiSettings]);
+  const applyConfigRef = useRef<(nextConfig: ReportConfig) => void>(() => {});
+  applyConfigRef.current = (nextConfig: ReportConfig) => {
+    setConfig(nextConfig);
+    setQuestion(nextConfig.question || "");
+    setIntro(nextConfig.intro || "");
+
+    if (nextConfig.provider) {
+      aiSettings.handleProviderChange(toSelectEvent(nextConfig.provider));
+    }
+    if (nextConfig.model) {
+      aiSettings.handleModelChange(toSelectEvent(nextConfig.model));
+    }
+    if (typeof nextConfig.extraction?.workers === "number") {
+      aiSettings.handleWorkersChange(nextConfig.extraction.workers);
+    }
+    if (typeof nextConfig.is_pubcom === "boolean") {
+      aiSettings.handlePubcomModeChange(nextConfig.is_pubcom);
+    }
+    if (typeof nextConfig.enable_source_link === "boolean") {
+      aiSettings.handleEnableSourceLinkChange(nextConfig.enable_source_link);
+    }
+    if (typeof nextConfig.is_embedded_at_local === "boolean") {
+      aiSettings.setIsEmbeddedAtLocal(nextConfig.is_embedded_at_local);
+    }
+    if (nextConfig.local_llm_address) {
+      aiSettings.setLocalLLMAddress(nextConfig.local_llm_address);
+    }
+
+    const clusterNums = nextConfig.hierarchical_clustering?.cluster_nums || [5, 50];
+    const lv1 = clusterNums[0] ?? 5;
+    const lv2 = clusterNums[1] ?? Math.max(lv1 * 2, 10);
+    clusterSettings.handleLv1Change(lv1);
+    clusterSettings.handleLv2Change(lv2);
+
+    promptSettings.setExtraction(nextConfig.extraction?.prompt || "");
+    promptSettings.setInitialLabelling(nextConfig.hierarchical_initial_labelling?.prompt || "");
+    promptSettings.setMergeLabelling(nextConfig.hierarchical_merge_labelling?.prompt || "");
+    promptSettings.setOverview(nextConfig.hierarchical_overview?.prompt || "");
+  };
 
   useEffect(() => {
     let active = true;
@@ -141,43 +180,7 @@ export default function Page({ params }: PageProps) {
         if (!nextConfig) {
           throw new Error("設定の取得に失敗しました");
         }
-
-        setConfig(nextConfig);
-        setQuestion(nextConfig.question || "");
-        setIntro(nextConfig.intro || "");
-
-        if (nextConfig.provider) {
-          aiSettings.handleProviderChange(toSelectEvent(nextConfig.provider));
-        }
-        if (nextConfig.model) {
-          aiSettings.handleModelChange(toSelectEvent(nextConfig.model));
-        }
-        if (typeof nextConfig.extraction?.workers === "number") {
-          aiSettings.handleWorkersChange(nextConfig.extraction.workers);
-        }
-        if (typeof nextConfig.is_pubcom === "boolean") {
-          aiSettings.handlePubcomModeChange(nextConfig.is_pubcom);
-        }
-        if (typeof nextConfig.enable_source_link === "boolean") {
-          aiSettings.handleEnableSourceLinkChange(nextConfig.enable_source_link);
-        }
-        if (typeof nextConfig.is_embedded_at_local === "boolean") {
-          aiSettings.setIsEmbeddedAtLocal(nextConfig.is_embedded_at_local);
-        }
-        if (nextConfig.local_llm_address) {
-          aiSettings.setLocalLLMAddress(nextConfig.local_llm_address);
-        }
-
-        const clusterNums = nextConfig.hierarchical_clustering?.cluster_nums || [5, 50];
-        const lv1 = clusterNums[0] ?? 5;
-        const lv2 = clusterNums[1] ?? Math.max(lv1 * 2, 10);
-        clusterSettings.handleLv1Change(lv1);
-        clusterSettings.handleLv2Change(lv2);
-
-        promptSettings.setExtraction(nextConfig.extraction?.prompt || "");
-        promptSettings.setInitialLabelling(nextConfig.hierarchical_initial_labelling?.prompt || "");
-        promptSettings.setMergeLabelling(nextConfig.hierarchical_merge_labelling?.prompt || "");
-        promptSettings.setOverview(nextConfig.hierarchical_overview?.prompt || "");
+        applyConfigRef.current(nextConfig);
       } catch (error) {
         if (error instanceof DOMException && error.name === "AbortError") return;
         setConfigError(error instanceof Error ? error.message : "設定の取得に失敗しました");


### PR DESCRIPTION
## 概要
`apps/admin/app/reuse/[slug]/page.tsx` の既存 Biome warning を解消します。

## 変更内容
- import 順を Biome の期待に合わせて整理
- 設定反映処理を `useEffectEvent` に切り出し
- `slug` 変更時の設定ロード effect から mutable handler 群を分離し、`useExhaustiveDependencies` warning を解消

## 確認
- `pnpm exec biome check 'apps/admin/app/reuse/[slug]/page.tsx'`
- `pnpm --filter @kouchou-ai/admin test -- --runInBand 'app/create/components/EnvironmentCheckDialog/EnvironmentCheckDialog.test.tsx'`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved configuration synchronization in the admin reuse page so loaded settings are applied consistently across the UI — including AI provider and model selections, worker and cluster-level settings, prompt fields, and source-link preferences — reducing state mismatch and improving reliability when switching or loading reuse configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/digitaldemocracy2030/kouchou-ai/pull/855?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->