### PR TITLE
legacy report_status の slug 欠落を吸収する

### DIFF
--- a/apps/api/src/services/report_status.py
+++ b/apps/api/src/services/report_status.py
@@ -26,6 +26,9 @@ def convert_old_format_status(status: dict) -> dict:
     旧形式では公開/非公開をis_publicで管理していたが、新形式ではvisibilityで管理している
     """
     for slug, report_status in status.items():
+        if "slug" not in report_status:
+            report_status["slug"] = slug
+
         if "is_public" in report_status:
             report_status["visibility"] = (
                 ReportVisibility.PUBLIC.value if report_status["is_public"] else ReportVisibility.PRIVATE.value

--- a/apps/api/tests/services/test_report_status.py
+++ b/apps/api/tests/services/test_report_status.py
@@ -6,6 +6,7 @@ from unittest.mock import mock_open, patch
 import pytest
 
 from src.schemas.report import Report, ReportStatus, ReportVisibility
+from src.services import report_status
 from src.services.report_status import add_analysis_data, convert_old_format_status
 
 
@@ -137,6 +138,23 @@ class TestReportStatus:
         # 結果を検証
         assert result == {}
 
+    def test_fill_missing_slug_from_status_key(self):
+        """slug フィールドが欠落している場合、status key から補完する"""
+        input_data = {
+            "missing-slug": {
+                "status": "ready",
+                "title": "テストタイトル",
+                "description": "テスト説明",
+                "is_pubcom": True,
+                "visibility": "public",
+                "created_at": "2025-05-13T07:56:58.405239+00:00",
+            }
+        }
+
+        result = convert_old_format_status(deepcopy(input_data))
+
+        assert result["missing-slug"]["slug"] == "missing-slug"
+
     def test_mixed_format_data(self, mixed_format_data):
         """旧形式と新形式が混在したデータのテスト"""
         # 入力データのコピーを作成して元のデータが変更されないようにする
@@ -158,6 +176,29 @@ class TestReportStatus:
         assert "visibility" in result["new-slug"]
         assert result["new-slug"]["visibility"] == original_new_visibility
         assert "is_public" not in result["new-slug"]
+
+    @patch("src.services.report_status.STATE_FILE", Path("/fake/report_status.json"))
+    def test_load_status_as_reports_fills_missing_slug(self):
+        """一覧読み出し時にも key 由来の slug 補完で ValidationError を避ける"""
+        status_data = {
+            "legacy-report": {
+                "status": "ready",
+                "title": "Legacy Report",
+                "description": "Legacy Description",
+                "is_pubcom": False,
+                "visibility": "public",
+                "created_at": "2025-05-13T07:56:58.405239+00:00",
+            }
+        }
+
+        report_status._report_status.clear()
+
+        with patch("builtins.open", mock_open(read_data=json.dumps(status_data))):
+            reports = report_status.load_status_as_reports()
+
+        assert len(reports) == 1
+        assert reports[0].slug == "legacy-report"
+        assert reports[0].status == ReportStatus.READY
 
 
 class TestAddAnalysisData:


### PR DESCRIPTION
## 概要
legacy な `report_status.json` に `slug` フィールドが無い場合でも、レポート一覧取得で落ちないようにします。

## 変更内容
- `convert_old_format_status()` で `slug` 欠落時は status key から補完
- 一覧読み出し (`load_status_as_reports`) で legacy データを読めることをテスト追加
- `is_public` → `visibility` の既存 migration 互換コードと同じ層で吸収

## 確認
- `uv run --project apps/api ruff check apps/api/src/services/report_status.py apps/api/tests/services/test_report_status.py`
- `ADMIN_API_KEY=test PUBLIC_API_KEY=test OPENAI_API_KEY=test apps/api/.venv/bin/python -m pytest apps/api/tests/services/test_report_status.py`

Closes #740


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved legacy report format conversion to ensure all required identifying information is properly populated when migrating report data from older formats.

* **Tests**
  * Added comprehensive test coverage for format conversion, including validation of identifying field handling and status assignment during legacy data transformation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/digitaldemocracy2030/kouchou-ai/pull/856?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->