### PR TITLE
散布図の source link クリックが modebar に阻害される問題を修正

### DIFF
--- a/apps/public-viewer/components/charts/ScatterChart.tsx
+++ b/apps/public-viewer/components/charts/ScatterChart.tsx
@@ -1,7 +1,7 @@
 import type { Argument, Cluster, Config } from "@/type";
 import { Box } from "@chakra-ui/react";
 import type { Annotations, Data, Layout, PlotMouseEvent } from "plotly.js";
-import { useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { ChartCore } from "./ChartCore";
 
 type Props = {
@@ -174,7 +174,7 @@ export function ScatterChart({
   const unhoverHandlerRef = useRef<((data: unknown) => void) | null>(null);
 
   /** 旧 gd からリスナーを解除する */
-  const detachHoverListeners = () => {
+  const detachHoverListeners = useCallback(() => {
     const oldGd = boundGdRef.current;
     if (!oldGd?.removeListener) return;
     if (hoverHandlerRef.current) oldGd.removeListener("plotly_hover", hoverHandlerRef.current);
@@ -182,7 +182,7 @@ export function ScatterChart({
     hoverHandlerRef.current = null;
     unhoverHandlerRef.current = null;
     boundGdRef.current = null;
-  };
+  }, []);
 
   useEffect(() => {
     return () => {
@@ -190,29 +190,14 @@ export function ScatterChart({
       if (hideTimerRef.current) clearTimeout(hideTimerRef.current);
       detachHoverListeners();
     };
-  }, []);
+  }, [detachHoverListeners]);
 
   // react-plotly.js の onUpdate は (figure, gd) で呼ばれる。
   // gd は Plotly が .on() メソッドを付与した HTMLElement。
   const onUpdate = (_figure: unknown, graphDiv?: Readonly<HTMLElement>) => {
     // Plotly単体で設定できないデザインを、onUpdateのタイミングでHTMLをオーバーライドして解決する
 
-    // アノテーションの角を丸にする
-    const bgRound = 4;
-    try {
-      for (const g of document.querySelectorAll("g.annotation")) {
-        const bg = g.querySelector("rect.bg");
-        if (bg) {
-          bg.setAttribute("rx", `${bgRound}px`);
-          bg.setAttribute("ry", `${bgRound}px`);
-        }
-      }
-    } catch (error) {
-      console.error("アノテーション要素の角丸化に失敗しました:", error);
-    }
-
-    // プロット操作用アイコンのエリアを「全画面終了」ボタンの下に移動する
-    avoidModBarCoveringShrinkButton();
+    applyScatterChartDomOverrides();
 
     // Plotly gd 要素に hover/unhover イベントを直接登録
     // graphDiv が差し替わった場合は旧リスナーを解除して再登録する
@@ -621,13 +606,43 @@ function convexHull(points: [number, number][]): [number, number][] {
   return hull;
 }
 
-function avoidModBarCoveringShrinkButton(): void {
-  const modeBarContainer = document.querySelector(".modebar-container") as HTMLElement;
-  if (!modeBarContainer) return;
-  const modeBar = modeBarContainer.children[0] as HTMLElement;
+export function applyScatterChartDomOverrides(): void {
+  // アノテーションの角を丸くする
+  const bgRound = 4;
+  try {
+    for (const g of document.querySelectorAll("g.annotation")) {
+      const bg = g.querySelector("rect.bg");
+      if (bg) {
+        bg.setAttribute("rx", `${bgRound}px`);
+        bg.setAttribute("ry", `${bgRound}px`);
+      }
+    }
+  } catch (error) {
+    console.error("アノテーション要素の角丸化に失敗しました:", error);
+  }
+
+  // hover modebar のコンテナは全体を覆うため、ボタン本体以外は pointer event を食わないようにする
+  const modeBarContainer = document.querySelector(".modebar-container") as HTMLElement | null;
+  const modeBar = modeBarContainer?.children[0] as HTMLElement | undefined;
+  if (modeBarContainer) {
+    modeBarContainer.style.pointerEvents = "none";
+  }
+  if (modeBar) {
+    modeBar.style.pointerEvents = "auto";
+  }
+
+  // プロット操作用アイコンのエリアを「全画面終了」ボタンの下に移動する
+  avoidModeBarCoveringShrinkButton(modeBarContainer, modeBar);
+}
+
+export function avoidModeBarCoveringShrinkButton(
+  modeBarContainer: HTMLElement | null,
+  modeBar?: HTMLElement | null,
+): void {
   const shrinkButton = document.getElementById("fullScreenButtons");
-  if (!modeBar || !shrinkButton) return;
-  const modeBarPos = modeBar.getBoundingClientRect();
+  const effectiveModeBar = modeBar ?? (modeBarContainer?.children[0] as HTMLElement | undefined);
+  if (!modeBarContainer || !effectiveModeBar || !shrinkButton) return;
+  const modeBarPos = effectiveModeBar.getBoundingClientRect();
   const btnPos = shrinkButton.getBoundingClientRect();
   const isCovered = !(
     btnPos.top > modeBarPos.bottom ||
@@ -638,5 +653,6 @@ function avoidModBarCoveringShrinkButton(): void {
   if (!isCovered) return;
 
   const diff = btnPos.bottom - modeBarPos.top;
-  modeBarContainer.style.top = `${Number.parseInt(modeBarContainer.style.top.slice(0, -2)) + diff + 10}px`;
+  const currentTop = Number.parseInt(modeBarContainer.style.top.slice(0, -2)) || 0;
+  modeBarContainer.style.top = `${currentTop + diff + 10}px`;
 }

--- a/apps/public-viewer/components/charts/__tests__/ScatterChart.test.ts
+++ b/apps/public-viewer/components/charts/__tests__/ScatterChart.test.ts
@@ -1,0 +1,63 @@
+import { applyScatterChartDomOverrides, avoidModeBarCoveringShrinkButton } from "../ScatterChart";
+
+describe("ScatterChart DOM helpers", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("modebar container ignores pointer events while the toolbar remains clickable", () => {
+    document.body.innerHTML = `
+      <div class="modebar-container" style="top: 0px;">
+        <div class="modebar"></div>
+      </div>
+    `;
+
+    applyScatterChartDomOverrides();
+
+    const modeBarContainer = document.querySelector(".modebar-container") as HTMLElement;
+    const modeBar = modeBarContainer.children[0] as HTMLElement;
+
+    expect(modeBarContainer.style.pointerEvents).toBe("none");
+    expect(modeBar.style.pointerEvents).toBe("auto");
+  });
+
+  it("moves the modebar below the fullscreen buttons when they overlap", () => {
+    document.body.innerHTML = `
+      <div class="modebar-container" style="top: 10px;">
+        <div class="modebar"></div>
+      </div>
+      <div id="fullScreenButtons"></div>
+    `;
+
+    const modeBarContainer = document.querySelector(".modebar-container") as HTMLElement;
+    const modeBar = modeBarContainer.children[0] as HTMLElement;
+    const shrinkButton = document.getElementById("fullScreenButtons") as HTMLElement;
+
+    modeBar.getBoundingClientRect = jest.fn(() => ({
+      top: 0,
+      right: 120,
+      bottom: 20,
+      left: 0,
+      width: 120,
+      height: 20,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    }));
+    shrinkButton.getBoundingClientRect = jest.fn(() => ({
+      top: 5,
+      right: 100,
+      bottom: 25,
+      left: 20,
+      width: 80,
+      height: 20,
+      x: 20,
+      y: 5,
+      toJSON: () => {},
+    }));
+
+    avoidModeBarCoveringShrinkButton(modeBarContainer, modeBar);
+
+    expect(modeBarContainer.style.top).toBe("45px");
+  });
+});


### PR DESCRIPTION
## 概要
散布図で source link を有効にしている時、`displayModeBar: "hover"` の modebar overlay が点クリックを奪い、リンク先を開けない問題を修正します。

## 変更内容
- `ScatterChart` の DOM override を helper 化
- hover modebar の container を `pointer-events: none`、実 toolbar のみ `pointer-events: auto` にして、点クリックを妨げないように変更
- fullscreen ボタンとの重なり回避ロジックは維持
- ScatterChart の DOM helper に対する unit test を追加

## 確認
- `pnpm --filter @kouchou-ai/public-viewer test -- --runInBand components/charts/__tests__/ScatterChart.test.ts`
- `pnpm exec biome check apps/public-viewer/components/charts/ScatterChart.tsx apps/public-viewer/components/charts/__tests__/ScatterChart.test.ts`

Closes #710


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed scatter chart modebar positioning to prevent overlap with adjacent UI elements.
  * Improved event listener cleanup and management for better reliability.

* **Tests**
  * Added comprehensive test coverage for scatter chart DOM interactions and positioning adjustments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/digitaldemocracy2030/kouchou-ai/pull/857?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->