### PR TITLE
[codex] Windows setup の文字化け耐性を改善

### DIFF
--- a/setup_win.bat
+++ b/setup_win.bat
@@ -1,74 +1,59 @@
 @echo off
 chcp 65001 >nul
+setlocal
 
 echo Kouchou-AI Setup Tool
 echo =====================
 
 REM Check if Docker Desktop is running
-docker info > nul 2>&1
-if %errorlevel% neq 0 (
+docker info >nul 2>&1
+if errorlevel 1 (
   echo Docker Desktop is not running.
   echo Please start Docker Desktop and try again.
-  echo 注意: Dockerのインストール直後は再起動が必要な場合があります。
+  echo Note: You may need to restart Windows after installing Docker Desktop.
   pause
-  exit /b
+  exit /b 1
 )
 
-REM Enter OpenAI API key
-echo OpenAI APIキーを入力してください。（省略可）
+REM Enter API keys
+echo Enter your OpenAI API key. This is optional.
 echo(
-echo 注意: Ctrl+Vが機能しない場合は、右クリックして「貼り付け」を選択してください。
+echo If Ctrl+V does not paste, right-click this window and choose Paste.
 echo(
 set /p OPENAI_API_KEY=Enter your OpenAI API key:
 
-REM Enter Gemini API key
 echo(
-echo Gemini APIキーを入力してください。（省略可）
+echo Enter your Gemini API key. This is optional.
 echo(
-echo 注意: Ctrl+Vが機能しない場合は、右クリックして「貼り付け」を選択してください。
+echo If Ctrl+V does not paste, right-click this window and choose Paste.
 echo(
 set /p GEMINI_API_KEY=Enter your Gemini API key:
 
-REM Validate OpenAI API key format
+REM Validate API key formats
 echo(
-echo APIキーの形式を確認しています...
+echo Checking API key formats...
 set "HAS_ERROR="
 
-REM OpenAI: 入力があるときだけチェック
-echo(
 if defined OPENAI_API_KEY (
-  echo %OPENAI_API_KEY% | findstr /R /C:"^sk-" >nul
-  if errorlevel 1 (
-    echo 警告: 入力されたOpenAI APIキーの形式が正しくない可能性があります。通常は「sk-」で始まります。
+  if /I not "%OPENAI_API_KEY:~0,3%"=="sk-" (
+    echo Warning: The OpenAI API key may be invalid. It usually starts with "sk-".
     set "HAS_ERROR=1"
   )
 )
 
-REM Gemini: 入力があるときだけチェック
-echo(
 if defined GEMINI_API_KEY (
-  echo %GEMINI_API_KEY% | findstr /R /C:"^AIza" >nul
-  if errorlevel 1 (
-    echo 警告: 入力されたGemini APIキーの形式が正しくない可能性があります。通常は「AIza」で始まります。
+  if /I not "%GEMINI_API_KEY:~0,4%"=="AIza" (
+    echo Warning: The Gemini API key may be invalid. It usually starts with "AIza".
     set "HAS_ERROR=1"
   )
 )
 
-REM どちらか不正なら継続確認
 if defined HAS_ERROR (
-  choice /c YN /n /m "続行しますか？ (Y/N): "
+  choice /c YN /n /m "Continue? (Y/N): "
   if errorlevel 2 (
-    echo セットアップを中止します。正しいAPIキーを用意してから再度実行してください。
+    echo Setup canceled. Please prepare the correct API keys and run this file again.
     pause
-    exit /b
-  )
-)
-
-REM Validate Gemini API key format
-if not "%GEMINI_API_KEY%"=="" (
-  echo %GEMINI_API_KEY% | findstr /r "^AIza" > nul
-  if %errorlevel% neq 0 (
-    echo 警告: 入力されたGemini APIキーの形式が正しくない可能性があります。（通常は「AIza」で始まります）
+    exit /b 1
   )
 )
 


### PR DESCRIPTION
## 概要

- `setup_win.bat` のユーザー向け実行メッセージを ASCII のみにして、Windows のコードページ差異で文字化けしてもセットアップが中断しないようにしました
- API キー形式チェックの重複を削除し、`findstr` パイプではなく prefix 比較に整理しました
- Docker 未起動/未インストール時は明示的に exit code 1 で終了するようにしました

## 背景

Fixes #731

Issue #731 では、Windows で配布 zip の `setup_win.bat` を実行した際に日本語メッセージが mojibake し、一部がコマンドとして解釈されてセットアップが止まる症状が報告されています。バッチファイル本体は利用者の端末コードページに左右されやすいため、実行に必要な案内は ASCII に寄せました。詳しい日本語手順は既存の `docs/getting-started/windows-setup.md` に残っています。

## 確認

- `cmd /c "echo. | setup_win.bat"` を Docker CLI が無い環境で実行し、Docker Desktop 未起動/未インストール時の停止パスが英語メッセージで表示されることを確認
- `rg -n "[^\x00-\x7F]" setup_win.bat` でバッチファイル内に非 ASCII 文字が残っていないことを確認
- `git diff --check` 実行済み（CRLF 変換 warning のみ）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved Windows setup script robustness with enhanced Docker environment validation
  * Simplified API key input handling with clearer validation for OpenAI and Gemini keys
  * Enhanced error messaging throughout the setup process with improved user guidance and confirmation prompts

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/digitaldemocracy2030/kouchou-ai/pull/858?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->