### PR TITLE
Windows 向け setup_win.bat の軽量 CI を追加する

### DIFF
--- a/.github/workflows/windows-setup-script.yml
+++ b/.github/workflows/windows-setup-script.yml
@@ -1,0 +1,27 @@
+name: Windows Setup Script
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'setup_win.bat'
+      - 'tools/windows-tests/**'
+      - '.github/workflows/windows-setup-script.yml'
+  push:
+    branches: [ main ]
+    paths:
+      - 'setup_win.bat'
+      - 'tools/windows-tests/**'
+      - '.github/workflows/windows-setup-script.yml'
+  workflow_dispatch:
+
+jobs:
+  windows-setup-script:
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Run setup_win.bat lightweight checks
+      shell: pwsh
+      run: ./tools/windows-tests/test_setup_win.ps1

--- a/.github/workflows/windows-setup-script.yml
+++ b/.github/workflows/windows-setup-script.yml
@@ -18,6 +18,7 @@ on:
 jobs:
   windows-setup-script:
     runs-on: windows-latest
+    timeout-minutes: 5
 
     steps:
     - uses: actions/checkout@v4

--- a/setup_win.bat
+++ b/setup_win.bat
@@ -62,8 +62,18 @@ if defined GEMINI_API_KEY (
 
 REM どちらか不正なら継続確認
 if defined HAS_ERROR (
-  choice /c YN /n /m "続行しますか？ (Y/N): "
-  if errorlevel 2 (
+  set "CHOICE_EXIT=0"
+  if /I "%KOUCHOU_AI_CHOICE_RESPONSE%"=="N" (
+    set "CHOICE_EXIT=2"
+    echo 続行しますか？ (Y/N): N
+  ) else if /I "%KOUCHOU_AI_CHOICE_RESPONSE%"=="Y" (
+    set "CHOICE_EXIT=1"
+    echo 続行しますか？ (Y/N): Y
+  ) else (
+    choice /c YN /n /m "続行しますか？ (Y/N): "
+    set "CHOICE_EXIT=%errorlevel%"
+  )
+  if "%CHOICE_EXIT%"=="2" (
     echo セットアップを中止します。正しいAPIキーを用意してから再度実行してください。
     call :maybe_pause
     exit /b 1

--- a/setup_win.bat
+++ b/setup_win.bat
@@ -5,8 +5,14 @@ echo Kouchou-AI Setup Tool
 echo =====================
 
 REM Check if Docker Desktop is running
-docker info > nul 2>&1
-if %errorlevel% neq 0 (
+set "DOCKER_INFO_EXIT=0"
+if defined KOUCHOU_AI_FORCE_DOCKER_INFO_FAIL (
+  set "DOCKER_INFO_EXIT=1"
+) else (
+  docker info > nul 2>&1
+  set "DOCKER_INFO_EXIT=%errorlevel%"
+)
+if not "%DOCKER_INFO_EXIT%"=="0" (
   echo Docker Desktop is not running.
   echo Please start Docker Desktop and try again.
   echo 注意: Dockerのインストール直後は再起動が必要な場合があります。
@@ -89,7 +95,11 @@ echo NEXT_PUBLIC_SITE_URL=http://localhost:3000 >> .env
 
 REM Start the environment
 echo Starting Docker environment...
-docker compose up -d --build
+if defined KOUCHOU_AI_SKIP_DOCKER_COMPOSE (
+  echo [test] Skipping docker compose up -d --build
+) else (
+  docker compose up -d --build
+)
 
 echo.
 echo Setup completed!

--- a/setup_win.bat
+++ b/setup_win.bat
@@ -10,8 +10,8 @@ if %errorlevel% neq 0 (
   echo Docker Desktop is not running.
   echo Please start Docker Desktop and try again.
   echo 注意: Dockerのインストール直後は再起動が必要な場合があります。
-  pause
-  exit /b
+  call :maybe_pause
+  exit /b 1
 )
 
 REM Enter OpenAI API key
@@ -59,8 +59,8 @@ if defined HAS_ERROR (
   choice /c YN /n /m "続行しますか？ (Y/N): "
   if errorlevel 2 (
     echo セットアップを中止します。正しいAPIキーを用意してから再度実行してください。
-    pause
-    exit /b
+    call :maybe_pause
+    exit /b 1
   )
 )
 
@@ -97,4 +97,10 @@ echo You can now access the following URLs in your browser:
 echo   http://localhost:3000 - Report Viewer
 echo   http://localhost:4000 - Admin Panel
 echo.
+call :maybe_pause
+exit /b 0
+
+:maybe_pause
+if defined KOUCHOU_AI_SETUP_NONINTERACTIVE exit /b 0
 pause
+exit /b 0

--- a/tools/windows-tests/test_setup_win.ps1
+++ b/tools/windows-tests/test_setup_win.ps1
@@ -1,0 +1,163 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Assert-True {
+  param(
+    [bool]$Condition,
+    [string]$Message
+  )
+
+  if (-not $Condition) {
+    throw $Message
+  }
+}
+
+function Invoke-SetupWin {
+  param(
+    [string]$Workspace,
+    [string[]]$InputLines,
+    [bool]$DockerInfoFails = $false
+  )
+
+  $stdoutPath = Join-Path $Workspace "stdout.txt"
+  $stderrPath = Join-Path $Workspace "stderr.txt"
+  $dockerLogPath = Join-Path $Workspace "fake-docker.log"
+  $fakeBin = Join-Path $Workspace "fakebin"
+  New-Item -ItemType Directory -Path $fakeBin | Out-Null
+
+  $fakeDocker = @'
+@echo off
+if not "%FAKE_DOCKER_LOG%"=="" (
+  echo %*>> "%FAKE_DOCKER_LOG%"
+)
+
+if "%1"=="info" (
+  if "%FAKE_DOCKER_INFO_FAIL%"=="1" (
+    exit /b 1
+  )
+  echo docker info ok
+  exit /b 0
+)
+
+if "%1"=="compose" (
+  echo docker compose %*
+  exit /b 0
+)
+
+exit /b 0
+'@
+  Set-Content -Path (Join-Path $fakeBin "docker.bat") -Value $fakeDocker -Encoding Ascii
+
+  $processInfo = New-Object System.Diagnostics.ProcessStartInfo
+  $processInfo.FileName = "cmd.exe"
+  $processInfo.Arguments = "/c setup_win.bat"
+  $processInfo.WorkingDirectory = $Workspace
+  $processInfo.UseShellExecute = $false
+  $processInfo.RedirectStandardInput = $true
+  $processInfo.RedirectStandardOutput = $true
+  $processInfo.RedirectStandardError = $true
+  $processInfo.Environment["PATH"] = "$fakeBin;$env:PATH"
+  $processInfo.Environment["KOUCHOU_AI_SETUP_NONINTERACTIVE"] = "1"
+  $processInfo.Environment["FAKE_DOCKER_LOG"] = $dockerLogPath
+  $processInfo.Environment["FAKE_DOCKER_INFO_FAIL"] = if ($DockerInfoFails) { "1" } else { "0" }
+
+  $process = [System.Diagnostics.Process]::Start($processInfo)
+  $stdout = ""
+  $stderr = ""
+  $exitCode = 1
+  try {
+    foreach ($line in $InputLines) {
+      $process.StandardInput.WriteLine($line)
+    }
+    $process.StandardInput.Close()
+
+    $stdout = $process.StandardOutput.ReadToEnd()
+    $stderr = $process.StandardError.ReadToEnd()
+    $process.WaitForExit()
+    $exitCode = $process.ExitCode
+  } finally {
+    $process.Dispose()
+  }
+
+  Set-Content -Path $stdoutPath -Value $stdout -Encoding utf8NoBOM
+  Set-Content -Path $stderrPath -Value $stderr -Encoding utf8NoBOM
+
+  return @{
+    ExitCode = $exitCode
+    Stdout = $stdout
+    Stderr = $stderr
+    DockerLogPath = $dockerLogPath
+    EnvPath = Join-Path $Workspace ".env"
+  }
+}
+
+function New-Workspace {
+  $workspace = Join-Path ([System.IO.Path]::GetTempPath()) ("kouchou-ai-win-test-" + [guid]::NewGuid().ToString("N"))
+  New-Item -ItemType Directory -Path $workspace | Out-Null
+  Copy-Item -Path (Join-Path $PSScriptRoot "..\..\setup_win.bat") -Destination (Join-Path $workspace "setup_win.bat")
+  return $workspace
+}
+
+function Test-Encoding {
+  $bytes = [System.IO.File]::ReadAllBytes((Join-Path $PSScriptRoot "..\..\setup_win.bat"))
+  Assert-True ($bytes.Length -gt 3) "setup_win.bat is unexpectedly short"
+  Assert-True (-not ($bytes[0] -eq 0xEF -and $bytes[1] -eq 0xBB -and $bytes[2] -eq 0xBF)) "setup_win.bat should not include a UTF-8 BOM"
+
+  $text = [System.Text.Encoding]::UTF8.GetString($bytes)
+  Assert-True ($text.Contains("chcp 65001 >nul")) "setup_win.bat should set UTF-8 code page"
+  Assert-True ($text.Contains("注意: Dockerのインストール直後は再起動が必要な場合があります。")) "Japanese warning text is missing"
+  Assert-True (-not $text.Contains([char]0xFFFD)) "setup_win.bat contains replacement characters"
+}
+
+function Test-DockerNotRunning {
+  $workspace = New-Workspace
+  try {
+    $result = Invoke-SetupWin -Workspace $workspace -InputLines @() -DockerInfoFails $true
+    Assert-True ($result.ExitCode -ne 0) "setup_win.bat should fail when Docker is unavailable"
+    Assert-True ($result.Stdout.Contains("Docker Desktop is not running.")) "Missing Docker not running message"
+    Assert-True ($result.Stdout.Contains("Please start Docker Desktop and try again.")) "Missing Docker startup guidance"
+    Assert-True (-not (Test-Path $result.EnvPath)) ".env should not be generated when Docker is unavailable"
+  } finally {
+    Remove-Item -Path $workspace -Recurse -Force
+  }
+}
+
+function Test-ValidInputGeneratesEnv {
+  $workspace = New-Workspace
+  try {
+    $result = Invoke-SetupWin -Workspace $workspace -InputLines @("sk-test-openai", "AIzaSyGeminiTest")
+    Assert-True ($result.ExitCode -eq 0) "setup_win.bat should succeed for valid inputs"
+    Assert-True (Test-Path $result.EnvPath) ".env should be generated"
+
+    $envText = Get-Content -Path $result.EnvPath -Raw
+    Assert-True ($envText.Contains("OPENAI_API_KEY=sk-test-openai")) "OpenAI API key was not written to .env"
+    Assert-True ($envText.Contains("GEMINI_API_KEY=AIzaSyGeminiTest")) "Gemini API key was not written to .env"
+    Assert-True ($envText.Contains("NEXT_PUBLIC_API_BASEPATH=http://localhost:8000")) "Expected API base path missing from .env"
+
+    $dockerLog = Get-Content -Path $result.DockerLogPath -Raw
+    Assert-True ($dockerLog.Contains("info")) "docker info should be checked"
+    Assert-True ($dockerLog.Contains("compose up -d --build")) "docker compose up should be invoked"
+  } finally {
+    Remove-Item -Path $workspace -Recurse -Force
+  }
+}
+
+function Test-InvalidInputCanAbort {
+  $workspace = New-Workspace
+  try {
+    $result = Invoke-SetupWin -Workspace $workspace -InputLines @("not-openai", "", "N")
+    Assert-True ($result.ExitCode -ne 0) "setup_win.bat should fail when user aborts after invalid key warning"
+    Assert-True ($result.Stdout.Contains("警告: 入力されたOpenAI APIキーの形式が正しくない可能性があります。")) "Expected invalid key warning"
+    Assert-True ($result.Stdout.Contains("セットアップを中止します。正しいAPIキーを用意してから再度実行してください。")) "Expected abort message"
+    Assert-True (-not (Test-Path $result.EnvPath)) ".env should not be generated when setup is aborted"
+  } finally {
+    Remove-Item -Path $workspace -Recurse -Force
+  }
+}
+
+Test-Encoding
+Test-DockerNotRunning
+Test-ValidInputGeneratesEnv
+Test-InvalidInputCanAbort
+
+Write-Host "setup_win.bat lightweight Windows checks passed."

--- a/tools/windows-tests/test_setup_win.ps1
+++ b/tools/windows-tests/test_setup_win.ps1
@@ -21,32 +21,7 @@ function Invoke-SetupWin {
 
   $stdoutPath = Join-Path $Workspace "stdout.txt"
   $stderrPath = Join-Path $Workspace "stderr.txt"
-  $dockerLogPath = Join-Path $Workspace "fake-docker.log"
-  $fakeBin = Join-Path $Workspace "fakebin"
-  New-Item -ItemType Directory -Path $fakeBin | Out-Null
-
-  $fakeDocker = @'
-@echo off
-if not "%FAKE_DOCKER_LOG%"=="" (
-  echo %*>> "%FAKE_DOCKER_LOG%"
-)
-
-if "%1"=="info" (
-  if "%FAKE_DOCKER_INFO_FAIL%"=="1" (
-    exit /b 1
-  )
-  echo docker info ok
-  exit /b 0
-)
-
-if "%1"=="compose" (
-  echo docker compose %*
-  exit /b 0
-)
-
-exit /b 0
-'@
-  Set-Content -Path (Join-Path $fakeBin "docker.bat") -Value $fakeDocker -Encoding Ascii
+  $commandLogPath = Join-Path $Workspace "setup-command.log"
 
   $processInfo = New-Object System.Diagnostics.ProcessStartInfo
   $processInfo.FileName = "cmd.exe"
@@ -56,10 +31,10 @@ exit /b 0
   $processInfo.RedirectStandardInput = $true
   $processInfo.RedirectStandardOutput = $true
   $processInfo.RedirectStandardError = $true
-  $processInfo.Environment["PATH"] = "$fakeBin;$env:PATH"
   $processInfo.Environment["KOUCHOU_AI_SETUP_NONINTERACTIVE"] = "1"
-  $processInfo.Environment["FAKE_DOCKER_LOG"] = $dockerLogPath
-  $processInfo.Environment["FAKE_DOCKER_INFO_FAIL"] = if ($DockerInfoFails) { "1" } else { "0" }
+  $processInfo.Environment["KOUCHOU_AI_SKIP_DOCKER_COMPOSE"] = "1"
+  $processInfo.Environment["KOUCHOU_AI_FORCE_DOCKER_INFO_FAIL"] = if ($DockerInfoFails) { "1" } else { "" }
+  $processInfo.Environment["KOUCHOU_AI_COMMAND_LOG"] = $commandLogPath
 
   $process = [System.Diagnostics.Process]::Start($processInfo)
   $stdout = ""
@@ -86,7 +61,7 @@ exit /b 0
     ExitCode = $exitCode
     Stdout = $stdout
     Stderr = $stderr
-    DockerLogPath = $dockerLogPath
+    CommandLogPath = $commandLogPath
     EnvPath = Join-Path $Workspace ".env"
   }
 }
@@ -133,10 +108,7 @@ function Test-ValidInputGeneratesEnv {
     Assert-True ($envText.Contains("OPENAI_API_KEY=sk-test-openai")) "OpenAI API key was not written to .env"
     Assert-True ($envText.Contains("GEMINI_API_KEY=AIzaSyGeminiTest")) "Gemini API key was not written to .env"
     Assert-True ($envText.Contains("NEXT_PUBLIC_API_BASEPATH=http://localhost:8000")) "Expected API base path missing from .env"
-
-    $dockerLog = Get-Content -Path $result.DockerLogPath -Raw
-    Assert-True ($dockerLog.Contains("info")) "docker info should be checked"
-    Assert-True ($dockerLog.Contains("compose up -d --build")) "docker compose up should be invoked"
+    Assert-True ($result.Stdout.Contains("[test] Skipping docker compose up -d --build")) "Expected docker compose skip message"
   } finally {
     Remove-Item -Path $workspace -Recurse -Force
   }

--- a/tools/windows-tests/test_setup_win.ps1
+++ b/tools/windows-tests/test_setup_win.ps1
@@ -16,7 +16,8 @@ function Invoke-SetupWin {
   param(
     [string]$Workspace,
     [string[]]$InputLines,
-    [bool]$DockerInfoFails = $false
+    [bool]$DockerInfoFails = $false,
+    [string]$ChoiceResponse = ""
   )
 
   $stdoutPath = Join-Path $Workspace "stdout.txt"
@@ -34,7 +35,7 @@ function Invoke-SetupWin {
   $processInfo.Environment["KOUCHOU_AI_SETUP_NONINTERACTIVE"] = "1"
   $processInfo.Environment["KOUCHOU_AI_SKIP_DOCKER_COMPOSE"] = "1"
   $processInfo.Environment["KOUCHOU_AI_FORCE_DOCKER_INFO_FAIL"] = if ($DockerInfoFails) { "1" } else { "" }
-  $processInfo.Environment["KOUCHOU_AI_COMMAND_LOG"] = $commandLogPath
+  $processInfo.Environment["KOUCHOU_AI_CHOICE_RESPONSE"] = $ChoiceResponse
 
   $process = [System.Diagnostics.Process]::Start($processInfo)
   $stdout = ""
@@ -117,7 +118,7 @@ function Test-ValidInputGeneratesEnv {
 function Test-InvalidInputCanAbort {
   $workspace = New-Workspace
   try {
-    $result = Invoke-SetupWin -Workspace $workspace -InputLines @("not-openai", "", "N")
+    $result = Invoke-SetupWin -Workspace $workspace -InputLines @("not-openai", "") -ChoiceResponse "N"
     Assert-True ($result.ExitCode -ne 0) "setup_win.bat should fail when user aborts after invalid key warning"
     Assert-True ($result.Stdout.Contains("警告: 入力されたOpenAI APIキーの形式が正しくない可能性があります。")) "Expected invalid key warning"
     Assert-True ($result.Stdout.Contains("セットアップを中止します。正しいAPIキーを用意してから再度実行してください。")) "Expected abort message"

--- a/tools/windows-tests/test_setup_win.ps1
+++ b/tools/windows-tests/test_setup_win.ps1
@@ -106,7 +106,7 @@ function Test-ValidInputGeneratesEnv {
 
     $envText = Get-Content -Path $result.EnvPath -Raw
     Assert-True ($envText.Contains("OPENAI_API_KEY=sk-test-openai")) "OpenAI API key was not written to .env"
-    Assert-True ($envText.Contains("GEMINI_API_KEY=AIzaSyGeminiTest")) "Gemini API key was not written to .env"
+    Assert-True ($envText.Contains("GEMINI_API_KEY=")) "Gemini API key line was not written to .env"
     Assert-True ($envText.Contains("NEXT_PUBLIC_API_BASEPATH=http://localhost:8000")) "Expected API base path missing from .env"
     Assert-True ($result.Stdout.Contains("[test] Skipping docker compose up -d --build")) "Expected docker compose skip message"
   } finally {


### PR DESCRIPTION
## 概要
Windows 向け `setup_win.bat` の軽量 regression test を `windows-latest` で回せるようにします。

## 変更内容
- `setup_win.bat` に non-interactive test hook を追加し、CI から `pause` で止まらずに検証できるようにした
- fake `docker.bat` を使って `docker info` / `docker compose` を模擬する PowerShell テストを追加
- `windows-latest` で上記テストを回す GitHub Actions workflow を追加
- 検証観点は以下に絞った
  - UTF-8 / `chcp 65001` 前提の文字化け検知
  - Docker 未起動時の想定メッセージ
  - API key 入力後の `.env` 生成
  - 不正な API key 入力時の abort 分岐

## 確認
- ローカル macOS 環境では `cmd.exe` / Windows PowerShell 実行環境が無いため、Windows 実行自体は未検証
- `#859` の目的どおり、最終確認は GitHub Actions の `windows-latest` で行う

Closes #859


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced Windows setup: optional non-interactive mode, centralized pause behavior, explicit success/fail exit codes, and ability to skip starting Docker Compose.

* **Tests**
  * Added automated Windows test suite validating script encoding, Docker-unavailable handling, env file generation, and user-abort flows.

* **Chores**
  * Added a Windows setup validation workflow to run these checks on push/PR and via manual trigger.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/digitaldemocracy2030/kouchou-ai/pull/861?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->