### PR TITLE
[codex] report_launcher の subprocess smoke と path cleanup を追加

### DIFF
--- a/apps/api/pytest.ini
+++ b/apps/api/pytest.ini
@@ -7,3 +7,4 @@ asyncio_mode = auto
 asyncio_default_fixture_loop_scope = function
 markers =
     asyncio: mark a test as an asyncio test
+    manual_smoke: manual smoke tests that launch real subprocesses and are intended for explicit local runs

--- a/apps/api/tests/manual/report_launcher_subprocess_smoke.py
+++ b/apps/api/tests/manual/report_launcher_subprocess_smoke.py
@@ -247,7 +247,7 @@ class LocalLLMServerProcess:
     def address(self) -> str:
         return f"127.0.0.1:{self.port}"
 
-    def __enter__(self) -> "LocalLLMServerProcess":
+    def __enter__(self) -> LocalLLMServerProcess:
         self._process = multiprocessing.Process(target=_serve_fake_local_llm, args=(self.port,), daemon=True)
         self._process.start()
         self._wait_until_ready()

--- a/apps/api/tests/manual/report_launcher_subprocess_smoke.py
+++ b/apps/api/tests/manual/report_launcher_subprocess_smoke.py
@@ -1,0 +1,237 @@
+"""Manual smoke tests for the API -> subprocess -> analysis-core boundary.
+
+These tests are intentionally kept out of default pytest collection by living in
+``tests/manual/`` with a non-``test_*.py`` filename.
+
+Run locally with the API virtualenv so the child ``python`` process resolves the
+API-side dependencies, while this test rewrites ``PATH`` so the child process
+uses ``packages/analysis-core/.venv/bin/python``.
+
+    cd apps/api
+    ADMIN_API_KEY=dummy PUBLIC_API_KEY=dummy OPENAI_API_KEY=dummy \
+      rye run pytest tests/manual/report_launcher_subprocess_smoke.py -q -s
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.manual_smoke
+
+
+class ImmediateThread:
+    """Run the background monitor inline so the smoke test stays deterministic."""
+
+    def __init__(self, target=None, args=(), kwargs=None, **_):
+        self.target = target
+        self.args = args
+        self.kwargs = kwargs or {}
+
+    def start(self):
+        if self.target is not None:
+            self.target(*self.args, **self.kwargs)
+
+
+class DummyReportSyncService:
+    """No-op sync service for local subprocess smoke tests."""
+
+    def sync_report_files_to_storage(self, value):
+        return value
+
+    def sync_input_file_to_storage(self, value):
+        return value
+
+    def sync_config_file_to_storage(self, value):
+        return value
+
+    def sync_status_file_to_storage(self):
+        return None
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[4]
+
+
+def _analysis_core_python() -> Path:
+    return _repo_root() / "packages" / "analysis-core" / ".venv" / "bin" / "python"
+
+
+def _prepend_analysis_core_python(monkeypatch: pytest.MonkeyPatch) -> None:
+    analysis_core_python = _analysis_core_python()
+    if not analysis_core_python.exists():
+        pytest.skip(
+            "analysis-core virtualenv is missing. Run `cd packages/analysis-core && rye sync` first."
+        )
+
+    analysis_core_bin = str(analysis_core_python.parent)
+    current_path = os.environ.get("PATH", "")
+    monkeypatch.setenv("PATH", f"{analysis_core_bin}{os.pathsep}{current_path}")
+
+
+def _ensure_analysis_core_cli_available() -> None:
+    env = os.environ.copy()
+    completed = subprocess.run(
+        ["python", "-m", "analysis_core", "--version"],
+        capture_output=True,
+        text=True,
+        cwd=_repo_root() / "apps" / "api",
+        env=env,
+    )
+    if completed.returncode != 0:
+        pytest.skip(
+            "analysis_core CLI is not runnable through the analysis-core virtualenv. "
+            "Check `packages/analysis-core/.venv` and sync that environment first."
+        )
+
+
+def _write_csv(path: Path, header: str, rows: list[str]) -> None:
+    path.write_text("\n".join([header, *rows]) + "\n", encoding="utf-8")
+
+
+def _seed_report_status(report_status_module, slug: str) -> None:
+    report_status_module._report_status.clear()
+    report_status_module._report_status[slug] = {
+        "slug": slug,
+        "source_slug": None,
+        "status": "processing",
+        "title": "Smoke test report",
+        "description": "Manual subprocess smoke test",
+        "is_pubcom": False,
+        "visibility": "unlisted",
+        "created_at": "2026-05-23T00:00:00+00:00",
+        "token_usage": 0,
+        "token_usage_input": 0,
+        "token_usage_output": 0,
+        "estimated_cost": 0.0,
+        "provider": "local",
+        "model": "manual-smoke-model",
+    }
+    report_status_module.save_status()
+
+
+def _seed_aggregation_inputs(report_dir: Path, input_dir: Path, slug: str) -> None:
+    output_dir = report_dir / slug
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    _write_csv(
+        input_dir / f"{slug}.csv",
+        "comment-id,comment-body",
+        ['c1,"Need more explanation for this proposal."'],
+    )
+    _write_csv(
+        output_dir / "args.csv",
+        "arg-id,argument",
+        ['a1,"Need more explanation"'],
+    )
+    _write_csv(
+        output_dir / "relations.csv",
+        "arg-id,comment-id",
+        ["a1,c1"],
+    )
+    _write_csv(
+        output_dir / "hierarchical_clusters.csv",
+        "arg-id,argument,x,y,cluster-level-1-id",
+        ['a1,"Need more explanation",0.1,0.2,1'],
+    )
+    _write_csv(
+        output_dir / "hierarchical_merge_labels.csv",
+        "level,id,label,description,value,parent,density_rank_percentile",
+        ['1,1,"説明不足","説明を求める意見が集まっている",1,0,1.0'],
+    )
+    (output_dir / "hierarchical_overview.txt").write_text(
+        "説明不足への対応を求める小さなクラスタが観測された。",
+        encoding="utf-8",
+    )
+
+
+def _write_config(config_dir: Path, slug: str) -> Path:
+    config_path = config_dir / f"{slug}.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "input": slug,
+                "question": "What should be improved?",
+                "intro": "Manual subprocess smoke test",
+                "provider": "local",
+                "model": "manual-smoke-model",
+                "is_pubcom": False,
+                "is_embedded_at_local": False,
+                "enable_source_link": False,
+                "extraction": {
+                    "limit": 1,
+                    "properties": [],
+                    "categories": {},
+                },
+                "hierarchical_aggregation": {
+                    "hidden_properties": {},
+                },
+            },
+            ensure_ascii=False,
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    return config_path
+
+
+def test_execute_aggregation_launches_real_analysis_core_subprocess(monkeypatch, tmp_path):
+    from src.services import report_launcher, report_status
+
+    slug = "manual-subprocess-smoke"
+    report_dir = tmp_path / "reports"
+    config_dir = tmp_path / "configs"
+    input_dir = tmp_path / "inputs"
+    data_dir = tmp_path / "data"
+    report_dir.mkdir(parents=True)
+    config_dir.mkdir(parents=True)
+    input_dir.mkdir(parents=True)
+    data_dir.mkdir(parents=True)
+
+    monkeypatch.setattr(report_launcher.settings, "REPORT_DIR", report_dir)
+    monkeypatch.setattr(report_launcher.settings, "CONFIG_DIR", config_dir)
+    monkeypatch.setattr(report_launcher.settings, "INPUT_DIR", input_dir)
+    monkeypatch.setattr(report_status.settings, "DATA_DIR", data_dir)
+    monkeypatch.setattr(report_status, "STATE_FILE", data_dir / "report_status.json")
+    monkeypatch.setattr(report_launcher.threading, "Thread", ImmediateThread)
+    monkeypatch.setattr(report_launcher, "ReportSyncService", DummyReportSyncService)
+    _prepend_analysis_core_python(monkeypatch)
+    _ensure_analysis_core_cli_available()
+
+    _seed_report_status(report_status, slug)
+    _seed_aggregation_inputs(report_dir, input_dir, slug)
+    _write_config(config_dir, slug)
+
+    result = report_launcher.execute_aggregation(slug)
+
+    assert result is True
+
+    result_path = report_dir / slug / "hierarchical_result.json"
+    status_path = report_dir / slug / "hierarchical_status.json"
+    log_path = report_dir / slug / report_launcher.ANALYSIS_LOG_FILENAME
+    assert result_path.exists()
+    assert status_path.exists()
+    assert log_path.exists()
+
+    result_data = json.loads(result_path.read_text(encoding="utf-8"))
+    status_data = json.loads(status_path.read_text(encoding="utf-8"))
+    updated = report_status._report_status[slug]
+
+    assert result_data["comment_num"] == 1
+    assert len(result_data["arguments"]) == 1
+    assert len(result_data["clusters"]) == 2
+    assert result_data["overview"] == "説明不足への対応を求める小さなクラスタが観測された。"
+    assert result_data["config"]["intro"].startswith("Manual subprocess smoke test")
+
+    assert status_data["status"] == "completed"
+    assert [job["step"] for job in status_data["completed_jobs"]] == ["hierarchical_aggregation"]
+    assert status_data["total_token_usage"] == 0
+
+    assert updated["status"] == "ready"
+    assert updated["token_usage"] == 0
+    assert updated["token_usage_input"] == 0
+    assert updated["token_usage_output"] == 0

--- a/apps/api/tests/manual/report_launcher_subprocess_smoke.py
+++ b/apps/api/tests/manual/report_launcher_subprocess_smoke.py
@@ -64,9 +64,7 @@ def _analysis_core_python() -> Path:
 def _prepend_analysis_core_python(monkeypatch: pytest.MonkeyPatch) -> None:
     analysis_core_python = _analysis_core_python()
     if not analysis_core_python.exists():
-        pytest.skip(
-            "analysis-core virtualenv is missing. Run `cd packages/analysis-core && rye sync` first."
-        )
+        pytest.skip("analysis-core virtualenv is missing. Run `cd packages/analysis-core && rye sync` first.")
 
     analysis_core_bin = str(analysis_core_python.parent)
     current_path = os.environ.get("PATH", "")

--- a/apps/api/tests/manual/report_launcher_subprocess_smoke.py
+++ b/apps/api/tests/manual/report_launcher_subprocess_smoke.py
@@ -14,9 +14,14 @@ uses ``packages/analysis-core/.venv/bin/python``.
 
 from __future__ import annotations
 
+import hashlib
 import json
+import multiprocessing
 import os
+import socket
 import subprocess
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 
 import pytest
@@ -89,6 +94,191 @@ def _ensure_analysis_core_cli_available() -> None:
 
 def _write_csv(path: Path, header: str, rows: list[str]) -> None:
     path.write_text("\n".join([header, *rows]) + "\n", encoding="utf-8")
+
+
+def _fake_embedding(text: str, dimensions: int = 8) -> list[float]:
+    digest = hashlib.sha256(text.encode("utf-8")).digest()
+    values = []
+    for index in range(dimensions):
+        chunk = digest[index * 4 : (index + 1) * 4]
+        if len(chunk) < 4:
+            chunk = chunk.ljust(4, b"\0")
+        values.append(round(int.from_bytes(chunk, "big") / 2**32, 6))
+    return values
+
+
+def _extracted_opinion(text: str) -> str:
+    normalized = " ".join(text.split()).strip()
+    if not normalized:
+        return "意見なし"
+    first_sentence = normalized.split("。")[0].strip()
+    return first_sentence or normalized
+
+
+def _label_payload(text: str) -> dict[str, str]:
+    lines = [line.strip(" -#") for line in text.splitlines() if line.strip()]
+    seed = lines[0] if lines else "意見群"
+    label = seed[:20]
+    return {
+        "label": label,
+        "description": f"{label}に関する意見のまとまり",
+    }
+
+
+def _overview_payload(text: str) -> dict[str, str]:
+    cluster_count = text.count("# Cluster ")
+    if cluster_count == 0:
+        cluster_count = 1
+    return {
+        "summary": f"{cluster_count}件の主要論点が確認された。ローカル偽 LLM による通常フロー smoke test。",
+    }
+
+
+def _chat_completion_response(payload: dict) -> dict:
+    messages = payload.get("messages", [])
+    user_content = messages[-1].get("content", "") if messages else ""
+    response_format = payload.get("response_format", {})
+    schema_name = response_format.get("json_schema", {}).get("name")
+
+    if schema_name == "ExtractionResponse":
+        content = json.dumps(
+            {"extractedOpinionList": [_extracted_opinion(user_content)]},
+            ensure_ascii=False,
+        )
+    elif schema_name == "LabellingFromat":
+        content = json.dumps(_label_payload(user_content), ensure_ascii=False)
+    elif schema_name == "OverviewResponse":
+        content = json.dumps(_overview_payload(user_content), ensure_ascii=False)
+    else:
+        content = json.dumps({"message": "ok"}, ensure_ascii=False)
+
+    prompt_tokens = max(1, len(json.dumps(messages, ensure_ascii=False)) // 20)
+    completion_tokens = max(1, len(content) // 20)
+
+    return {
+        "id": "chatcmpl-fake-local",
+        "object": "chat.completion",
+        "created": 0,
+        "model": payload.get("model", "manual-smoke-model"),
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": content},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": prompt_tokens + completion_tokens,
+        },
+    }
+
+
+def _embedding_response(payload: dict) -> dict:
+    inputs = payload.get("input", [])
+    if isinstance(inputs, str):
+        inputs = [inputs]
+
+    return {
+        "object": "list",
+        "data": [
+            {
+                "object": "embedding",
+                "index": index,
+                "embedding": _fake_embedding(text),
+            }
+            for index, text in enumerate(inputs)
+        ],
+        "model": payload.get("model", "text-embedding-3-small"),
+        "usage": {
+            "prompt_tokens": len(inputs),
+            "total_tokens": len(inputs),
+        },
+    }
+
+
+def _serve_fake_local_llm(port: int) -> None:
+    class Handler(BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.0"
+
+        def do_POST(self):  # noqa: N802
+            content_length = int(self.headers.get("Content-Length", "0"))
+            raw_body = self.rfile.read(content_length).decode("utf-8")
+            payload = json.loads(raw_body or "{}")
+
+            if self.path == "/v1/chat/completions":
+                response = _chat_completion_response(payload)
+                _send_json(self, 200, response)
+                return
+
+            if self.path == "/v1/embeddings":
+                response = _embedding_response(payload)
+                _send_json(self, 200, response)
+                return
+
+            _send_json(self, 404, {"error": f"Unsupported path: {self.path}"})
+
+        def log_message(self, *_args, **_kwargs):
+            return
+
+    with HTTPServer(("127.0.0.1", port), Handler) as httpd:
+        httpd.serve_forever(poll_interval=0.1)
+
+
+def _send_json(handler: BaseHTTPRequestHandler, status_code: int, payload: dict) -> None:
+    encoded = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+    handler.send_response(status_code)
+    handler.send_header("Content-Type", "application/json")
+    handler.send_header("Content-Length", str(len(encoded)))
+    handler.send_header("Connection", "close")
+    handler.end_headers()
+    handler.wfile.write(encoded)
+
+
+class LocalLLMServerProcess:
+    """Run a tiny OpenAI-compatible fake server in a child process."""
+
+    def __init__(self) -> None:
+        self.port = self._reserve_port()
+        self._process: multiprocessing.Process | None = None
+
+    @property
+    def address(self) -> str:
+        return f"127.0.0.1:{self.port}"
+
+    def __enter__(self) -> "LocalLLMServerProcess":
+        self._process = multiprocessing.Process(target=_serve_fake_local_llm, args=(self.port,), daemon=True)
+        self._process.start()
+        self._wait_until_ready()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        if self._process is None:
+            return
+        if self._process.is_alive():
+            self._process.terminate()
+            self._process.join(timeout=5)
+        if self._process.is_alive():
+            self._process.kill()
+            self._process.join(timeout=5)
+
+    @staticmethod
+    def _reserve_port() -> int:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.bind(("127.0.0.1", 0))
+            return int(sock.getsockname()[1])
+
+    def _wait_until_ready(self) -> None:
+        for _ in range(50):
+            if self._process is not None and not self._process.is_alive():
+                raise RuntimeError("fake local LLM process exited before becoming ready")
+            try:
+                with socket.create_connection(("127.0.0.1", self.port), timeout=0.1):
+                    return
+            except OSError:
+                time.sleep(0.1)
+        raise RuntimeError("fake local LLM process did not become ready")
 
 
 def _seed_report_status(report_status_module, slug: str) -> None:
@@ -177,6 +367,37 @@ def _write_config(config_dir: Path, slug: str) -> Path:
     return config_path
 
 
+def _full_flow_report_input(local_llm_address: str):
+    from src.schemas.admin_report import Comment, Prompt, ReportInput
+
+    return ReportInput(
+        input="manual-full-subprocess-smoke",
+        question="通常フロー smoke test",
+        intro="Fake local LLM smoke test",
+        cluster=[2],
+        model="manual-smoke-model",
+        workers=1,
+        prompt=Prompt(
+            extraction="コメントから意見を1件抽出してください。",
+            initial_labelling="クラスタのラベルと説明を返してください。",
+            merge_labelling="上位クラスタのラベルと説明を返してください。",
+            overview="全体概要を要約してください。",
+        ),
+        comments=[
+            Comment(id="1", comment="医療分野でAI活用をもっと進めてほしい。"),
+            Comment(id="2", comment="再生可能エネルギーへの投資を増やすべきだ。"),
+            Comment(id="3", comment="地方の教育格差を埋めるためにオンライン学習を強化したい。"),
+            Comment(id="4", comment="介護現場ではロボット支援の導入が必要だ。"),
+            Comment(id="5", comment="プライバシー保護のルール整備を急いでほしい。"),
+        ],
+        is_pubcom=False,
+        provider="local",
+        local_llm_address=local_llm_address,
+        is_embedded_at_local=False,
+        enable_source_link=False,
+    )
+
+
 def test_execute_aggregation_launches_real_analysis_core_subprocess(monkeypatch, tmp_path):
     from src.services import report_launcher, report_status
 
@@ -233,3 +454,78 @@ def test_execute_aggregation_launches_real_analysis_core_subprocess(monkeypatch,
     assert updated["token_usage"] == 0
     assert updated["token_usage_input"] == 0
     assert updated["token_usage_output"] == 0
+
+
+def test_launch_report_generation_runs_full_analysis_core_subprocess(monkeypatch, tmp_path):
+    from src.services import report_launcher, report_status
+
+    slug = "manual-full-subprocess-smoke"
+    report_dir = tmp_path / "reports"
+    config_dir = tmp_path / "configs"
+    input_dir = tmp_path / "inputs"
+    data_dir = tmp_path / "data"
+    report_dir.mkdir(parents=True)
+    config_dir.mkdir(parents=True)
+    input_dir.mkdir(parents=True)
+    data_dir.mkdir(parents=True)
+
+    monkeypatch.setattr(report_launcher.settings, "REPORT_DIR", report_dir)
+    monkeypatch.setattr(report_launcher.settings, "CONFIG_DIR", config_dir)
+    monkeypatch.setattr(report_launcher.settings, "INPUT_DIR", input_dir)
+    monkeypatch.setattr(report_status.settings, "DATA_DIR", data_dir)
+    monkeypatch.setattr(report_status, "STATE_FILE", data_dir / "report_status.json")
+    monkeypatch.setattr(report_launcher.threading, "Thread", ImmediateThread)
+    monkeypatch.setattr(report_launcher, "ReportSyncService", DummyReportSyncService)
+    _prepend_analysis_core_python(monkeypatch)
+    _ensure_analysis_core_cli_available()
+    report_status._report_status.clear()
+
+    with LocalLLMServerProcess() as fake_llm:
+        report_input = _full_flow_report_input(fake_llm.address)
+        report_launcher.launch_report_generation(report_input)
+
+    output_dir = report_dir / slug
+    result_path = output_dir / "hierarchical_result.json"
+    status_path = output_dir / "hierarchical_status.json"
+    log_path = output_dir / report_launcher.ANALYSIS_LOG_FILENAME
+    args_path = output_dir / "args.csv"
+    embeddings_path = output_dir / "embeddings.pkl"
+
+    assert result_path.exists()
+    assert status_path.exists()
+    assert log_path.exists()
+    assert args_path.exists()
+    assert embeddings_path.exists()
+
+    result_data = json.loads(result_path.read_text(encoding="utf-8"))
+    status_data = json.loads(status_path.read_text(encoding="utf-8"))
+    updated = report_status._report_status[slug]
+
+    assert result_data["comment_num"] == 5
+    assert len(result_data["arguments"]) >= 5
+    assert len(result_data["clusters"]) >= 3
+    assert "主要論点" in result_data["overview"]
+    assert result_data["config"]["provider"] == "local"
+    assert result_data["config"]["model"] == "manual-smoke-model"
+    assert "Fake local LLM smoke test" in result_data["config"]["intro"]
+
+    assert status_data["status"] == "completed"
+    assert [job["step"] for job in status_data["completed_jobs"]] == [
+        "extraction",
+        "embedding",
+        "hierarchical_clustering",
+        "hierarchical_initial_labelling",
+        "hierarchical_merge_labelling",
+        "hierarchical_overview",
+        "hierarchical_aggregation",
+    ]
+    assert status_data["total_token_usage"] > 0
+    assert status_data["token_usage_input"] > 0
+    assert status_data["token_usage_output"] > 0
+
+    assert updated["status"] == "ready"
+    assert updated["provider"] == "local"
+    assert updated["model"] == "manual-smoke-model"
+    assert updated["token_usage"] > 0
+    assert updated["token_usage_input"] > 0
+    assert updated["token_usage_output"] > 0

--- a/packages/analysis-core/src/analysis_core/plugins/builtin/_legacy_config.py
+++ b/packages/analysis-core/src/analysis_core/plugins/builtin/_legacy_config.py
@@ -1,0 +1,60 @@
+"""Helpers for adapting workflow context to legacy step configs."""
+
+from pathlib import Path
+from typing import Any
+
+from analysis_core.plugin import StepContext, StepInputs
+
+
+def build_legacy_runtime_config(
+    ctx: StepContext,
+    inputs: StepInputs | None = None,
+    *,
+    include_input: bool = False,
+    include_token_usage: bool = False,
+) -> dict[str, Any]:
+    """Build the common runtime keys legacy step functions expect."""
+    legacy_config: dict[str, Any] = {
+        "output_dir": ctx.dataset,
+        "_output_base_dir": str(ctx.output_dir.parent),
+        "provider": ctx.provider,
+        "local_llm_address": ctx.local_llm_address,
+    }
+
+    if include_input:
+        input_name, input_base_dir = resolve_input_location(ctx, inputs)
+        legacy_config["input"] = input_name
+        legacy_config["_input_base_dir"] = str(input_base_dir)
+
+    if include_token_usage:
+        legacy_config.update(
+            {
+                "total_token_usage": 0,
+                "token_usage_input": 0,
+                "token_usage_output": 0,
+            }
+        )
+
+    return legacy_config
+
+
+def resolve_input_location(
+    ctx: StepContext,
+    inputs: StepInputs | None,
+) -> tuple[str, Path]:
+    """Resolve the input slug and base directory from workflow inputs."""
+    input_name = ctx.dataset
+    input_base_dir = ctx.input_dir
+
+    if inputs is not None:
+        configured_input = inputs.config.get("input")
+        if isinstance(configured_input, str) and configured_input:
+            input_name = configured_input
+
+        comments_path = inputs.artifacts.get("comments")
+        if comments_path is not None:
+            comments_path = Path(comments_path)
+            input_name = comments_path.stem
+            input_base_dir = comments_path.parent
+
+    return input_name, input_base_dir

--- a/packages/analysis-core/src/analysis_core/plugins/builtin/_legacy_config.py
+++ b/packages/analysis-core/src/analysis_core/plugins/builtin/_legacy_config.py
@@ -52,7 +52,7 @@ def resolve_input_location(
             input_name = configured_input
 
         comments_path = inputs.artifacts.get("comments")
-        if comments_path is not None:
+        if not (isinstance(configured_input, str) and configured_input) and comments_path is not None:
             comments_path = Path(comments_path)
             input_name = comments_path.stem
             input_base_dir = comments_path.parent

--- a/packages/analysis-core/src/analysis_core/plugins/builtin/embedding.py
+++ b/packages/analysis-core/src/analysis_core/plugins/builtin/embedding.py
@@ -12,6 +12,7 @@ from analysis_core.plugin import (
     StepOutputs,
     step_plugin,
 )
+from analysis_core.plugins.builtin._legacy_config import build_legacy_runtime_config
 
 
 @step_plugin(
@@ -40,15 +41,10 @@ def embedding_plugin(
     from analysis_core.steps.embedding import embedding as embedding_impl
 
     step_config = config.get("embedding", config)
-    legacy_config = {
-        "output_dir": ctx.dataset,
-        "provider": ctx.provider,
-        "local_llm_address": ctx.local_llm_address,
-        "is_embedded_at_local": inputs.config.get("is_embedded_at_local", False),
-        "_output_base_dir": str(ctx.output_dir.parent),
-        "embedding": {
-            "model": step_config.get("model", "text-embedding-3-small"),
-        },
+    legacy_config = build_legacy_runtime_config(ctx, inputs)
+    legacy_config["is_embedded_at_local"] = inputs.config.get("is_embedded_at_local", False)
+    legacy_config["embedding"] = {
+        "model": step_config.get("model", "text-embedding-3-small"),
     }
 
     embedding_impl(legacy_config)

--- a/packages/analysis-core/src/analysis_core/plugins/builtin/embedding.py
+++ b/packages/analysis-core/src/analysis_core/plugins/builtin/embedding.py
@@ -45,6 +45,7 @@ def embedding_plugin(
         "provider": ctx.provider,
         "local_llm_address": ctx.local_llm_address,
         "is_embedded_at_local": inputs.config.get("is_embedded_at_local", False),
+        "_output_base_dir": str(ctx.output_dir.parent),
         "embedding": {
             "model": step_config.get("model", "text-embedding-3-small"),
         },

--- a/packages/analysis-core/src/analysis_core/plugins/builtin/extraction.py
+++ b/packages/analysis-core/src/analysis_core/plugins/builtin/extraction.py
@@ -4,7 +4,6 @@ Extraction step plugin.
 Extracts opinions/arguments from comments using LLM.
 """
 
-from pathlib import Path
 from typing import Any
 
 from analysis_core.plugin import (
@@ -13,6 +12,7 @@ from analysis_core.plugin import (
     StepOutputs,
     step_plugin,
 )
+from analysis_core.plugins.builtin._legacy_config import build_legacy_runtime_config
 
 
 @step_plugin(
@@ -45,33 +45,14 @@ def extraction_plugin(
     # Import here to avoid circular imports
     from analysis_core.steps.extraction import extraction as extraction_impl
 
-    comments_path = inputs.artifacts.get("comments")
-    input_name = inputs.config.get("input", ctx.dataset)
-    input_base_dir = ctx.input_dir
-    if comments_path is not None:
-        input_name = Path(comments_path).stem
-        input_base_dir = Path(comments_path).parent
-
-    # Build legacy config format for compatibility
     step_config = config.get("extraction", config)
-    legacy_config = {
-        "output_dir": ctx.dataset,
-        "input": input_name,
-        "provider": ctx.provider,
-        "local_llm_address": ctx.local_llm_address,
-        "_input_base_dir": str(input_base_dir),
-        "_output_base_dir": str(ctx.output_dir.parent),
-        "extraction": {
-            "model": step_config.get("model", ctx.model),
-            "prompt": step_config.get("prompt", ""),
-            "workers": step_config.get("workers", 1),
-            "limit": step_config.get("limit", 1000),
-            "properties": step_config.get("properties", []),
-        },
-        # Token tracking
-        "total_token_usage": 0,
-        "token_usage_input": 0,
-        "token_usage_output": 0,
+    legacy_config = build_legacy_runtime_config(ctx, inputs, include_input=True, include_token_usage=True)
+    legacy_config["extraction"] = {
+        "model": step_config.get("model", ctx.model),
+        "prompt": step_config.get("prompt", ""),
+        "workers": step_config.get("workers", 1),
+        "limit": step_config.get("limit", 1000),
+        "properties": step_config.get("properties", []),
     }
 
     # Run the extraction

--- a/packages/analysis-core/src/analysis_core/plugins/builtin/extraction.py
+++ b/packages/analysis-core/src/analysis_core/plugins/builtin/extraction.py
@@ -4,6 +4,7 @@ Extraction step plugin.
 Extracts opinions/arguments from comments using LLM.
 """
 
+from pathlib import Path
 from typing import Any
 
 from analysis_core.plugin import (
@@ -44,13 +45,22 @@ def extraction_plugin(
     # Import here to avoid circular imports
     from analysis_core.steps.extraction import extraction as extraction_impl
 
+    comments_path = inputs.artifacts.get("comments")
+    input_name = inputs.config.get("input", ctx.dataset)
+    input_base_dir = ctx.input_dir
+    if comments_path is not None:
+        input_name = Path(comments_path).stem
+        input_base_dir = Path(comments_path).parent
+
     # Build legacy config format for compatibility
     step_config = config.get("extraction", config)
     legacy_config = {
         "output_dir": ctx.dataset,
-        "input": inputs.config.get("input", ctx.dataset),
+        "input": input_name,
         "provider": ctx.provider,
         "local_llm_address": ctx.local_llm_address,
+        "_input_base_dir": str(input_base_dir),
+        "_output_base_dir": str(ctx.output_dir.parent),
         "extraction": {
             "model": step_config.get("model", ctx.model),
             "prompt": step_config.get("prompt", ""),

--- a/packages/analysis-core/src/analysis_core/plugins/builtin/hierarchical_aggregation.py
+++ b/packages/analysis-core/src/analysis_core/plugins/builtin/hierarchical_aggregation.py
@@ -4,6 +4,7 @@ Hierarchical aggregation step plugin.
 Aggregates all results into a final JSON output file.
 """
 
+from pathlib import Path
 from typing import Any
 
 from analysis_core.plugin import (
@@ -45,11 +46,19 @@ def hierarchical_aggregation_plugin(
 
     # Build legacy config - aggregation needs many fields from full config
     legacy_config = inputs.config.copy() if inputs.config else {}
+    comments_path = inputs.artifacts.get("comments")
+    input_name = inputs.config.get("input", ctx.dataset)
+    input_base_dir = ctx.input_dir
+    if comments_path is not None:
+        input_name = Path(comments_path).stem
+        input_base_dir = Path(comments_path).parent
     legacy_config.update(
         {
             "output_dir": ctx.dataset,
-            "input": inputs.config.get("input", ctx.dataset),
+            "input": input_name,
             "provider": ctx.provider,
+            "_input_base_dir": str(input_base_dir),
+            "_output_base_dir": str(ctx.output_dir.parent),
             "hierarchical_aggregation": {
                 "hidden_properties": step_config.get("hidden_properties", {}),
             },

--- a/packages/analysis-core/src/analysis_core/plugins/builtin/hierarchical_aggregation.py
+++ b/packages/analysis-core/src/analysis_core/plugins/builtin/hierarchical_aggregation.py
@@ -4,7 +4,6 @@ Hierarchical aggregation step plugin.
 Aggregates all results into a final JSON output file.
 """
 
-from pathlib import Path
 from typing import Any
 
 from analysis_core.plugin import (
@@ -13,6 +12,7 @@ from analysis_core.plugin import (
     StepOutputs,
     step_plugin,
 )
+from analysis_core.plugins.builtin._legacy_config import build_legacy_runtime_config
 
 
 @step_plugin(
@@ -44,26 +44,13 @@ def hierarchical_aggregation_plugin(
 
     step_config = config.get("hierarchical_aggregation", config)
 
-    # Build legacy config - aggregation needs many fields from full config
     legacy_config = inputs.config.copy() if inputs.config else {}
-    comments_path = inputs.artifacts.get("comments")
-    input_name = inputs.config.get("input", ctx.dataset)
-    input_base_dir = ctx.input_dir
-    if comments_path is not None:
-        input_name = Path(comments_path).stem
-        input_base_dir = Path(comments_path).parent
     legacy_config.update(
-        {
-            "output_dir": ctx.dataset,
-            "input": input_name,
-            "provider": ctx.provider,
-            "_input_base_dir": str(input_base_dir),
-            "_output_base_dir": str(ctx.output_dir.parent),
-            "hierarchical_aggregation": {
-                "hidden_properties": step_config.get("hidden_properties", {}),
-            },
-        }
+        build_legacy_runtime_config(ctx, inputs, include_input=True)
     )
+    legacy_config["hierarchical_aggregation"] = {
+        "hidden_properties": step_config.get("hidden_properties", {}),
+    }
 
     # Ensure required fields exist
     if "extraction" not in legacy_config:

--- a/packages/analysis-core/src/analysis_core/plugins/builtin/hierarchical_clustering.py
+++ b/packages/analysis-core/src/analysis_core/plugins/builtin/hierarchical_clustering.py
@@ -44,6 +44,7 @@ def hierarchical_clustering_plugin(
     step_config = config.get("hierarchical_clustering", config)
     legacy_config = {
         "output_dir": ctx.dataset,
+        "_output_base_dir": str(ctx.output_dir.parent),
         "hierarchical_clustering": {
             "cluster_nums": step_config.get("cluster_nums"),
         },

--- a/packages/analysis-core/src/analysis_core/plugins/builtin/hierarchical_clustering.py
+++ b/packages/analysis-core/src/analysis_core/plugins/builtin/hierarchical_clustering.py
@@ -12,6 +12,7 @@ from analysis_core.plugin import (
     StepOutputs,
     step_plugin,
 )
+from analysis_core.plugins.builtin._legacy_config import build_legacy_runtime_config
 
 
 @step_plugin(
@@ -42,12 +43,9 @@ def hierarchical_clustering_plugin(
     )
 
     step_config = config.get("hierarchical_clustering", config)
-    legacy_config = {
-        "output_dir": ctx.dataset,
-        "_output_base_dir": str(ctx.output_dir.parent),
-        "hierarchical_clustering": {
-            "cluster_nums": step_config.get("cluster_nums"),
-        },
+    legacy_config = build_legacy_runtime_config(ctx, inputs)
+    legacy_config["hierarchical_clustering"] = {
+        "cluster_nums": step_config.get("cluster_nums"),
     }
 
     clustering_impl(legacy_config)

--- a/packages/analysis-core/src/analysis_core/plugins/builtin/hierarchical_initial_labelling.py
+++ b/packages/analysis-core/src/analysis_core/plugins/builtin/hierarchical_initial_labelling.py
@@ -12,6 +12,7 @@ from analysis_core.plugin import (
     StepOutputs,
     step_plugin,
 )
+from analysis_core.plugins.builtin._legacy_config import build_legacy_runtime_config
 
 
 @step_plugin(
@@ -45,21 +46,12 @@ def hierarchical_initial_labelling_plugin(
     )
 
     step_config = config.get("hierarchical_initial_labelling", config)
-    legacy_config = {
-        "output_dir": ctx.dataset,
-        "provider": ctx.provider,
-        "local_llm_address": ctx.local_llm_address,
-        "_output_base_dir": str(ctx.output_dir.parent),
-        "hierarchical_initial_labelling": {
-            "sampling_num": step_config.get("sampling_num", 10),
-            "prompt": step_config.get("prompt", ""),
-            "model": step_config.get("model", ctx.model),
-            "workers": step_config.get("workers", 3),
-        },
-        # Token tracking
-        "total_token_usage": 0,
-        "token_usage_input": 0,
-        "token_usage_output": 0,
+    legacy_config = build_legacy_runtime_config(ctx, inputs, include_token_usage=True)
+    legacy_config["hierarchical_initial_labelling"] = {
+        "sampling_num": step_config.get("sampling_num", 10),
+        "prompt": step_config.get("prompt", ""),
+        "model": step_config.get("model", ctx.model),
+        "workers": step_config.get("workers", 3),
     }
 
     labelling_impl(legacy_config)

--- a/packages/analysis-core/src/analysis_core/plugins/builtin/hierarchical_initial_labelling.py
+++ b/packages/analysis-core/src/analysis_core/plugins/builtin/hierarchical_initial_labelling.py
@@ -49,6 +49,7 @@ def hierarchical_initial_labelling_plugin(
         "output_dir": ctx.dataset,
         "provider": ctx.provider,
         "local_llm_address": ctx.local_llm_address,
+        "_output_base_dir": str(ctx.output_dir.parent),
         "hierarchical_initial_labelling": {
             "sampling_num": step_config.get("sampling_num", 10),
             "prompt": step_config.get("prompt", ""),

--- a/packages/analysis-core/src/analysis_core/plugins/builtin/hierarchical_merge_labelling.py
+++ b/packages/analysis-core/src/analysis_core/plugins/builtin/hierarchical_merge_labelling.py
@@ -49,6 +49,7 @@ def hierarchical_merge_labelling_plugin(
         "output_dir": ctx.dataset,
         "provider": ctx.provider,
         "local_llm_address": ctx.local_llm_address,
+        "_output_base_dir": str(ctx.output_dir.parent),
         "hierarchical_merge_labelling": {
             "sampling_num": step_config.get("sampling_num", 10),
             "prompt": step_config.get("prompt", ""),

--- a/packages/analysis-core/src/analysis_core/plugins/builtin/hierarchical_merge_labelling.py
+++ b/packages/analysis-core/src/analysis_core/plugins/builtin/hierarchical_merge_labelling.py
@@ -12,6 +12,7 @@ from analysis_core.plugin import (
     StepOutputs,
     step_plugin,
 )
+from analysis_core.plugins.builtin._legacy_config import build_legacy_runtime_config
 
 
 @step_plugin(
@@ -45,21 +46,12 @@ def hierarchical_merge_labelling_plugin(
     )
 
     step_config = config.get("hierarchical_merge_labelling", config)
-    legacy_config = {
-        "output_dir": ctx.dataset,
-        "provider": ctx.provider,
-        "local_llm_address": ctx.local_llm_address,
-        "_output_base_dir": str(ctx.output_dir.parent),
-        "hierarchical_merge_labelling": {
-            "sampling_num": step_config.get("sampling_num", 10),
-            "prompt": step_config.get("prompt", ""),
-            "model": step_config.get("model", ctx.model),
-            "workers": step_config.get("workers", 3),
-        },
-        # Token tracking
-        "total_token_usage": 0,
-        "token_usage_input": 0,
-        "token_usage_output": 0,
+    legacy_config = build_legacy_runtime_config(ctx, inputs, include_token_usage=True)
+    legacy_config["hierarchical_merge_labelling"] = {
+        "sampling_num": step_config.get("sampling_num", 10),
+        "prompt": step_config.get("prompt", ""),
+        "model": step_config.get("model", ctx.model),
+        "workers": step_config.get("workers", 3),
     }
 
     merge_impl(legacy_config)

--- a/packages/analysis-core/src/analysis_core/plugins/builtin/hierarchical_overview.py
+++ b/packages/analysis-core/src/analysis_core/plugins/builtin/hierarchical_overview.py
@@ -47,6 +47,7 @@ def hierarchical_overview_plugin(
         "output_dir": ctx.dataset,
         "provider": ctx.provider,
         "local_llm_address": ctx.local_llm_address,
+        "_output_base_dir": str(ctx.output_dir.parent),
         "hierarchical_overview": {
             "prompt": step_config.get("prompt", ""),
             "model": step_config.get("model", ctx.model),

--- a/packages/analysis-core/src/analysis_core/plugins/builtin/hierarchical_overview.py
+++ b/packages/analysis-core/src/analysis_core/plugins/builtin/hierarchical_overview.py
@@ -12,6 +12,7 @@ from analysis_core.plugin import (
     StepOutputs,
     step_plugin,
 )
+from analysis_core.plugins.builtin._legacy_config import build_legacy_runtime_config
 
 
 @step_plugin(
@@ -43,19 +44,10 @@ def hierarchical_overview_plugin(
     )
 
     step_config = config.get("hierarchical_overview", config)
-    legacy_config = {
-        "output_dir": ctx.dataset,
-        "provider": ctx.provider,
-        "local_llm_address": ctx.local_llm_address,
-        "_output_base_dir": str(ctx.output_dir.parent),
-        "hierarchical_overview": {
-            "prompt": step_config.get("prompt", ""),
-            "model": step_config.get("model", ctx.model),
-        },
-        # Token tracking
-        "total_token_usage": 0,
-        "token_usage_input": 0,
-        "token_usage_output": 0,
+    legacy_config = build_legacy_runtime_config(ctx, inputs, include_token_usage=True)
+    legacy_config["hierarchical_overview"] = {
+        "prompt": step_config.get("prompt", ""),
+        "model": step_config.get("model", ctx.model),
     }
 
     overview_impl(legacy_config)

--- a/packages/analysis-core/src/analysis_core/plugins/builtin/hierarchical_visualization.py
+++ b/packages/analysis-core/src/analysis_core/plugins/builtin/hierarchical_visualization.py
@@ -12,6 +12,7 @@ from analysis_core.plugin import (
     StepOutputs,
     step_plugin,
 )
+from analysis_core.plugins.builtin._legacy_config import build_legacy_runtime_config
 
 
 @step_plugin(
@@ -43,13 +44,10 @@ def hierarchical_visualization_plugin(
     )
 
     step_config = config.get("hierarchical_visualization", config)
-    legacy_config = {
-        "output_dir": ctx.dataset,
-        "_output_base_dir": str(ctx.output_dir.parent),
-        "report_dir": step_config.get("report_dir", "../report"),
-        "report_html_title": step_config.get("report_html_title"),
-        "report_url_pattern": step_config.get("report_url_pattern"),
-    }
+    legacy_config = build_legacy_runtime_config(ctx, inputs)
+    legacy_config["report_dir"] = step_config.get("report_dir", "../report")
+    legacy_config["report_html_title"] = step_config.get("report_html_title")
+    legacy_config["report_url_pattern"] = step_config.get("report_url_pattern")
 
     viz_impl(legacy_config)
 

--- a/packages/analysis-core/src/analysis_core/plugins/builtin/hierarchical_visualization.py
+++ b/packages/analysis-core/src/analysis_core/plugins/builtin/hierarchical_visualization.py
@@ -45,6 +45,7 @@ def hierarchical_visualization_plugin(
     step_config = config.get("hierarchical_visualization", config)
     legacy_config = {
         "output_dir": ctx.dataset,
+        "_output_base_dir": str(ctx.output_dir.parent),
         "report_dir": step_config.get("report_dir", "../report"),
         "report_html_title": step_config.get("report_html_title"),
         "report_url_pattern": step_config.get("report_url_pattern"),

--- a/packages/analysis-core/tests/test_builtin_plugins.py
+++ b/packages/analysis-core/tests/test_builtin_plugins.py
@@ -45,8 +45,8 @@ def test_visualization_plugin_reports_report_html_path(tmp_path, monkeypatch):
     assert outputs.artifacts["html"] == output_dir / "report.html"
 
 
-def test_extraction_plugin_passes_resolved_input_and_output_paths(tmp_path, monkeypatch):
-    """The workflow plugin should pass input/output base dirs to legacy steps."""
+def test_extraction_plugin_keeps_explicit_input_over_comments_fallback(tmp_path, monkeypatch):
+    """Explicit configured input should win over comments-derived fallback."""
 
     output_dir = tmp_path / "custom-output" / "demo"
     input_dir = tmp_path / "custom-input"
@@ -79,7 +79,61 @@ def test_extraction_plugin_passes_resolved_input_and_output_paths(tmp_path, monk
         ctx,
         StepInputs(
             artifacts={"comments": comments_path},
-            config={"input": "ignored-by-comments-artifact"},
+            config={"input": "configured-input"},
+        ),
+        {
+            "extraction": {
+                "model": "test-model",
+                "prompt": "extract",
+                "workers": 2,
+                "limit": 10,
+                "properties": [],
+            }
+        },
+    )
+
+    assert seen["input"] == "configured-input"
+    assert seen["_input_base_dir"] == str(input_dir)
+    assert seen["_output_base_dir"] == str(output_dir.parent)
+    assert outputs.artifacts["arguments"] == output_dir / "args.csv"
+    assert outputs.artifacts["relations"] == output_dir / "relations.csv"
+
+
+def test_extraction_plugin_uses_comments_path_as_input_fallback(tmp_path, monkeypatch):
+    """Comments artifact should provide input slug and base dir when config omits it."""
+
+    output_dir = tmp_path / "custom-output" / "demo"
+    input_dir = tmp_path / "custom-input"
+    comments_dir = input_dir / "nested"
+    comments_path = comments_dir / "sample-comments.csv"
+    output_dir.mkdir(parents=True)
+    comments_dir.mkdir(parents=True)
+    comments_path.write_text("comment-id,comment-body\n1,test\n", encoding="utf-8")
+
+    ctx = StepContext(
+        output_dir=output_dir,
+        input_dir=input_dir,
+        dataset="demo",
+        provider="local",
+        model="dummy-model",
+        local_llm_address="127.0.0.1:9999",
+    )
+
+    seen = {}
+
+    def fake_extraction(config):
+        seen.update(config)
+        (output_dir / "args.csv").write_text("arg-id,argument\na1,test\n", encoding="utf-8")
+        (output_dir / "relations.csv").write_text("arg-id,comment-id\na1,1\n", encoding="utf-8")
+
+    extraction_module = importlib.import_module("analysis_core.steps.extraction")
+    monkeypatch.setattr(extraction_module, "extraction", fake_extraction)
+
+    outputs = extraction_plugin.run(
+        ctx,
+        StepInputs(
+            artifacts={"comments": comments_path},
+            config={},
         ),
         {
             "extraction": {

--- a/packages/analysis-core/tests/test_builtin_plugins.py
+++ b/packages/analysis-core/tests/test_builtin_plugins.py
@@ -3,6 +3,7 @@
 import importlib
 
 from analysis_core.plugin import StepContext, StepInputs
+from analysis_core.plugins.builtin.extraction import extraction_plugin
 from analysis_core.plugins.builtin.hierarchical_visualization import hierarchical_visualization_plugin
 
 
@@ -42,3 +43,57 @@ def test_visualization_plugin_reports_report_html_path(tmp_path, monkeypatch):
     )
 
     assert outputs.artifacts["html"] == output_dir / "report.html"
+
+
+def test_extraction_plugin_passes_resolved_input_and_output_paths(tmp_path, monkeypatch):
+    """The workflow plugin should pass input/output base dirs to legacy steps."""
+
+    output_dir = tmp_path / "custom-output" / "demo"
+    input_dir = tmp_path / "custom-input"
+    comments_dir = input_dir / "nested"
+    comments_path = comments_dir / "sample-comments.csv"
+    output_dir.mkdir(parents=True)
+    comments_dir.mkdir(parents=True)
+    comments_path.write_text("comment-id,comment-body\n1,test\n", encoding="utf-8")
+
+    ctx = StepContext(
+        output_dir=output_dir,
+        input_dir=input_dir,
+        dataset="demo",
+        provider="local",
+        model="dummy-model",
+        local_llm_address="127.0.0.1:9999",
+    )
+
+    seen = {}
+
+    def fake_extraction(config):
+        seen.update(config)
+        (output_dir / "args.csv").write_text("arg-id,argument\na1,test\n", encoding="utf-8")
+        (output_dir / "relations.csv").write_text("arg-id,comment-id\na1,1\n", encoding="utf-8")
+
+    extraction_module = importlib.import_module("analysis_core.steps.extraction")
+    monkeypatch.setattr(extraction_module, "extraction", fake_extraction)
+
+    outputs = extraction_plugin.run(
+        ctx,
+        StepInputs(
+            artifacts={"comments": comments_path},
+            config={"input": "ignored-by-comments-artifact"},
+        ),
+        {
+            "extraction": {
+                "model": "test-model",
+                "prompt": "extract",
+                "workers": 2,
+                "limit": 10,
+                "properties": [],
+            }
+        },
+    )
+
+    assert seen["input"] == "sample-comments"
+    assert seen["_input_base_dir"] == str(comments_dir)
+    assert seen["_output_base_dir"] == str(output_dir.parent)
+    assert outputs.artifacts["arguments"] == output_dir / "args.csv"
+    assert outputs.artifacts["relations"] == output_dir / "relations.csv"


### PR DESCRIPTION
## 変更内容
- `apps/api -> subprocess -> analysis_core` の境界を本物の subprocess で踏む manual smoke test を追加
- その smoke を、通常の `launch_report_generation()` フロー全体まで拡張し、`hierarchical_result.json`、`hierarchical_status.json`、`report_status.json` まで確認
- workflow plugin から legacy step へ渡す input/output path の配線を修正し、相対 `inputs/` / `outputs/` に落ちないようにした
- 共通の legacy config 組み立てを `_legacy_config.py` に集約し、extraction の path 解決に regression test を追加

## 背景
- 既存 repo には `analysis-core` 単体の e2e と、API 側の mock ベース service test はあったが、本番で使っている `apps/api -> subprocess -> analysis_core` の境界を手元で再現可能な形で踏むテストがなかった
- 通常フロー smoke を追加して初めて、workflow plugin 側が `--input-dir` / `--output-dir` を十分に legacy step へ渡しておらず、cwd 相対の `inputs/` / `outputs/` に依存していることが分かった
- path 修正を個別 plugin に散らしたままにすると再発しやすいため、共通化と回帰テストまで同じ PR に含めた

## 影響
- launcher や workflow path を触る変更の前に、production に近い API 実行経路を手元で 1 回踏めるようになる
- workflow 経由の実行でも、設定された report/input directory をより一貫して尊重するようになる
- extraction plugin について、comments artifact を使った path 解決の regression coverage が追加される

## 根本原因
workflow plugin 層が、解決済みの input/output base dir を legacy step 関数へ一貫して渡していなかった。そのため、API からの実 subprocess 実行でも `inputs/<slug>.csv` を current working directory 基準で探してしまう経路が残っていた。

## 動作確認
- `cd packages/analysis-core && ./.venv/bin/ruff check src/analysis_core/plugins/builtin tests/test_builtin_plugins.py`
- `cd packages/analysis-core && ./.venv/bin/pytest tests/test_builtin_plugins.py tests/test_workflow_engine.py -q`
- `cd apps/api && ADMIN_API_KEY=dummy PUBLIC_API_KEY=dummy OPENAI_API_KEY=dummy ./.venv/bin/pytest tests/services/test_report_launcher.py -q`
- `cd apps/api && ADMIN_API_KEY=dummy PUBLIC_API_KEY=dummy OPENAI_API_KEY=dummy ./.venv/bin/pytest tests/manual/report_launcher_subprocess_smoke.py -q -s`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a manual smoke-testing capability to validate end-to-end report generation with a simulated local LLM to ensure subprocess-driven workflows produce expected outputs.

* **Tests**
  * Added manual smoke tests covering full report generation and aggregation flows.
  * Added regression tests verifying extraction step input selection and artifact outputs.

* **Refactor**
  * Consolidated legacy runtime configuration construction across multiple plugins; now includes consistent input location resolution and token-usage tracking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/digitaldemocracy2030/kouchou-ai/pull/864?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->