### PR TITLE
[codex] LLM grouping 分析モードを追加

### DIFF
--- a/packages/analysis-core/src/analysis_core/compat/config_converter.py
+++ b/packages/analysis-core/src/analysis_core/compat/config_converter.py
@@ -10,7 +10,7 @@ from typing import Any
 
 from analysis_core.prompts import get_default_prompt
 from analysis_core.workflow import WorkflowDefinition
-from analysis_core.workflows import HIERARCHICAL_DEFAULT_WORKFLOW
+from analysis_core.workflows import get_workflow_for_mode
 
 
 def _get_step_source_codes() -> dict[str, str]:
@@ -24,6 +24,7 @@ def _get_step_source_codes() -> dict[str, str]:
         hierarchical_merge_labelling,
         hierarchical_overview,
         hierarchical_visualization,
+        llm_grouping,
     )
 
     step_functions = {
@@ -35,6 +36,7 @@ def _get_step_source_codes() -> dict[str, str]:
         "hierarchical_overview": hierarchical_overview,
         "hierarchical_aggregation": hierarchical_aggregation,
         "hierarchical_visualization": hierarchical_visualization,
+        "llm_grouping": llm_grouping,
     }
 
     source_codes = {}
@@ -72,6 +74,7 @@ def normalize_config(config: dict[str, Any], include_source_code: bool = True) -
     # Top-level defaults
     result.setdefault("model", "gpt-4o-mini")
     result.setdefault("provider", "openai")
+    result.setdefault("analysis_mode", "hierarchical")
     result.setdefault("is_embedded_at_local", False)
     result.setdefault("is_pubcom", False)
     result.setdefault("intro", "")
@@ -99,6 +102,19 @@ def normalize_config(config: dict[str, Any], include_source_code: bool = True) -
     clustering = result.setdefault("hierarchical_clustering", {})
     if "hierarchical_clustering" in source_codes:
         clustering.setdefault("source_code", source_codes["hierarchical_clustering"])
+
+    # LLM grouping defaults
+    llm_grouping = result.setdefault("llm_grouping", {})
+    llm_grouping.setdefault("group_count", None)
+    llm_grouping.setdefault("discovery_sample_size", 80)
+    llm_grouping.setdefault("assignment_batch_size", 25)
+    if not llm_grouping.get("discovery_prompt"):
+        llm_grouping["discovery_prompt"] = get_default_prompt("llm_grouping_discovery") or ""
+    if not llm_grouping.get("assignment_prompt"):
+        llm_grouping["assignment_prompt"] = get_default_prompt("llm_grouping_assignment") or ""
+    llm_grouping.setdefault("model", result["model"])
+    if "llm_grouping" in source_codes:
+        llm_grouping.setdefault("source_code", source_codes["llm_grouping"])
 
     # Initial labelling defaults
     initial_labelling = result.setdefault("hierarchical_initial_labelling", {})
@@ -157,9 +173,7 @@ def convert_legacy_config(
     # Normalize the config first
     normalized = normalize_config(legacy_config)
 
-    # Use the default hierarchical workflow
-    # In the future, we could detect different workflow types from config
-    workflow = HIERARCHICAL_DEFAULT_WORKFLOW
+    workflow = get_workflow_for_mode(normalized.get("analysis_mode", "hierarchical"))
 
     return workflow, normalized
 

--- a/packages/analysis-core/src/analysis_core/core/__init__.py
+++ b/packages/analysis-core/src/analysis_core/core/__init__.py
@@ -7,6 +7,7 @@ This module provides the fundamental building blocks for pipeline orchestration.
 from analysis_core.core.orchestration import (
     decide_what_to_run,
     get_specs,
+    get_specs_path_for_mode,
     initialization,
     load_specs,
     plan_requires_input,
@@ -29,6 +30,7 @@ __all__ = [
     # Orchestration
     "load_specs",
     "get_specs",
+    "get_specs_path_for_mode",
     "validate_config",
     "decide_what_to_run",
     "plan_requires_input",

--- a/packages/analysis-core/src/analysis_core/core/orchestration.py
+++ b/packages/analysis-core/src/analysis_core/core/orchestration.py
@@ -23,6 +23,12 @@ _specs: list[dict[str, Any]] = []
 _PACKAGE_DIR = Path(__file__).parent.parent
 
 
+def get_specs_path_for_mode(analysis_mode: str) -> Path:
+    """Return the pipeline specs file for the requested analysis mode."""
+    specs_name = "llm_grouping_specs.json" if analysis_mode == "llm_grouping" else "hierarchical_specs.json"
+    return _PACKAGE_DIR / "specs" / specs_name
+
+
 def sync_without_html_keys(config: dict[str, Any]) -> None:
     """Keep ``without_html`` and ``without-html`` aligned in-place."""
     if "without-html" in config:
@@ -142,6 +148,7 @@ def validate_config(config: dict[str, Any], specs: list[dict[str, Any]] | None =
         "is_pubcom",
         "is_embedded_at_local",
         "provider",
+        "analysis_mode",
         "local_llm_address",
         "enable_source_link",
         "without_html",
@@ -464,16 +471,16 @@ def initialization(
         output_base_dir = Path("outputs")
     if input_base_dir is None:
         input_base_dir = Path("inputs")
-    if specs_path is None:
-        specs_path = _PACKAGE_DIR / "specs" / "hierarchical_specs.json"
-
-    # Load specs
-    specs = load_specs(specs_path)
-
     # Load config
     job_name = config_path.stem
     with open(config_path, "r", encoding="utf-8") as f:
         config = json.load(f)
+
+    if specs_path is None:
+        specs_path = get_specs_path_for_mode(config.get("analysis_mode", "hierarchical"))
+
+    # Load specs
+    specs = load_specs(specs_path)
 
     # Validate config
     validate_config(config, specs)
@@ -563,6 +570,14 @@ def initialization(
                 default_prompt = get_default_prompt(step)
                 if default_prompt:
                     config[step]["prompt"] = default_prompt
+
+        if step == "llm_grouping":
+            from analysis_core.prompts import get_default_prompt
+
+            if not config[step].get("discovery_prompt"):
+                config[step]["discovery_prompt"] = get_default_prompt("llm_grouping_discovery") or ""
+            if not config[step].get("assignment_prompt"):
+                config[step]["assignment_prompt"] = get_default_prompt("llm_grouping_assignment") or ""
 
     # Create output directory if needed
     output_path = output_base_dir / output_dir

--- a/packages/analysis-core/src/analysis_core/core/orchestration.py
+++ b/packages/analysis-core/src/analysis_core/core/orchestration.py
@@ -25,6 +25,8 @@ _PACKAGE_DIR = Path(__file__).parent.parent
 
 def get_specs_path_for_mode(analysis_mode: str) -> Path:
     """Return the pipeline specs file for the requested analysis mode."""
+    if analysis_mode not in {"hierarchical", "llm_grouping"}:
+        raise ValueError(f"Unknown analysis_mode: {analysis_mode}")
     specs_name = "llm_grouping_specs.json" if analysis_mode == "llm_grouping" else "hierarchical_specs.json"
     return _PACKAGE_DIR / "specs" / specs_name
 

--- a/packages/analysis-core/src/analysis_core/orchestrator.py
+++ b/packages/analysis-core/src/analysis_core/orchestrator.py
@@ -58,6 +58,7 @@ DEFAULT_STEP_MODULES: dict[str, tuple[str, str]] = {
         "analysis_core.steps.hierarchical_merge_labelling",
         "hierarchical_merge_labelling",
     ),
+    "llm_grouping": ("analysis_core.steps.llm_grouping", "llm_grouping"),
     "hierarchical_overview": ("analysis_core.steps.hierarchical_overview", "hierarchical_overview"),
     "hierarchical_aggregation": ("analysis_core.steps.hierarchical_aggregation", "hierarchical_aggregation"),
     "hierarchical_visualization": ("analysis_core.steps.hierarchical_visualization", "hierarchical_visualization"),
@@ -331,7 +332,12 @@ class PipelineOrchestrator:
             Initialized PipelineOrchestrator
         """
         from analysis_core.compat import normalize_config
-        from analysis_core.core.orchestration import _PACKAGE_DIR, decide_what_to_run, load_specs, validate_api_keys
+        from analysis_core.core.orchestration import (
+            decide_what_to_run,
+            get_specs_path_for_mode,
+            load_specs,
+            validate_api_keys,
+        )
 
         # Normalize config with defaults
         normalized = normalize_config(config.copy())
@@ -362,7 +368,7 @@ class PipelineOrchestrator:
             previous = json.loads(status_file.read_text(encoding="utf-8"))
             normalized["previous"] = previous
 
-        specs = load_specs(_PACKAGE_DIR / "specs" / "hierarchical_specs.json")
+        specs = load_specs(get_specs_path_for_mode(normalized.get("analysis_mode", "hierarchical")))
         if "plan" in config:
             normalized["plan"] = config["plan"]
         else:
@@ -387,14 +393,15 @@ class PipelineOrchestrator:
         from analysis_core.compat import create_step_context_from_config
         from analysis_core.workflow import WorkflowEngine
         from analysis_core.workflow.definition import StepResult as WorkflowStepResult
-        from analysis_core.workflows import HIERARCHICAL_DEFAULT_WORKFLOW
+        from analysis_core.workflows import get_workflow_for_mode
 
         start_time = datetime.now()
-        workflow = HIERARCHICAL_DEFAULT_WORKFLOW
+        workflow = get_workflow_for_mode(self.config.get("analysis_mode", "hierarchical"))
         plan_step_to_workflow_step = {
             "extraction": "extraction",
             "embedding": "embedding",
             "hierarchical_clustering": "clustering",
+            "llm_grouping": "llm_grouping",
             "hierarchical_initial_labelling": "initial_labelling",
             "hierarchical_merge_labelling": "merge_labelling",
             "hierarchical_overview": "overview",

--- a/packages/analysis-core/src/analysis_core/plugins/builtin/__init__.py
+++ b/packages/analysis-core/src/analysis_core/plugins/builtin/__init__.py
@@ -14,10 +14,11 @@ def register_all(registry: "PluginRegistry") -> None:
     """
     Register all built-in plugins with the registry.
 
-    This function registers the 8 standard analysis steps:
+    This function registers the standard analysis steps:
     - analysis.extraction
     - analysis.embedding
     - analysis.hierarchical_clustering
+    - analysis.llm_grouping
     - analysis.hierarchical_initial_labelling
     - analysis.hierarchical_merge_labelling
     - analysis.hierarchical_overview
@@ -36,11 +37,13 @@ def register_all(registry: "PluginRegistry") -> None:
     from analysis_core.plugins.builtin.hierarchical_merge_labelling import hierarchical_merge_labelling_plugin
     from analysis_core.plugins.builtin.hierarchical_overview import hierarchical_overview_plugin
     from analysis_core.plugins.builtin.hierarchical_visualization import hierarchical_visualization_plugin
+    from analysis_core.plugins.builtin.llm_grouping import llm_grouping_plugin
 
     plugins = [
         extraction_plugin,
         embedding_plugin,
         hierarchical_clustering_plugin,
+        llm_grouping_plugin,
         hierarchical_initial_labelling_plugin,
         hierarchical_merge_labelling_plugin,
         hierarchical_overview_plugin,

--- a/packages/analysis-core/src/analysis_core/plugins/builtin/llm_grouping.py
+++ b/packages/analysis-core/src/analysis_core/plugins/builtin/llm_grouping.py
@@ -1,0 +1,49 @@
+"""LLM grouping step plugin."""
+
+from typing import Any
+
+from analysis_core.plugin import StepContext, StepInputs, StepOutputs, step_plugin
+from analysis_core.plugins.builtin._legacy_config import build_legacy_runtime_config
+
+
+@step_plugin(
+    id="analysis.llm_grouping",
+    version="1.0.0",
+    name="LLM Grouping",
+    description="Assign arguments to top-level groups with LLM while preserving embedding-based coordinates",
+    inputs=["arguments", "embeddings"],
+    outputs=["clusters", "merge_labels"],
+    use_llm=True,
+)
+def llm_grouping_plugin(
+    ctx: StepContext,
+    inputs: StepInputs,
+    config: dict[str, Any],
+) -> StepOutputs:
+    """Run LLM-driven grouping and emit viewer-compatible cluster artifacts."""
+    from analysis_core.steps.llm_grouping import llm_grouping as grouping_impl
+
+    step_config = config.get("llm_grouping", config)
+    legacy_config = build_legacy_runtime_config(ctx, inputs, include_token_usage=True)
+    legacy_config["question"] = inputs.config.get("question", "")
+    legacy_config["hierarchical_clustering"] = inputs.config.get("hierarchical_clustering", {})
+    legacy_config["llm_grouping"] = {
+        "group_count": step_config.get("group_count"),
+        "discovery_sample_size": step_config.get("discovery_sample_size", 80),
+        "assignment_batch_size": step_config.get("assignment_batch_size", 25),
+        "discovery_prompt": step_config.get("discovery_prompt", ""),
+        "assignment_prompt": step_config.get("assignment_prompt", ""),
+        "model": step_config.get("model", ctx.model),
+    }
+
+    grouping_impl(legacy_config)
+
+    return StepOutputs(
+        artifacts={
+            "clusters": ctx.output_dir / "hierarchical_clusters.csv",
+            "merge_labels": ctx.output_dir / "hierarchical_merge_labels.csv",
+        },
+        token_usage=legacy_config.get("total_token_usage", 0),
+        token_input=legacy_config.get("token_usage_input", 0),
+        token_output=legacy_config.get("token_usage_output", 0),
+    )

--- a/packages/analysis-core/src/analysis_core/prompts/__init__.py
+++ b/packages/analysis-core/src/analysis_core/prompts/__init__.py
@@ -102,6 +102,27 @@ OVERVIEW_PROMPT = """/system
 出力は日本語で行ってください。
 """
 
+LLM_GROUPING_DISCOVERY_PROMPT = """あなたは意見分析のアシスタントです。
+与えられた意見群を、内容上まとまりのある少数のグループへ整理してください。
+
+# 指示
+- グループは内容ベースでまとめてください
+- 賛成 / 反対が同じトピックに混ざるなら、その違いが重要かどうかを見て判断してください
+- 出力する group_id は g1, g2, ... の形式にしてください
+- label は短く具体的に、description は何がそのグループを特徴づけるかを2〜3文で説明してください
+- JSON だけを返してください
+"""
+
+LLM_GROUPING_ASSIGNMENT_PROMPT = """あなたは意見分析のアシスタントです。
+既知のグループ定義に基づいて、各意見を最も近いグループへ1つだけ割り当ててください。
+
+# 指示
+- 新しいグループは作らないでください
+- group_id は与えられた候補から必ず1つ選んでください
+- 意見文そのものを優先して判断し、表面的な単語一致だけに引きずられないでください
+- JSON だけを返してください
+"""
+
 
 # Mapping from step names to default prompts
 DEFAULT_PROMPTS = {
@@ -109,6 +130,8 @@ DEFAULT_PROMPTS = {
     "hierarchical_initial_labelling": INITIAL_LABELLING_PROMPT,
     "hierarchical_merge_labelling": MERGE_LABELLING_PROMPT,
     "hierarchical_overview": OVERVIEW_PROMPT,
+    "llm_grouping_discovery": LLM_GROUPING_DISCOVERY_PROMPT,
+    "llm_grouping_assignment": LLM_GROUPING_ASSIGNMENT_PROMPT,
 }
 
 

--- a/packages/analysis-core/src/analysis_core/specs/llm_grouping_specs.json
+++ b/packages/analysis-core/src/analysis_core/specs/llm_grouping_specs.json
@@ -1,0 +1,63 @@
+[
+  {
+    "step": "extraction",
+    "filename": "args.csv",
+    "dependencies": { "params": ["limit"], "steps": [] },
+    "options": {
+      "limit": 1000,
+      "workers": 1,
+      "properties": [],
+      "categories": {},
+      "category_batch_size": 5
+    },
+    "use_llm": true
+  },
+  {
+    "step": "embedding",
+    "filename": "embeddings.pkl",
+    "dependencies": { "params": ["model"], "steps": ["extraction"] },
+    "options": { "model": "text-embedding-3-small" }
+  },
+  {
+    "step": "llm_grouping",
+    "filename": "hierarchical_clusters.csv",
+    "dependencies": {
+      "params": ["group_count", "discovery_sample_size", "assignment_batch_size"],
+      "steps": ["extraction", "embedding"]
+    },
+    "options": {
+      "group_count": null,
+      "discovery_sample_size": 80,
+      "assignment_batch_size": 25,
+      "discovery_prompt": "",
+      "assignment_prompt": "",
+      "model": "gpt-4o-mini"
+    },
+    "use_llm": true
+  },
+  {
+    "step": "hierarchical_overview",
+    "filename": "hierarchical_overview.txt",
+    "dependencies": { "params": [], "steps": ["llm_grouping"] },
+    "options": {},
+    "use_llm": true
+  },
+  {
+    "step": "hierarchical_aggregation",
+    "filename": "hierarchical_result.json",
+    "dependencies": {
+      "params": [],
+      "steps": ["extraction", "llm_grouping", "hierarchical_overview"]
+    },
+    "options": {
+      "sampling_num": 5000,
+      "hidden_properties": {}
+    }
+  },
+  {
+    "step": "hierarchical_visualization",
+    "filename": "report",
+    "dependencies": { "params": ["replacements"], "steps": ["hierarchical_aggregation"] },
+    "options": { "replacements": [] }
+  }
+]

--- a/packages/analysis-core/src/analysis_core/specs/llm_grouping_specs.json
+++ b/packages/analysis-core/src/analysis_core/specs/llm_grouping_specs.json
@@ -22,7 +22,7 @@
     "step": "llm_grouping",
     "filename": "hierarchical_clusters.csv",
     "dependencies": {
-      "params": ["group_count", "discovery_sample_size", "assignment_batch_size"],
+      "params": ["group_count", "discovery_sample_size", "assignment_batch_size", "discovery_prompt", "assignment_prompt"],
       "steps": ["extraction", "embedding"]
     },
     "options": {

--- a/packages/analysis-core/src/analysis_core/steps/__init__.py
+++ b/packages/analysis-core/src/analysis_core/steps/__init__.py
@@ -12,6 +12,7 @@ _STEP_MODULES = {
     "hierarchical_merge_labelling": "analysis_core.steps.hierarchical_merge_labelling",
     "hierarchical_overview": "analysis_core.steps.hierarchical_overview",
     "hierarchical_visualization": "analysis_core.steps.hierarchical_visualization",
+    "llm_grouping": "analysis_core.steps.llm_grouping",
 }
 
 __all__ = [
@@ -23,6 +24,7 @@ __all__ = [
     "hierarchical_overview",
     "hierarchical_aggregation",
     "hierarchical_visualization",
+    "llm_grouping",
 ]
 
 

--- a/packages/analysis-core/src/analysis_core/steps/llm_grouping.py
+++ b/packages/analysis-core/src/analysis_core/steps/llm_grouping.py
@@ -1,0 +1,281 @@
+"""LLM-driven grouping while preserving embedding-based coordinates for visualization."""
+
+from __future__ import annotations
+
+import json
+import os
+import pickle
+from collections import Counter
+from dataclasses import dataclass
+
+import numpy as np
+import polars as pl
+from pydantic import BaseModel, Field
+
+from analysis_core.services.llm import request_to_chat_ai
+from analysis_core.steps.hierarchical_clustering import (
+    _load_clustering_dependencies,
+    calculate_recommended_cluster_nums,
+)
+
+LLM_GROUPING_TIMEOUT_SECONDS = 300
+
+
+class ProposedGroup(BaseModel):
+    """Single discovered group."""
+
+    group_id: str = Field(..., description="Short stable identifier like g1")
+    label: str = Field(..., description="Human readable group label")
+    description: str = Field(..., description="Explanation of what belongs to the group")
+
+
+class GroupDiscoveryResponse(BaseModel):
+    """Response schema for top-level group discovery."""
+
+    groups: list[ProposedGroup]
+
+
+class GroupAssignment(BaseModel):
+    """Assignment of one argument to one discovered group."""
+
+    arg_id: str = Field(..., description="Argument id from the input batch")
+    group_id: str = Field(..., description="One of the discovered group ids")
+
+
+class GroupAssignmentResponse(BaseModel):
+    """Response schema for batch assignments."""
+
+    assignments: list[GroupAssignment]
+
+
+@dataclass
+class GroupDefinition:
+    """Normalized discovered group."""
+
+    group_id: str
+    label: str
+    description: str
+
+
+def llm_grouping(config: dict) -> None:
+    """Generate `hierarchical_clusters.csv` and `hierarchical_merge_labels.csv` via LLM grouping."""
+    dataset = config["output_dir"]
+    output_base_dir = config.get("_output_base_dir", "outputs")
+    args_df = pl.read_csv(f"{output_base_dir}/{dataset}/args.csv", columns=["arg-id", "argument"])
+    arg_ids = args_df["arg-id"].to_list()
+    arguments = args_df["argument"].to_list()
+
+    llm_config = config["llm_grouping"]
+    group_count = _resolve_group_count(config, len(arg_ids))
+    groups = _discover_groups(
+        arguments=arguments,
+        question=config.get("question", ""),
+        group_count=group_count,
+        sample_size=llm_config.get("discovery_sample_size", 80),
+        prompt=llm_config["discovery_prompt"],
+        model=llm_config["model"],
+        provider=config["provider"],
+        local_llm_address=config.get("local_llm_address"),
+        config=config,
+    )
+    assignments = _assign_groups(
+        arg_ids=arg_ids,
+        arguments=arguments,
+        groups=groups,
+        batch_size=llm_config.get("assignment_batch_size", 25),
+        prompt=llm_config["assignment_prompt"],
+        model=llm_config["model"],
+        provider=config["provider"],
+        local_llm_address=config.get("local_llm_address"),
+        config=config,
+    )
+    points = _project_embeddings_to_xy(output_base_dir, dataset, arg_ids)
+
+    clusters_path = f"{output_base_dir}/{dataset}/hierarchical_clusters.csv"
+    merge_labels_path = f"{output_base_dir}/{dataset}/hierarchical_merge_labels.csv"
+
+    cluster_rows = []
+    for arg_id, argument, (x, y) in zip(arg_ids, arguments, points, strict=True):
+        cluster_rows.append(
+            {
+                "arg-id": arg_id,
+                "argument": argument,
+                "x": float(x),
+                "y": float(y),
+                "cluster-level-1-id": assignments[arg_id],
+            }
+        )
+
+    pl.DataFrame(cluster_rows).write_csv(clusters_path)
+    _write_merge_labels(merge_labels_path, groups, assignments)
+
+
+def _resolve_group_count(config: dict, argument_count: int) -> int:
+    step_config = config.get("llm_grouping", {})
+    explicit = step_config.get("group_count")
+    if explicit:
+        return min(max(1, int(explicit)), max(1, argument_count))
+
+    cluster_nums = config.get("hierarchical_clustering", {}).get("cluster_nums")
+    if cluster_nums:
+        return min(max(1, int(cluster_nums[0])), max(1, argument_count))
+
+    return calculate_recommended_cluster_nums(max(2, argument_count))[0]
+
+
+def _discover_groups(
+    *,
+    arguments: list[str],
+    question: str,
+    group_count: int,
+    sample_size: int,
+    prompt: str,
+    model: str,
+    provider: str,
+    local_llm_address: str | None,
+    config: dict,
+) -> list[GroupDefinition]:
+    sample_n = min(len(arguments), max(1, sample_size))
+    sample_df = pl.DataFrame({"argument": arguments}).sample(n=sample_n, shuffle=True, seed=0)
+    sample_lines = "\n".join(f"- {argument}" for argument in sample_df["argument"].to_list())
+    user_message = (
+        f"問い:\n{question}\n\n"
+        f"以下の意見群を {group_count} 個前後のグループに整理してください。\n"
+        "出力する group_id は g1, g2, ... の形式にしてください。\n\n"
+        f"{sample_lines}"
+    )
+    response_text, token_input, token_output, token_total = request_to_chat_ai(
+        messages=[
+            {"role": "system", "content": prompt},
+            {"role": "user", "content": user_message},
+        ],
+        model=model,
+        provider=provider,
+        json_schema=GroupDiscoveryResponse,
+        local_llm_address=local_llm_address,
+        user_api_key=os.getenv("USER_API_KEY"),
+        timeout_seconds=LLM_GROUPING_TIMEOUT_SECONDS,
+    )
+    _accumulate_token_usage(config, token_input, token_output, token_total)
+    response_json = json.loads(response_text) if isinstance(response_text, str) else response_text
+    raw_groups = response_json.get("groups", [])
+    if not raw_groups:
+        raise ValueError("llm_grouping group discovery returned no groups")
+
+    normalized_groups = []
+    for index, group in enumerate(raw_groups, start=1):
+        normalized_groups.append(
+            GroupDefinition(
+                group_id=f"g{index}",
+                label=group.get("label", f"グループ {index}"),
+                description=group.get("description", ""),
+            )
+        )
+    return normalized_groups
+
+
+def _assign_groups(
+    *,
+    arg_ids: list[str],
+    arguments: list[str],
+    groups: list[GroupDefinition],
+    batch_size: int,
+    prompt: str,
+    model: str,
+    provider: str,
+    local_llm_address: str | None,
+    config: dict,
+) -> dict[str, str]:
+    assignments: dict[str, str] = {}
+    allowed_group_ids = {group.group_id for group in groups}
+    group_text = "\n".join(f"- {group.group_id}: {group.label}\n  {group.description}" for group in groups)
+
+    for start in range(0, len(arg_ids), max(1, batch_size)):
+        batch_ids = arg_ids[start : start + batch_size]
+        batch_arguments = arguments[start : start + batch_size]
+        batch_lines = "\n".join(
+            f"- {arg_id}: {argument}" for arg_id, argument in zip(batch_ids, batch_arguments, strict=True)
+        )
+        user_message = (
+            "既知のグループ定義:\n"
+            f"{group_text}\n\n"
+            "各意見を最も近いグループへ 1 つだけ割り当ててください。\n"
+            "新しいグループは作らず、group_id は必ず既知のものから選んでください。\n\n"
+            f"意見一覧:\n{batch_lines}"
+        )
+        response_text, token_input, token_output, token_total = request_to_chat_ai(
+            messages=[
+                {"role": "system", "content": prompt},
+                {"role": "user", "content": user_message},
+            ],
+            model=model,
+            provider=provider,
+            json_schema=GroupAssignmentResponse,
+            local_llm_address=local_llm_address,
+            user_api_key=os.getenv("USER_API_KEY"),
+            timeout_seconds=LLM_GROUPING_TIMEOUT_SECONDS,
+        )
+        _accumulate_token_usage(config, token_input, token_output, token_total)
+        response_json = json.loads(response_text) if isinstance(response_text, str) else response_text
+        batch_assignments = {
+            assignment.get("arg_id"): assignment.get("group_id")
+            for assignment in response_json.get("assignments", [])
+            if assignment.get("arg_id")
+        }
+
+        fallback_group_id = groups[0].group_id
+        for arg_id in batch_ids:
+            group_id = batch_assignments.get(arg_id, fallback_group_id)
+            if group_id not in allowed_group_ids:
+                group_id = fallback_group_id
+            assignments[arg_id] = group_id
+
+    return assignments
+
+
+def _project_embeddings_to_xy(output_base_dir: str, dataset: str, arg_ids: list[str]) -> np.ndarray:
+    UMAP, _, _ = _load_clustering_dependencies()
+    with open(f"{output_base_dir}/{dataset}/embeddings.pkl", "rb") as f:
+        embeddings_data = pickle.load(f)
+
+    if isinstance(embeddings_data, list):
+        embed_by_id = {item["arg-id"]: item["embedding"] for item in embeddings_data}
+        embeddings_array = np.asarray([embed_by_id[arg_id] for arg_id in arg_ids])
+    else:
+        embeddings_array = np.asarray(embeddings_data["embedding"].values.tolist())
+
+    n_samples = embeddings_array.shape[0]
+    n_neighbors = max(2, min(15, n_samples - 1)) if n_samples > 1 else 1
+    if n_samples < 2:
+        return np.zeros((n_samples, 2))
+
+    umap_model = UMAP(n_components=2, n_neighbors=n_neighbors)
+    return umap_model.fit_transform(embeddings_array)
+
+
+def _write_merge_labels(path: str, groups: list[GroupDefinition], assignments: dict[str, str]) -> None:
+    counts = Counter(assignments.values())
+    sorted_groups = sorted(groups, key=lambda group: counts.get(group.group_id, 0), reverse=True)
+    total_groups = max(1, len(sorted_groups))
+    rows = []
+    for index, group in enumerate(sorted_groups):
+        rows.append(
+            {
+                "level": 1,
+                "id": group.group_id,
+                "label": group.label,
+                "description": group.description,
+                "value": counts.get(group.group_id, 0),
+                "parent": "0",
+                "density_rank_percentile": (total_groups - index - 1) / max(1, total_groups - 1)
+                if total_groups > 1
+                else 0.0,
+            }
+        )
+    pl.DataFrame(rows).write_csv(path)
+
+
+def _accumulate_token_usage(config: dict, token_input: int, token_output: int, token_total: int) -> None:
+    config["total_token_usage"] = config.get("total_token_usage", 0) + token_total
+    config["token_usage_input"] = config.get("token_usage_input", 0) + token_input
+    config["token_usage_output"] = config.get("token_usage_output", 0) + token_output

--- a/packages/analysis-core/src/analysis_core/steps/llm_grouping.py
+++ b/packages/analysis-core/src/analysis_core/steps/llm_grouping.py
@@ -190,9 +190,10 @@ def _assign_groups(
     allowed_group_ids = {group.group_id for group in groups}
     group_text = "\n".join(f"- {group.group_id}: {group.label}\n  {group.description}" for group in groups)
 
-    for start in range(0, len(arg_ids), max(1, batch_size)):
-        batch_ids = arg_ids[start : start + batch_size]
-        batch_arguments = arguments[start : start + batch_size]
+    safe_batch_size = max(1, batch_size)
+    for start in range(0, len(arg_ids), safe_batch_size):
+        batch_ids = arg_ids[start : start + safe_batch_size]
+        batch_arguments = arguments[start : start + safe_batch_size]
         batch_lines = "\n".join(
             f"- {arg_id}: {argument}" for arg_id, argument in zip(batch_ids, batch_arguments, strict=True)
         )
@@ -239,7 +240,19 @@ def _project_embeddings_to_xy(output_base_dir: str, dataset: str, arg_ids: list[
         embeddings_data = pickle.load(f)
 
     if isinstance(embeddings_data, list):
-        embed_by_id = {item["arg-id"]: item["embedding"] for item in embeddings_data}
+        embed_by_id = {}
+        for index, item in enumerate(embeddings_data):
+            item_arg_id = item.get("arg-id") if isinstance(item, dict) else None
+            if item_arg_id is None and index < len(arg_ids):
+                item_arg_id = arg_ids[index]
+            if item_arg_id is None:
+                continue
+            embed_by_id[item_arg_id] = item["embedding"]
+
+        missing_arg_ids = [arg_id for arg_id in arg_ids if arg_id not in embed_by_id]
+        if missing_arg_ids:
+            raise ValueError(f"Missing embeddings for arg ids: {missing_arg_ids}")
+
         embeddings_array = np.asarray([embed_by_id[arg_id] for arg_id in arg_ids])
     else:
         embeddings_array = np.asarray(embeddings_data["embedding"].values.tolist())

--- a/packages/analysis-core/src/analysis_core/workflows/__init__.py
+++ b/packages/analysis-core/src/analysis_core/workflows/__init__.py
@@ -9,8 +9,22 @@ from analysis_core.workflows.hierarchical_default import (
     HIERARCHICAL_DEFAULT_WORKFLOW,
     create_hierarchical_workflow,
 )
+from analysis_core.workflows.llm_grouping_compatible import (
+    LLM_GROUPING_COMPATIBLE_WORKFLOW,
+    create_llm_grouping_workflow,
+)
+
+
+def get_workflow_for_mode(analysis_mode: str):
+    """Return the canonical workflow for a configured analysis mode."""
+    if analysis_mode == "llm_grouping":
+        return LLM_GROUPING_COMPATIBLE_WORKFLOW
+    return HIERARCHICAL_DEFAULT_WORKFLOW
 
 __all__ = [
     "HIERARCHICAL_DEFAULT_WORKFLOW",
     "create_hierarchical_workflow",
+    "LLM_GROUPING_COMPATIBLE_WORKFLOW",
+    "create_llm_grouping_workflow",
+    "get_workflow_for_mode",
 ]

--- a/packages/analysis-core/src/analysis_core/workflows/llm_grouping_compatible.py
+++ b/packages/analysis-core/src/analysis_core/workflows/llm_grouping_compatible.py
@@ -1,0 +1,81 @@
+"""Workflow that uses LLM for grouping while keeping embedding-based coordinates."""
+
+from analysis_core.workflow import WorkflowDefinition, WorkflowStep
+
+
+def create_llm_grouping_workflow(include_visualization: bool = True) -> WorkflowDefinition:
+    """Create the short-term compatibility workflow for LLM grouping."""
+    steps = [
+        WorkflowStep(
+            id="extraction",
+            plugin="analysis.extraction",
+            config={
+                "limit": "${config.extraction.limit}",
+                "workers": "${config.extraction.workers}",
+                "prompt": "${config.extraction.prompt}",
+                "model": "${config.extraction.model}",
+                "properties": "${config.extraction.properties}",
+            },
+        ),
+        WorkflowStep(
+            id="embedding",
+            plugin="analysis.embedding",
+            depends_on=["extraction"],
+            config={
+                "model": "${config.embedding.model}",
+            },
+        ),
+        WorkflowStep(
+            id="llm_grouping",
+            plugin="analysis.llm_grouping",
+            depends_on=["extraction", "embedding"],
+            config={
+                "group_count": "${config.llm_grouping.group_count}",
+                "discovery_sample_size": "${config.llm_grouping.discovery_sample_size}",
+                "assignment_batch_size": "${config.llm_grouping.assignment_batch_size}",
+                "discovery_prompt": "${config.llm_grouping.discovery_prompt}",
+                "assignment_prompt": "${config.llm_grouping.assignment_prompt}",
+                "model": "${config.llm_grouping.model}",
+            },
+        ),
+        WorkflowStep(
+            id="overview",
+            plugin="analysis.hierarchical_overview",
+            depends_on=["llm_grouping"],
+            config={
+                "prompt": "${config.hierarchical_overview.prompt}",
+                "model": "${config.hierarchical_overview.model}",
+            },
+        ),
+        WorkflowStep(
+            id="aggregation",
+            plugin="analysis.hierarchical_aggregation",
+            depends_on=["extraction", "llm_grouping", "overview"],
+            config={
+                "hidden_properties": "${config.hierarchical_aggregation.hidden_properties}",
+            },
+        ),
+    ]
+
+    if include_visualization:
+        steps.append(
+            WorkflowStep(
+                id="visualization",
+                plugin="analysis.hierarchical_visualization",
+                depends_on=["aggregation"],
+                optional=True,
+                condition="${not config.without_html}",
+                config={},
+            )
+        )
+
+    return WorkflowDefinition(
+        id="llm-grouping-compatible",
+        version="1.0.0",
+        name="LLM Grouping (Compatibility)",
+        description="LLM-based grouping with embedding-derived scatter coordinates for viewer compatibility",
+        steps=steps,
+    )
+
+
+LLM_GROUPING_COMPATIBLE_WORKFLOW = create_llm_grouping_workflow(include_visualization=True)

--- a/packages/analysis-core/tests/test_compat.py
+++ b/packages/analysis-core/tests/test_compat.py
@@ -13,6 +13,7 @@ class TestNormalizeConfig:
 
         assert result["model"] == "gpt-4o-mini"
         assert result["provider"] == "openai"
+        assert result["analysis_mode"] == "hierarchical"
         assert result["is_embedded_at_local"] is False
         assert result["is_pubcom"] is False
 
@@ -44,6 +45,18 @@ class TestNormalizeConfig:
         assert "hierarchical_clustering" in result
         assert "cluster_nums" not in result["hierarchical_clustering"]
 
+    def test_fills_llm_grouping_defaults(self):
+        """Test that llm_grouping defaults are filled in."""
+        config = {}
+        result = normalize_config(config)
+
+        assert "llm_grouping" in result
+        assert result["llm_grouping"]["group_count"] is None
+        assert result["llm_grouping"]["discovery_sample_size"] == 80
+        assert result["llm_grouping"]["assignment_batch_size"] == 25
+        assert len(result["llm_grouping"]["discovery_prompt"]) > 0
+        assert len(result["llm_grouping"]["assignment_prompt"]) > 0
+
     def test_fills_labelling_defaults(self):
         """Test that labelling defaults are filled in."""
         config = {}
@@ -69,6 +82,7 @@ class TestNormalizeConfig:
             "hierarchical_overview",
             "hierarchical_aggregation",
             "hierarchical_visualization",
+            "llm_grouping",
         ]
 
         for step in steps:

--- a/packages/analysis-core/tests/test_imports.py
+++ b/packages/analysis-core/tests/test_imports.py
@@ -128,6 +128,12 @@ class TestStepImports:
 
         assert hierarchical_merge_labelling is not None
 
+    def test_llm_grouping_step(self):
+        """Test LLM grouping step import."""
+        from analysis_core.steps import llm_grouping
+
+        assert llm_grouping is not None
+
     def test_overview_step(self):
         """Test overview step import."""
         from analysis_core.steps import hierarchical_overview
@@ -157,6 +163,7 @@ class TestStepImports:
             hierarchical_merge_labelling,
             hierarchical_overview,
             hierarchical_visualization,
+            llm_grouping,
         )
 
         steps = [
@@ -165,12 +172,13 @@ class TestStepImports:
             hierarchical_clustering,
             hierarchical_initial_labelling,
             hierarchical_merge_labelling,
+            llm_grouping,
             hierarchical_overview,
             hierarchical_aggregation,
             hierarchical_visualization,
         ]
         assert all(step is not None for step in steps)
-        assert len(steps) == 8
+        assert len(steps) == 9
 
 
 class TestConfigModule:

--- a/packages/analysis-core/tests/test_llm_grouping.py
+++ b/packages/analysis-core/tests/test_llm_grouping.py
@@ -1,0 +1,136 @@
+"""Tests for the LLM grouping workflow mode."""
+
+import importlib
+import pickle
+
+import numpy as np
+import polars as pl
+
+from analysis_core.orchestrator import PipelineOrchestrator
+
+
+def test_run_workflow_uses_llm_grouping_workflow_when_mode_is_enabled(tmp_path, monkeypatch):
+    """Workflow selection should honor analysis_mode=llm_grouping."""
+    from analysis_core.workflow.definition import StepResult as WorkflowStepResult
+    from analysis_core.workflow.definition import WorkflowResult
+
+    orchestrator = PipelineOrchestrator.from_dict(
+        config={
+            "name": "demo",
+            "input": "demo",
+            "question": "Test?",
+            "provider": "local",
+            "model": "dummy",
+            "analysis_mode": "llm_grouping",
+        },
+        output_dir="demo",
+        output_base_dir=tmp_path / "outputs",
+        input_base_dir=tmp_path / "inputs",
+    )
+
+    seen = {}
+
+    class FakeEngine:
+        def run(self, workflow, config, ctx, on_step_start=None, on_step_complete=None, skip_steps=None):
+            seen["workflow_id"] = workflow.id
+            result = WorkflowResult(workflow_id=workflow.id)
+            step_result = WorkflowStepResult(step_id="llm_grouping", success=True)
+            result.step_results["llm_grouping"] = step_result
+            if on_step_start:
+                on_step_start("llm_grouping")
+            if on_step_complete:
+                on_step_complete("llm_grouping", step_result)
+            return result
+
+    monkeypatch.setattr("analysis_core.workflow.WorkflowEngine", FakeEngine)
+
+    result = orchestrator.run_workflow()
+
+    assert seen["workflow_id"] == "llm-grouping-compatible"
+    assert [step.step_name for step in result.steps] == ["llm_grouping"]
+
+
+def test_llm_grouping_step_creates_viewer_compatible_outputs(tmp_path, monkeypatch):
+    """The step should cluster arguments directly with LLM and preserve embedding-based coordinates."""
+    llm_grouping_step = importlib.import_module("analysis_core.steps.llm_grouping")
+
+    output_dir = tmp_path / "outputs" / "demo"
+    output_dir.mkdir(parents=True)
+    args_df = pl.DataFrame(
+        {
+            "arg-id": ["a1", "a2", "a3"],
+            "argument": ["電車を増やしてほしい", "バスの本数が足りない", "公園を増やしてほしい"],
+        }
+    )
+    args_df.write_csv(output_dir / "args.csv")
+    with open(output_dir / "embeddings.pkl", "wb") as f:
+        pickle.dump(
+            [
+                {"arg-id": "a1", "embedding": [0.1, 0.2, 0.3]},
+                {"arg-id": "a2", "embedding": [0.2, 0.1, 0.3]},
+                {"arg-id": "a3", "embedding": [0.9, 0.8, 0.7]},
+            ],
+            f,
+        )
+
+    class FakeUMAP:
+        def __init__(self, n_components, n_neighbors):
+            self.n_components = n_components
+            self.n_neighbors = n_neighbors
+
+        def fit_transform(self, embeddings):
+            return np.array([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]])
+
+    monkeypatch.setattr(llm_grouping_step, "_load_clustering_dependencies", lambda: (FakeUMAP, None, None))
+
+    responses = [
+        {
+            "groups": [
+                {"group_id": "g1", "label": "交通", "description": "公共交通に関する意見"},
+                {"group_id": "g2", "label": "公園", "description": "公園整備に関する意見"},
+            ]
+        },
+        {
+            "assignments": [
+                {"arg_id": "a1", "group_id": "g1"},
+                {"arg_id": "a2", "group_id": "g1"},
+            ]
+        },
+        {
+            "assignments": [
+                {"arg_id": "a3", "group_id": "g2"},
+            ]
+        },
+    ]
+
+    def fake_request_to_chat_ai(**kwargs):
+        response = responses.pop(0)
+        return response, 10, 5, 15
+
+    monkeypatch.setattr(llm_grouping_step, "request_to_chat_ai", fake_request_to_chat_ai)
+
+    config = {
+        "output_dir": "demo",
+        "_output_base_dir": str(tmp_path / "outputs"),
+        "question": "住みやすい街にするには？",
+        "provider": "local",
+        "llm_grouping": {
+            "group_count": 2,
+            "discovery_sample_size": 3,
+            "assignment_batch_size": 2,
+            "discovery_prompt": "discover",
+            "assignment_prompt": "assign",
+            "model": "dummy-model",
+        },
+        "hierarchical_clustering": {"cluster_nums": [2, 4]},
+    }
+
+    llm_grouping_step.llm_grouping(config)
+
+    clusters = pl.read_csv(output_dir / "hierarchical_clusters.csv")
+    labels = pl.read_csv(output_dir / "hierarchical_merge_labels.csv")
+
+    assert clusters.columns == ["arg-id", "argument", "x", "y", "cluster-level-1-id"]
+    assert clusters["cluster-level-1-id"].to_list() == ["g1", "g1", "g2"]
+    assert labels.select(["id", "label"]).to_dict(as_series=False) == {"id": ["g1", "g2"], "label": ["交通", "公園"]}
+    assert config["total_token_usage"] == 45

--- a/packages/analysis-core/tests/test_llm_grouping.py
+++ b/packages/analysis-core/tests/test_llm_grouping.py
@@ -1,10 +1,12 @@
 """Tests for the LLM grouping workflow mode."""
 
 import importlib
+import json
 import pickle
 
 import numpy as np
 import polars as pl
+import pytest
 
 from analysis_core.orchestrator import PipelineOrchestrator
 
@@ -48,6 +50,26 @@ def test_run_workflow_uses_llm_grouping_workflow_when_mode_is_enabled(tmp_path, 
 
     assert seen["workflow_id"] == "llm-grouping-compatible"
     assert [step.step_name for step in result.steps] == ["llm_grouping"]
+
+
+def test_get_specs_path_for_mode_rejects_unknown_mode():
+    """Unknown analysis modes should fail fast instead of silently falling back."""
+    from analysis_core.core.orchestration import get_specs_path_for_mode
+
+    with pytest.raises(ValueError, match="Unknown analysis_mode: unexpected_mode"):
+        get_specs_path_for_mode("unexpected_mode")
+
+
+def test_llm_grouping_specs_treat_prompt_changes_as_dependencies():
+    """Prompt fields must participate in rerun invalidation."""
+    from analysis_core.core.orchestration import get_specs_path_for_mode
+
+    specs_path = get_specs_path_for_mode("llm_grouping")
+    specs = json.loads(specs_path.read_text(encoding="utf-8"))
+    llm_grouping_spec = next(spec for spec in specs if spec["step"] == "llm_grouping")
+
+    assert "discovery_prompt" in llm_grouping_spec["dependencies"]["params"]
+    assert "assignment_prompt" in llm_grouping_spec["dependencies"]["params"]
 
 
 def test_llm_grouping_step_creates_viewer_compatible_outputs(tmp_path, monkeypatch):
@@ -134,3 +156,75 @@ def test_llm_grouping_step_creates_viewer_compatible_outputs(tmp_path, monkeypat
     assert clusters["cluster-level-1-id"].to_list() == ["g1", "g1", "g2"]
     assert labels.select(["id", "label"]).to_dict(as_series=False) == {"id": ["g1", "g2"], "label": ["交通", "公園"]}
     assert config["total_token_usage"] == 45
+
+
+def test_llm_grouping_uses_legacy_embedding_order_when_arg_ids_are_missing(tmp_path, monkeypatch):
+    """Legacy embedding lists without arg-id keys should fall back to positional matching."""
+    llm_grouping_step = importlib.import_module("analysis_core.steps.llm_grouping")
+
+    output_dir = tmp_path / "outputs" / "demo"
+    output_dir.mkdir(parents=True)
+    with open(output_dir / "embeddings.pkl", "wb") as f:
+        pickle.dump(
+            [
+                {"embedding": [0.1, 0.2, 0.3]},
+                {"embedding": [0.2, 0.1, 0.3]},
+            ],
+            f,
+        )
+
+    class FakeUMAP:
+        def __init__(self, n_components, n_neighbors):
+            self.n_components = n_components
+            self.n_neighbors = n_neighbors
+
+        def fit_transform(self, embeddings):
+            return np.asarray(embeddings[:, :2])
+
+    monkeypatch.setattr(llm_grouping_step, "_load_clustering_dependencies", lambda: (FakeUMAP, None, None))
+
+    result = llm_grouping_step._project_embeddings_to_xy(str(tmp_path / "outputs"), "demo", ["a1", "a2"])
+    assert result.shape == (2, 2)
+
+
+def test_llm_grouping_reports_missing_embedding_arg_ids(tmp_path):
+    """Missing embeddings should raise a clear error with the missing ids."""
+    llm_grouping_step = importlib.import_module("analysis_core.steps.llm_grouping")
+
+    output_dir = tmp_path / "outputs" / "demo"
+    output_dir.mkdir(parents=True)
+    with open(output_dir / "embeddings.pkl", "wb") as f:
+        pickle.dump([{"arg-id": "a1", "embedding": [0.1, 0.2, 0.3]}], f)
+
+    with pytest.raises(ValueError, match=r"Missing embeddings for arg ids: \['a2'\]"):
+        llm_grouping_step._project_embeddings_to_xy(str(tmp_path / "outputs"), "demo", ["a1", "a2"])
+
+
+def test_assign_groups_uses_safe_batch_size_for_non_positive_input(monkeypatch):
+    """Non-positive batch sizes should still process all arguments consistently."""
+    llm_grouping_step = importlib.import_module("analysis_core.steps.llm_grouping")
+
+    captured_messages = []
+
+    def fake_request_to_chat_ai(**kwargs):
+        captured_messages.append(kwargs["messages"][1]["content"])
+        arg_id = f"a{len(captured_messages)}"
+        return {"assignments": [{"arg_id": arg_id, "group_id": "g1"}]}, 0, 0, 0
+
+    monkeypatch.setattr(llm_grouping_step, "request_to_chat_ai", fake_request_to_chat_ai)
+
+    groups = [llm_grouping_step.GroupDefinition(group_id="g1", label="交通", description="公共交通")]
+    assignments = llm_grouping_step._assign_groups(
+        arg_ids=["a1", "a2"],
+        arguments=["電車", "バス"],
+        groups=groups,
+        batch_size=0,
+        prompt="assign",
+        model="dummy-model",
+        provider="local",
+        local_llm_address=None,
+        config={},
+    )
+
+    assert assignments == {"a1": "g1", "a2": "g1"}
+    assert len(captured_messages) == 2

--- a/packages/analysis-core/tests/test_prompts.py
+++ b/packages/analysis-core/tests/test_prompts.py
@@ -7,6 +7,8 @@ from analysis_core.prompts import (
     DEFAULT_PROMPTS,
     EXTRACTION_PROMPT,
     INITIAL_LABELLING_PROMPT,
+    LLM_GROUPING_ASSIGNMENT_PROMPT,
+    LLM_GROUPING_DISCOVERY_PROMPT,
     MERGE_LABELLING_PROMPT,
     OVERVIEW_PROMPT,
     get_default_prompt,
@@ -40,12 +42,21 @@ class TestDefaultPrompts:
         assert len(OVERVIEW_PROMPT) > 0
         assert "リサーチアシスタント" in OVERVIEW_PROMPT
 
+    def test_llm_grouping_prompts_exist(self):
+        """Test that LLM grouping prompts are defined."""
+        assert len(LLM_GROUPING_DISCOVERY_PROMPT) > 0
+        assert len(LLM_GROUPING_ASSIGNMENT_PROMPT) > 0
+        assert "グループ" in LLM_GROUPING_DISCOVERY_PROMPT
+        assert "group_id" in LLM_GROUPING_ASSIGNMENT_PROMPT
+
     def test_default_prompts_mapping(self):
         """Test that DEFAULT_PROMPTS maps step names to prompts."""
         assert "extraction" in DEFAULT_PROMPTS
         assert "hierarchical_initial_labelling" in DEFAULT_PROMPTS
         assert "hierarchical_merge_labelling" in DEFAULT_PROMPTS
         assert "hierarchical_overview" in DEFAULT_PROMPTS
+        assert "llm_grouping_discovery" in DEFAULT_PROMPTS
+        assert "llm_grouping_assignment" in DEFAULT_PROMPTS
 
     def test_get_default_prompt_extraction(self):
         """Test get_default_prompt for extraction step."""
@@ -66,6 +77,11 @@ class TestDefaultPrompts:
         """Test get_default_prompt for overview step."""
         prompt = get_default_prompt("hierarchical_overview")
         assert prompt == OVERVIEW_PROMPT
+
+    def test_get_default_prompt_llm_grouping(self):
+        """Test get_default_prompt for LLM grouping prompts."""
+        assert get_default_prompt("llm_grouping_discovery") == LLM_GROUPING_DISCOVERY_PROMPT
+        assert get_default_prompt("llm_grouping_assignment") == LLM_GROUPING_ASSIGNMENT_PROMPT
 
     def test_get_default_prompt_unknown_step(self):
         """Test get_default_prompt returns None for unknown step."""
@@ -96,6 +112,7 @@ class TestPromptsInConfig:
         config = initialization(
             config_path=config_path,
             skip_interaction=True,
+            validate_api_keys_early=False,
             output_base_dir=tmp_path / "outputs",
             input_base_dir=tmp_path / "inputs",
         )
@@ -130,6 +147,7 @@ class TestPromptsInConfig:
         config = initialization(
             config_path=config_path,
             skip_interaction=True,
+            validate_api_keys_early=False,
             output_base_dir=tmp_path / "outputs",
             input_base_dir=tmp_path / "inputs",
         )
@@ -138,3 +156,30 @@ class TestPromptsInConfig:
         assert config["extraction"]["prompt"] == custom_prompt
         # Other steps should still use defaults
         assert config["hierarchical_initial_labelling"]["prompt"] == INITIAL_LABELLING_PROMPT
+
+    def test_initialization_adds_llm_grouping_prompts(self, tmp_path: Path):
+        """Test that initialization adds default LLM grouping prompts."""
+        from analysis_core.core.orchestration import initialization
+
+        config_path = tmp_path / "test.json"
+        config_path.write_text(
+            json.dumps(
+                {
+                    "input": "test",
+                    "question": "Test question?",
+                    "provider": "local",
+                    "analysis_mode": "llm_grouping",
+                }
+            )
+        )
+
+        config = initialization(
+            config_path=config_path,
+            skip_interaction=True,
+            validate_api_keys_early=False,
+            output_base_dir=tmp_path / "outputs",
+            input_base_dir=tmp_path / "inputs",
+        )
+
+        assert config["llm_grouping"]["discovery_prompt"] == LLM_GROUPING_DISCOVERY_PROMPT
+        assert config["llm_grouping"]["assignment_prompt"] == LLM_GROUPING_ASSIGNMENT_PROMPT


### PR DESCRIPTION
## 概要

- `analysis_mode=llm_grouping` で LLM による意見グルーピング workflow を選べるようにしました
- `analysis.llm_grouping` plugin / step / specs / workflow を追加し、既存 viewer 互換の `hierarchical_clusters.csv` と `hierarchical_merge_labels.csv` を出力します
- discovery / assignment 用の default prompt と config normalization を追加し、`from_config` / `from_dict` の両方で mode に応じた specs と workflow を選ぶようにしました

## 意図

散布図互換を保ったまま、embedding によるクラスタリングではなく raw argument を LLM で top-level group に割り当てる実験用の入口を先に切り出します。label refinement は別論点なので、この PR には含めていません。

## 確認

- `rye run ruff check src tests/test_llm_grouping.py tests/test_compat.py tests/test_imports.py tests/test_prompts.py`
- `rye run python -m pytest tests/test_llm_grouping.py tests/test_compat.py tests/test_imports.py tests/test_prompts.py tests/test_integration.py tests/test_orchestration.py -q`
- `rye run python -m pytest tests/test_cli.py tests/test_pipeline_paths_integration.py -q`
- `rye run python -m pytest -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added LLM-based grouping workflow as an alternative to hierarchical clustering for analyzing opinions
  * Configuration now supports selecting analysis modes to choose between different grouping strategies
  * Implemented automated group discovery and assignment with customizable AI-powered prompts

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/digitaldemocracy2030/kouchou-ai/pull/866?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->