### PR TITLE
[codex] 既存出力を再利用して再実行できるようにする

### DIFF
--- a/packages/analysis-core/src/analysis_core/__main__.py
+++ b/packages/analysis-core/src/analysis_core/__main__.py
@@ -64,6 +64,11 @@ def main() -> int:
         help="Base directory for inputs (default: inputs)",
     )
     parser.add_argument(
+        "--reuse-from",
+        type=str,
+        help="Reuse intermediate outputs from another job directory or output name",
+    )
+    parser.add_argument(
         "--dry-run",
         action="store_true",
         help="Show execution plan without running",
@@ -104,6 +109,7 @@ def main() -> int:
             persist_status=not (args.dry_run or args.validate_config or args.validate_input),
             output_base_dir=args.output_dir,
             input_base_dir=args.input_dir,
+            reuse_from=args.reuse_from,
         )
 
         plan = orchestrator.get_plan()

--- a/packages/analysis-core/src/analysis_core/core/orchestration.py
+++ b/packages/analysis-core/src/analysis_core/core/orchestration.py
@@ -8,6 +8,7 @@ with configurable paths and reduced external dependencies.
 import inspect
 import json
 import os
+import shutil
 import traceback
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -43,6 +44,93 @@ def resolve_user_api_key(config: dict[str, Any] | None = None) -> str | None:
         if user_api_key:
             return str(user_api_key)
     return os.getenv("USER_API_KEY") or None
+
+
+def _resolve_reuse_source(output_base_dir: Path, reuse_from: str) -> Path:
+    """Resolve a reusable output directory from a job name or explicit path."""
+    candidate = Path(reuse_from).expanduser()
+    if candidate.exists():
+        return candidate.resolve()
+    return (output_base_dir / reuse_from).resolve()
+
+
+def _seed_reused_outputs(
+    *,
+    config: dict[str, Any],
+    output_base_dir: Path,
+    specs: list[dict[str, Any]],
+) -> None:
+    """Copy reusable step outputs from another job into the current output dir."""
+    reuse_from = config.get("reuse_from")
+    if not reuse_from:
+        return
+
+    dest_dir = output_base_dir / config["output_dir"]
+    status_file = dest_dir / "hierarchical_status.json"
+    if status_file.exists():
+        return
+
+    source_dir = _resolve_reuse_source(output_base_dir, reuse_from)
+    if not source_dir.exists():
+        raise RuntimeError(f"reuse_from source not found: {reuse_from}")
+    if not source_dir.is_dir():
+        raise RuntimeError(f"reuse_from must point to a directory: {source_dir}")
+
+    source_status_file = source_dir / "hierarchical_status.json"
+    source_status: dict[str, Any] = {}
+    if source_status_file.exists():
+        with open(source_status_file, encoding="utf-8") as f:
+            source_status = json.load(f)
+
+    reusable_steps = []
+    for step_spec in specs:
+        source_artifact = source_dir / step_spec["filename"]
+        if not source_artifact.exists():
+            continue
+
+        copied_files = [source_artifact]
+        if step_spec["step"] == "extraction":
+            relations = source_dir / "relations.csv"
+            if relations.exists():
+                copied_files.append(relations)
+
+        for artifact in copied_files:
+            target = dest_dir / artifact.name
+            if artifact.is_dir():
+                shutil.copytree(artifact, target, dirs_exist_ok=True)
+            else:
+                shutil.copy2(artifact, target)
+        reusable_steps.append(step_spec["step"])
+
+    if not reusable_steps:
+        raise RuntimeError(f"No reusable artifacts found in {source_dir}")
+
+    completed_jobs = source_status.get("completed_jobs", []) + source_status.get("previously_completed_jobs", [])
+    status_by_step = {job.get("step"): job for job in completed_jobs if job.get("step")}
+    seeded_jobs = []
+    for step_spec in specs:
+        step_name = step_spec["step"]
+        if step_name not in reusable_steps:
+            continue
+        current_params = dict(config.get(step_name, {}))
+        source_job = status_by_step.get(step_name, {})
+        seeded_jobs.append(
+            {
+                "step": step_name,
+                "params": current_params or source_job.get("params", {}),
+            }
+        )
+
+    seeded_status = {
+        "status": "completed",
+        "completed_jobs": seeded_jobs,
+        "previously_completed_jobs": [],
+        "reused_from": str(source_dir),
+    }
+    with open(status_file, "w", encoding="utf-8") as f:
+        json.dump(seeded_status, f, indent=2, ensure_ascii=False)
+
+    print(f"Seeded outputs for {config['output_dir']} from {source_dir.name}: {', '.join(reusable_steps)}")
 
 
 def load_specs(specs_path: Path) -> list[dict[str, Any]]:
@@ -155,6 +243,7 @@ def validate_config(config: dict[str, Any], specs: list[dict[str, Any]] | None =
         "enable_source_link",
         "without_html",
         "without-html",
+        "reuse_from",
     ]
     step_names = [x["step"] for x in specs]
 
@@ -446,6 +535,7 @@ def initialization(
     input_base_dir: Path | None = None,
     specs_path: Path | None = None,
     steps_module: Any = None,
+    reuse_from: str | None = None,
 ) -> dict[str, Any]:
     """
     Initialize pipeline configuration.
@@ -462,6 +552,7 @@ def initialization(
         input_base_dir: Base directory for inputs (default: inputs/)
         specs_path: Path to specs JSON file (default: package specs)
         steps_module: Module containing step functions (for source code extraction)
+        reuse_from: Reuse intermediate outputs from another job directory
 
     Returns:
         Initialized configuration dictionary
@@ -505,6 +596,8 @@ def initialization(
         config["force"] = True
     if only:
         config["only"] = only
+    if reuse_from:
+        config["reuse_from"] = reuse_from
     if skip_interaction:
         config["skip-interaction"] = True
     if without_html:
@@ -515,23 +608,6 @@ def initialization(
     sync_without_html_keys(config)
 
     output_dir = config["output_dir"]
-
-    # Check if job has run before
-    previous: dict[str, Any] | bool = False
-    status_file = output_base_dir / output_dir / "hierarchical_status.json"
-    if status_file.exists():
-        with open(status_file, "r", encoding="utf-8") as f:
-            previous = json.load(f)
-        config["previous"] = previous
-
-    # Crash if job is already running and locked
-    if previous and isinstance(previous, dict) and previous.get("status") == "running":
-        lock_until = previous.get("lock_until")
-        if lock_until and datetime.fromisoformat(lock_until) > datetime.now():
-            print("Job already running and locked. Try again in 5 minutes.")
-            raise Exception("Job already running.")
-        else:
-            print("Hum, the last Job crashed a while ago...Proceeding!")
 
     # Set default LLM model
     if "model" not in config:
@@ -577,6 +653,25 @@ def initialization(
     output_path = output_base_dir / output_dir
     if not output_path.exists():
         output_path.mkdir(parents=True, exist_ok=True)
+
+    _seed_reused_outputs(config=config, output_base_dir=output_base_dir, specs=specs)
+
+    # Check if job has run before
+    previous: dict[str, Any] | bool = False
+    status_file = output_base_dir / output_dir / "hierarchical_status.json"
+    if status_file.exists():
+        with open(status_file, "r", encoding="utf-8") as f:
+            previous = json.load(f)
+        config["previous"] = previous
+
+    # Crash if job is already running and locked
+    if previous and isinstance(previous, dict) and previous.get("status") == "running":
+        lock_until = previous.get("lock_until")
+        if lock_until and datetime.fromisoformat(lock_until) > datetime.now():
+            print("Job already running and locked. Try again in 5 minutes.")
+            raise Exception("Job already running.")
+        else:
+            print("Hum, the last Job crashed a while ago...Proceeding!")
 
     # Decide what to run
     plan = decide_what_to_run(config, previous if isinstance(previous, dict) else None, specs, output_base_dir)

--- a/packages/analysis-core/src/analysis_core/core/orchestration.py
+++ b/packages/analysis-core/src/analysis_core/core/orchestration.py
@@ -82,17 +82,25 @@ def _seed_reused_outputs(
         with open(source_status_file, encoding="utf-8") as f:
             source_status = json.load(f)
 
+    completed_jobs = source_status.get("completed_jobs", []) + source_status.get("previously_completed_jobs", [])
+    status_by_step = {job.get("step"): job for job in completed_jobs if job.get("step")}
     reusable_steps = []
     for step_spec in specs:
+        step_name = step_spec["step"]
+        source_job = status_by_step.get(step_name)
+        if not source_job:
+            continue
+
         source_artifact = source_dir / step_spec["filename"]
         if not source_artifact.exists():
             continue
 
         copied_files = [source_artifact]
-        if step_spec["step"] == "extraction":
+        if step_name == "extraction":
             relations = source_dir / "relations.csv"
-            if relations.exists():
-                copied_files.append(relations)
+            if not relations.exists():
+                continue
+            copied_files.append(relations)
 
         for artifact in copied_files:
             target = dest_dir / artifact.name
@@ -100,24 +108,21 @@ def _seed_reused_outputs(
                 shutil.copytree(artifact, target, dirs_exist_ok=True)
             else:
                 shutil.copy2(artifact, target)
-        reusable_steps.append(step_spec["step"])
+        reusable_steps.append(step_name)
 
     if not reusable_steps:
         raise RuntimeError(f"No reusable artifacts found in {source_dir}")
 
-    completed_jobs = source_status.get("completed_jobs", []) + source_status.get("previously_completed_jobs", [])
-    status_by_step = {job.get("step"): job for job in completed_jobs if job.get("step")}
     seeded_jobs = []
     for step_spec in specs:
         step_name = step_spec["step"]
         if step_name not in reusable_steps:
             continue
-        current_params = dict(config.get(step_name, {}))
         source_job = status_by_step.get(step_name, {})
         seeded_jobs.append(
             {
                 "step": step_name,
-                "params": current_params or source_job.get("params", {}),
+                "params": source_job.get("params", {}),
             }
         )
 

--- a/packages/analysis-core/src/analysis_core/orchestrator.py
+++ b/packages/analysis-core/src/analysis_core/orchestrator.py
@@ -137,6 +137,7 @@ class PipelineOrchestrator:
         persist_status: bool = True,
         output_base_dir: Path | None = None,
         input_base_dir: Path | None = None,
+        reuse_from: str | None = None,
     ) -> "PipelineOrchestrator":
         """
         Create an orchestrator from a config file.
@@ -157,6 +158,7 @@ class PipelineOrchestrator:
             persist_status: Persist running/completed status to hierarchical_status.json
             output_base_dir: Base directory for outputs
             input_base_dir: Base directory for inputs
+            reuse_from: Reuse intermediate outputs from another job directory
 
         Returns:
             Initialized PipelineOrchestrator
@@ -174,6 +176,7 @@ class PipelineOrchestrator:
             output_base_dir=output_base_dir,
             input_base_dir=input_base_dir,
             steps_module=steps_module,
+            reuse_from=reuse_from,
         )
 
         return cls(

--- a/packages/analysis-core/tests/test_cli.py
+++ b/packages/analysis-core/tests/test_cli.py
@@ -102,6 +102,8 @@ class TestCLI:
 
     def test_cli_dry_run_with_reuse_from_skips_seeded_steps(self, tmp_path):
         """Test CLI --reuse-from seeds previous artifacts for comparison runs."""
+        from analysis_core.prompts import get_default_prompt
+
         config_path = tmp_path / "test_config.json"
         config_path.write_text(
             json.dumps(
@@ -128,7 +130,14 @@ class TestCLI:
                 {
                     "status": "completed",
                     "completed_jobs": [
-                        {"step": "extraction", "params": {"limit": 1000}},
+                        {
+                            "step": "extraction",
+                            "params": {
+                                "limit": 1000,
+                                "model": "gpt-4o-mini",
+                                "prompt": get_default_prompt("extraction"),
+                            },
+                        },
                         {"step": "embedding", "params": {"model": "text-embedding-3-small"}},
                     ],
                 }

--- a/packages/analysis-core/tests/test_cli.py
+++ b/packages/analysis-core/tests/test_cli.py
@@ -27,6 +27,7 @@ class TestCLI:
         assert "--force" in result.stdout
         assert "--only" in result.stdout
         assert "--dry-run" in result.stdout
+        assert "--reuse-from" in result.stdout
 
     def test_cli_version(self):
         """Test CLI --version option."""
@@ -98,6 +99,67 @@ class TestCLI:
         assert "extraction" in result.stdout
         assert "embedding" in result.stdout
         assert not (output_dir / "test_config" / "hierarchical_status.json").exists()
+
+    def test_cli_dry_run_with_reuse_from_skips_seeded_steps(self, tmp_path):
+        """Test CLI --reuse-from seeds previous artifacts for comparison runs."""
+        config_path = tmp_path / "test_config.json"
+        config_path.write_text(
+            json.dumps(
+                {
+                    "input": "test",
+                    "question": "Test question?",
+                    "provider": "local",
+                }
+            )
+        )
+
+        input_dir = tmp_path / "inputs"
+        input_dir.mkdir()
+        (input_dir / "test.csv").write_text("comment-id,comment-body\n1,test\n", encoding="utf-8")
+
+        output_dir = tmp_path / "outputs"
+        source_dir = output_dir / "baseline"
+        source_dir.mkdir(parents=True)
+        (source_dir / "args.csv").write_text("arg-id,argument\nA1,test\n", encoding="utf-8")
+        (source_dir / "relations.csv").write_text("arg-id,comment-id\nA1,1\n", encoding="utf-8")
+        (source_dir / "embeddings.pkl").write_bytes(b"pickle-placeholder")
+        (source_dir / "hierarchical_status.json").write_text(
+            json.dumps(
+                {
+                    "status": "completed",
+                    "completed_jobs": [
+                        {"step": "extraction", "params": {"limit": 1000}},
+                        {"step": "embedding", "params": {"model": "text-embedding-3-small"}},
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "analysis_core",
+                "--config",
+                str(config_path),
+                "--dry-run",
+                "--reuse-from",
+                "baseline",
+                "--input-dir",
+                str(input_dir),
+                "--output-dir",
+                str(output_dir),
+            ],
+            capture_output=True,
+            text=True,
+            cwd=PACKAGE_ROOT,
+        )
+
+        assert result.returncode == 0
+        assert "Seeded outputs for test_config from baseline: extraction, embedding" in result.stdout
+        assert "[SKIP] extraction: nothing changed" in result.stdout
+        assert "[SKIP] embedding: nothing changed" in result.stdout
 
     def test_cli_validate_config(self, tmp_path):
         """Test standalone config validation mode."""

--- a/packages/analysis-core/tests/test_orchestration.py
+++ b/packages/analysis-core/tests/test_orchestration.py
@@ -241,6 +241,7 @@ class TestInitialization:
         monkeypatch.setenv("USER_API_KEY", "runtime-user-key")
 
         config_path = tmp_path / "job.json"
+
         config_path.write_text(
             json.dumps(
                 {
@@ -265,6 +266,66 @@ class TestInitialization:
         assert "user_api_key" not in config
         status = json.loads((output_dir / "job" / "hierarchical_status.json").read_text())
         assert "user_api_key" not in status
+
+    def test_initialization_can_seed_from_previous_output(self, tmp_path):
+        """Test reuse_from seeds reusable artifacts and skips upstream steps."""
+        from analysis_core.core import initialization
+
+        config_path = tmp_path / "compare_job.json"
+        config_path.write_text(
+            json.dumps(
+                {
+                    "input": "test",
+                    "question": "Test?",
+                    "provider": "local",
+                }
+            )
+        )
+
+        input_dir = tmp_path / "inputs"
+        output_dir = tmp_path / "outputs"
+        input_dir.mkdir()
+
+        source_dir = output_dir / "source_job"
+        source_dir.mkdir(parents=True)
+        (source_dir / "args.csv").write_text("arg-id,argument\nA1,test\n", encoding="utf-8")
+        (source_dir / "relations.csv").write_text("arg-id,comment-id\nA1,1\n", encoding="utf-8")
+        (source_dir / "embeddings.pkl").write_bytes(b"pickle-placeholder")
+        report_dir = source_dir / "report"
+        report_dir.mkdir()
+        (report_dir / "index.html").write_text("<html></html>", encoding="utf-8")
+        (source_dir / "hierarchical_status.json").write_text(
+            json.dumps(
+                {
+                    "status": "completed",
+                    "completed_jobs": [
+                        {"step": "extraction", "params": {"limit": 1000}},
+                        {"step": "embedding", "params": {"model": "text-embedding-3-small"}},
+                        {"step": "hierarchical_visualization", "params": {}},
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+        config = initialization(
+            config_path=config_path,
+            skip_interaction=True,
+            output_base_dir=output_dir,
+            input_base_dir=input_dir,
+            reuse_from="source_job",
+        )
+
+        seeded_dir = output_dir / "compare_job"
+        assert (seeded_dir / "args.csv").exists()
+        assert (seeded_dir / "relations.csv").exists()
+        assert (seeded_dir / "embeddings.pkl").exists()
+        assert (seeded_dir / "report" / "index.html").exists()
+        assert config["previous"]["reused_from"].endswith("source_job")
+
+        plan_by_step = {item["step"]: item for item in config["plan"]}
+        assert plan_by_step["extraction"]["run"] is False
+        assert plan_by_step["embedding"]["run"] is False
+        assert plan_by_step["hierarchical_clustering"]["run"] is True
 
 
 class TestValidateApiKeys:

--- a/packages/analysis-core/tests/test_orchestration.py
+++ b/packages/analysis-core/tests/test_orchestration.py
@@ -270,6 +270,7 @@ class TestInitialization:
     def test_initialization_can_seed_from_previous_output(self, tmp_path):
         """Test reuse_from seeds reusable artifacts and skips upstream steps."""
         from analysis_core.core import initialization
+        from analysis_core.prompts import get_default_prompt
 
         config_path = tmp_path / "compare_job.json"
         config_path.write_text(
@@ -299,7 +300,14 @@ class TestInitialization:
                 {
                     "status": "completed",
                     "completed_jobs": [
-                        {"step": "extraction", "params": {"limit": 1000}},
+                        {
+                            "step": "extraction",
+                            "params": {
+                                "limit": 1000,
+                                "model": "gpt-4o-mini",
+                                "prompt": get_default_prompt("extraction"),
+                            },
+                        },
                         {"step": "embedding", "params": {"model": "text-embedding-3-small"}},
                         {"step": "hierarchical_visualization", "params": {}},
                     ],
@@ -326,6 +334,74 @@ class TestInitialization:
         assert plan_by_step["extraction"]["run"] is False
         assert plan_by_step["embedding"]["run"] is False
         assert plan_by_step["hierarchical_clustering"]["run"] is True
+        previous_jobs = {job["step"]: job for job in config["previous"]["completed_jobs"]}
+        assert previous_jobs["extraction"]["params"] == {
+            "limit": 1000,
+            "model": "gpt-4o-mini",
+            "prompt": get_default_prompt("extraction"),
+        }
+        assert previous_jobs["embedding"]["params"] == {"model": "text-embedding-3-small"}
+
+    def test_initialization_only_seeds_steps_completed_in_source_status(self, tmp_path):
+        """Test reuse_from ignores artifacts for steps not completed in source status."""
+        from analysis_core.core import initialization
+        from analysis_core.prompts import get_default_prompt
+
+        config_path = tmp_path / "compare_job.json"
+        config_path.write_text(
+            json.dumps(
+                {
+                    "input": "test",
+                    "question": "Test?",
+                    "provider": "local",
+                }
+            )
+        )
+
+        input_dir = tmp_path / "inputs"
+        output_dir = tmp_path / "outputs"
+        input_dir.mkdir()
+
+        source_dir = output_dir / "source_job"
+        source_dir.mkdir(parents=True)
+        (source_dir / "args.csv").write_text("arg-id,argument\nA1,test\n", encoding="utf-8")
+        (source_dir / "relations.csv").write_text("arg-id,comment-id\nA1,1\n", encoding="utf-8")
+        (source_dir / "embeddings.pkl").write_bytes(b"pickle-placeholder")
+        (source_dir / "hierarchical_status.json").write_text(
+            json.dumps(
+                {
+                    "status": "completed",
+                    "completed_jobs": [
+                        {
+                            "step": "extraction",
+                            "params": {
+                                "limit": 1000,
+                                "model": "gpt-4o-mini",
+                                "prompt": get_default_prompt("extraction"),
+                            },
+                        },
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        config = initialization(
+            config_path=config_path,
+            skip_interaction=True,
+            output_base_dir=output_dir,
+            input_base_dir=input_dir,
+            reuse_from="source_job",
+        )
+
+        seeded_dir = output_dir / "compare_job"
+        assert (seeded_dir / "args.csv").exists()
+        assert (seeded_dir / "relations.csv").exists()
+        assert not (seeded_dir / "embeddings.pkl").exists()
+
+        plan_by_step = {item["step"]: item for item in config["plan"]}
+        assert plan_by_step["extraction"]["run"] is False
+        assert plan_by_step["embedding"]["run"] is True
 
 
 class TestValidateApiKeys:


### PR DESCRIPTION
## 概要
- CLI に `--reuse-from` を追加し、既存の出力ディレクトリ名またはパスを指定できるようにしました。
- 指定元に存在する中間成果物を新しい出力ディレクトリへ seed し、対応するステップを `nothing changed` として skip できるようにしました。
- `extraction` では `args.csv` とあわせて `relations.csv` も再利用し、`report` のようなディレクトリ成果物もコピーできるようにしています。

## スコープ
- このPRは `--reuse-from` のみです。
- LLM grouping と label refinement の実装は含めていません。

## 確認
- `rye run ruff check src tests/test_cli.py tests/test_orchestration.py`
- `rye run python -m pytest tests/test_cli.py tests/test_orchestration.py tests/test_pipeline_paths_integration.py -q`
- `OPENAI_API_KEY=dummy rye run python -m pytest -q`

補足: `OPENAI_API_KEY` なしの全体 pytest は、既存の prompt テスト2件が環境変数未設定で失敗しました。ダミー値を入れると `181 passed` です。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --reuse-from CLI option to reuse intermediate outputs from a prior run, seed those outputs into the current run, and skip already-completed upstream stages.
  * CLI help documents the new flag and dry-run displays seeded/skipped steps.

* **Tests**
  * Added tests validating CLI behavior, seeded outputs, and orchestration initialization to ensure correct skipping and downstream execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/digitaldemocracy2030/kouchou-ai/pull/867?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->