### PR TITLE
[codex] 実行時ユーザーAPIキーの受け渡しを直す

### DIFF
--- a/packages/analysis-core/src/analysis_core/compat/config_converter.py
+++ b/packages/analysis-core/src/analysis_core/compat/config_converter.py
@@ -184,6 +184,7 @@ def create_step_context_from_config(
     """
     from pathlib import Path
 
+    from analysis_core.core.orchestration import resolve_user_api_key
     from analysis_core.plugin import StepContext
 
     dataset = output_dir or config.get("output_dir", config.get("name", "analysis"))
@@ -195,5 +196,5 @@ def create_step_context_from_config(
         provider=config.get("provider", "openai"),
         model=config.get("model", "gpt-4o-mini"),
         local_llm_address=config.get("local_llm_address"),
-        user_api_key=config.get("user_api_key"),
+        user_api_key=resolve_user_api_key(config),
     )

--- a/packages/analysis-core/src/analysis_core/core/orchestration.py
+++ b/packages/analysis-core/src/analysis_core/core/orchestration.py
@@ -36,6 +36,15 @@ def sync_without_html_keys(config: dict[str, Any]) -> None:
     config["without_html"] = canonical
 
 
+def resolve_user_api_key(config: dict[str, Any] | None = None) -> str | None:
+    """Resolve the runtime user-provided API key without persisting it."""
+    if config:
+        user_api_key = config.get("user_api_key")
+        if user_api_key:
+            return str(user_api_key)
+    return os.getenv("USER_API_KEY") or None
+
+
 def load_specs(specs_path: Path) -> list[dict[str, Any]]:
     """Load pipeline step specifications from a JSON file."""
     global _specs
@@ -482,7 +491,7 @@ def initialization(
     # This ensures we catch missing API keys before starting any pipeline steps
     provider = config.get("provider", "openai")
     if validate_api_keys_early:
-        validate_api_keys(provider)
+        validate_api_keys(provider, resolve_user_api_key(config))
 
     # Set output directory
     config["output_dir"] = job_name

--- a/packages/analysis-core/src/analysis_core/plugins/builtin/_legacy_config.py
+++ b/packages/analysis-core/src/analysis_core/plugins/builtin/_legacy_config.py
@@ -20,6 +20,8 @@ def build_legacy_runtime_config(
         "provider": ctx.provider,
         "local_llm_address": ctx.local_llm_address,
     }
+    if ctx.user_api_key:
+        legacy_config["user_api_key"] = ctx.user_api_key
 
     if include_input:
         input_name, input_base_dir = resolve_input_location(ctx, inputs)

--- a/packages/analysis-core/src/analysis_core/steps/embedding.py
+++ b/packages/analysis-core/src/analysis_core/steps/embedding.py
@@ -10,6 +10,7 @@ from analysis_core.services.llm import request_to_embed
 def embedding(config):
     model = config["embedding"]["model"]
     is_embedded_at_local = config["is_embedded_at_local"]
+    user_api_key = config.get("user_api_key") or os.getenv("USER_API_KEY")
     # print("start embedding")
     # print(f"embedding model: {model}, is_embedded_at_local: {is_embedded_at_local}")
 
@@ -29,7 +30,7 @@ def embedding(config):
             is_embedded_at_local,
             config["provider"],
             local_llm_address=config.get("local_llm_address"),
-            user_api_key=os.getenv("USER_API_KEY"),
+            user_api_key=user_api_key,
         )
         embeddings.extend(embeds)
     # Store as list[dict] for polars compatibility

--- a/packages/analysis-core/src/analysis_core/steps/extraction.py
+++ b/packages/analysis-core/src/analysis_core/steps/extraction.py
@@ -61,6 +61,7 @@ def extraction(config):
     limit = config["extraction"]["limit"]
     property_columns = config["extraction"]["properties"]
     timeout_seconds = config["extraction"].get("timeout_seconds", EXTRACTION_WAIT_TIMEOUT_SECONDS)
+    user_api_key = config.get("user_api_key") or os.getenv("USER_API_KEY")
 
     if "provider" not in config:
         raise RuntimeError("provider is not set")
@@ -87,7 +88,15 @@ def extraction(config):
         batch = comment_ids[i : i + workers]
         batch_inputs = [comments_lookup[id]["comment-body"] for id in batch]
         batch_results = extract_batch(
-            batch_inputs, prompt, model, workers, provider, config.get("local_llm_address"), config, timeout_seconds
+            batch_inputs,
+            prompt,
+            model,
+            workers,
+            provider,
+            config.get("local_llm_address"),
+            config,
+            timeout_seconds,
+            user_api_key,
         )
 
         for comment_id, extracted_args in zip(batch, batch_results, strict=False):
@@ -133,11 +142,24 @@ def extract_batch(
     local_llm_address=None,
     config=None,
     timeout_seconds=EXTRACTION_WAIT_TIMEOUT_SECONDS,
+    user_api_key=None,
 ):
     """Run argument extraction concurrently for a batch of comment texts."""
     with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
         futures_with_index = [
-            (i, executor.submit(extract_arguments, input, prompt, model, provider, local_llm_address, timeout_seconds))
+            (
+                i,
+                executor.submit(
+                    extract_arguments,
+                    input,
+                    prompt,
+                    model,
+                    provider,
+                    local_llm_address,
+                    timeout_seconds,
+                    user_api_key,
+                ),
+            )
             for i, input in enumerate(batch)
         ]
 
@@ -185,6 +207,7 @@ def extract_arguments(
     provider="openai",
     local_llm_address=None,
     timeout_seconds=EXTRACTION_WAIT_TIMEOUT_SECONDS,
+    user_api_key=None,
 ):
     """Send a single comment to the LLM and return extracted arguments."""
     messages = [
@@ -199,7 +222,7 @@ def extract_arguments(
             json_schema=ExtractionResponse,
             provider=provider,
             local_llm_address=local_llm_address,
-            user_api_key=os.getenv("USER_API_KEY"),
+            user_api_key=user_api_key or os.getenv("USER_API_KEY"),
             timeout_seconds=timeout_seconds,
         )
         items = parse_extraction_response(response)

--- a/packages/analysis-core/src/analysis_core/steps/hierarchical_initial_labelling.py
+++ b/packages/analysis-core/src/analysis_core/steps/hierarchical_initial_labelling.py
@@ -159,13 +159,14 @@ def process_initial_labelling(
         {"role": "user", "content": input},
     ]
     try:
+        user_api_key = config.get("user_api_key") if config is not None else None
         response_text, token_input, token_output, token_total = request_to_chat_ai(
             messages=messages,
             model=model,
             provider=provider,
             json_schema=LabellingFromat,
             local_llm_address=local_llm_address,
-            user_api_key=os.getenv("USER_API_KEY"),
+            user_api_key=user_api_key or os.getenv("USER_API_KEY"),
         )
 
         # トークン使用量を累積（configが渡されている場合）

--- a/packages/analysis-core/src/analysis_core/steps/hierarchical_merge_labelling.py
+++ b/packages/analysis-core/src/analysis_core/steps/hierarchical_merge_labelling.py
@@ -280,7 +280,7 @@ def process_merge_labelling(
             json_schema=LabellingFromat,
             provider=config["provider"],
             local_llm_address=config.get("local_llm_address"),
-            user_api_key=os.getenv("USER_API_KEY"),
+            user_api_key=config.get("user_api_key") or os.getenv("USER_API_KEY"),
         )
 
         config["total_token_usage"] = config.get("total_token_usage", 0) + token_total

--- a/packages/analysis-core/src/analysis_core/steps/hierarchical_overview.py
+++ b/packages/analysis-core/src/analysis_core/steps/hierarchical_overview.py
@@ -44,7 +44,7 @@ def hierarchical_overview(config):
         model=model,
         provider=config["provider"],
         local_llm_address=config.get("local_llm_address"),
-        user_api_key=os.getenv("USER_API_KEY"),
+        user_api_key=config.get("user_api_key") or os.getenv("USER_API_KEY"),
         json_schema=OverviewResponse,
         timeout_seconds=OVERVIEW_TIMEOUT_SECONDS,
     )

--- a/packages/analysis-core/tests/test_builtin_plugins.py
+++ b/packages/analysis-core/tests/test_builtin_plugins.py
@@ -63,6 +63,7 @@ def test_extraction_plugin_keeps_explicit_input_over_comments_fallback(tmp_path,
         provider="local",
         model="dummy-model",
         local_llm_address="127.0.0.1:9999",
+        user_api_key="ctx-user-key",
     )
 
     seen = {}
@@ -95,6 +96,7 @@ def test_extraction_plugin_keeps_explicit_input_over_comments_fallback(tmp_path,
     assert seen["input"] == "configured-input"
     assert seen["_input_base_dir"] == str(input_dir)
     assert seen["_output_base_dir"] == str(output_dir.parent)
+    assert seen["user_api_key"] == "ctx-user-key"
     assert outputs.artifacts["arguments"] == output_dir / "args.csv"
     assert outputs.artifacts["relations"] == output_dir / "relations.csv"
 

--- a/packages/analysis-core/tests/test_compat.py
+++ b/packages/analysis-core/tests/test_compat.py
@@ -122,6 +122,7 @@ class TestCreateStepContextFromConfig:
             "provider": "azure",
             "model": "gpt-4o",
             "local_llm_address": "http://localhost:11434",
+            "user_api_key": "config-user-key",
         }
         ctx = create_step_context_from_config(config)
 
@@ -129,6 +130,15 @@ class TestCreateStepContextFromConfig:
         assert ctx.provider == "azure"
         assert ctx.model == "gpt-4o"
         assert ctx.local_llm_address == "http://localhost:11434"
+        assert ctx.user_api_key == "config-user-key"
+
+    def test_uses_user_api_key_from_env(self, monkeypatch):
+        """Test that StepContext picks up runtime user API key from env."""
+        monkeypatch.setenv("USER_API_KEY", "env-user-key")
+
+        ctx = create_step_context_from_config({"output_dir": "my-output"})
+
+        assert ctx.user_api_key == "env-user-key"
 
     def test_output_dir_override(self):
         """Test that output_dir parameter overrides config."""

--- a/packages/analysis-core/tests/test_orchestration.py
+++ b/packages/analysis-core/tests/test_orchestration.py
@@ -233,6 +233,39 @@ class TestInitialization:
         assert config["without-html"] is True
         assert config["without_html"] is True
 
+    def test_initialization_uses_runtime_user_api_key_for_validation(self, tmp_path, monkeypatch):
+        """Test USER_API_KEY satisfies fail-fast provider validation without persisting it."""
+        from analysis_core.core import initialization
+
+        monkeypatch.setenv("OPENAI_API_KEY", "")
+        monkeypatch.setenv("USER_API_KEY", "runtime-user-key")
+
+        config_path = tmp_path / "job.json"
+        config_path.write_text(
+            json.dumps(
+                {
+                    "input": "test",
+                    "question": "Test?",
+                    "provider": "openai",
+                }
+            )
+        )
+
+        input_dir = tmp_path / "inputs"
+        output_dir = tmp_path / "outputs"
+        input_dir.mkdir()
+
+        config = initialization(
+            config_path=config_path,
+            skip_interaction=True,
+            output_base_dir=output_dir,
+            input_base_dir=input_dir,
+        )
+
+        assert "user_api_key" not in config
+        status = json.loads((output_dir / "job" / "hierarchical_status.json").read_text())
+        assert "user_api_key" not in status
+
 
 class TestValidateApiKeys:
     """Test API key validation."""

--- a/packages/analysis-core/tests/test_pipeline_paths_integration.py
+++ b/packages/analysis-core/tests/test_pipeline_paths_integration.py
@@ -191,12 +191,15 @@ class TestPipelinePathsIntegration:
         with patch("analysis_core.steps.embedding.request_to_embed") as mock_embed:
             mock_embed.return_value = [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
 
+            sample_config["user_api_key"] = "config-user-key"
+
             # Run embedding
             embedding(sample_config)
 
         # Verify output file was created in the correct location
         embeddings_file = output_subdir / "embeddings.pkl"
         assert embeddings_file.exists(), f"embeddings.pkl not found at {embeddings_file}"
+        assert mock_embed.call_args.kwargs["user_api_key"] == "config-user-key"
 
         # Verify hardcoded path was NOT used
         hardcoded_embeddings = Path("outputs") / sample_config["output_dir"] / "embeddings.pkl"


### PR DESCRIPTION
## 概要
- `USER_API_KEY` を `analysis-core` の初期 API key 検証で使えるようにしました。
- workflow の `StepContext` と built-in plugin の legacy runtime config に、実行時の user API key を伝播するようにしました。
- 既存の legacy step でも `config["user_api_key"]` を優先し、なければ従来通り `USER_API_KEY` env を参照するようにしました。

## 意図
- Web/API 側は `x-user-api-key` を subprocess の `USER_API_KEY` に渡していますが、core 側の fail-fast validation や plugin 経由の step 実行で一貫して扱えていませんでした。
- user API key は `initialization()` の戻り config や status JSON に保存しないようにしています。

## スコープ
- API key plumbing の修正のみです。
- LLM grouping / label refinement / `--reuse-from` の実装は含めていません。

## 確認
- `rye run ruff check src tests/test_builtin_plugins.py tests/test_compat.py tests/test_orchestration.py tests/test_pipeline_paths_integration.py`
- `rye run python -m pytest tests/test_builtin_plugins.py tests/test_compat.py tests/test_orchestration.py tests/test_pipeline_paths_integration.py -q`
- `OPENAI_API_KEY=dummy rye run python -m pytest -q`