### PR TITLE
[codex] Azure deploy を直列化して更新競合を避ける

### DIFF
--- a/.github/workflows/azure-deploy.yml
+++ b/.github/workflows/azure-deploy.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   workflow_dispatch:
 
+concurrency:
+  group: azure-deploy-${{ github.ref }}
+  cancel-in-progress: false
+
 env:
   AZURE_ACR_NAME: ${{ vars.AZURE_ACR_NAME }}
   AZURE_RESOURCE_GROUP: ${{ vars.AZURE_RESOURCE_GROUP }}


### PR DESCRIPTION
## 概要

- `Azure Deployment` workflow に `concurrency` を追加し、`main` 向け deploy を 1 本ずつ流すようにしました
- `cancel-in-progress: false` とし、先行 deploy を途中で止めず順番待ちさせます

## 背景

issue #741 の recent run を見ると、直近の failure は `npm` の一時的な fetch error というより、`ContainerAppOperationInProgress` による Azure Container Apps 更新競合でした。

短時間に `main` へ複数 merge が入ると、前の deploy が Azure 側で provisioning 中の間に次の deploy が `az containerapp update` を叩き、後続 run が失敗します。

まずは workflow 単位で deploy を直列化し、更新競合を起こしにくくします。

## 確認

- ローカルでは workflow YAML の差分確認のみ実施
- 実際の有効性確認は、この PR の merge 後または branch 上での GitHub Actions 実行が必要

Closes #741


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Azure deployment process to prevent interruption of ongoing deployments when multiple deployments are queued simultaneously.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/digitaldemocracy2030/kouchou-ai/pull/873?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->