### PR TITLE
[codex] 開発者向け導線を利用モード別に整理する (closes #876)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,9 @@ docker compose up
 - admin: <http://localhost:4000>
 - api: <http://localhost:8000/docs>
 
-!!! note "`.env` を編集したら再ビルドが必要なことがある"
-    一部の環境変数はビルド時に埋め込まれるため、変更後は `docker compose down && docker compose up --build` が必要です。詳細は [開発者向けスタートガイド](https://digitaldemocracy2030.github.io/kouchou-ai/development/developer-quickstart) を参照。
+> **Note**: `.env` を編集したら再ビルドが必要なことがある
+>
+> 一部の環境変数はビルド時に埋め込まれるため、変更後は `docker compose down && docker compose up --build` が必要です。詳細は [開発者向けスタートガイド](https://digitaldemocracy2030.github.io/kouchou-ai/development/developer-quickstart) を参照。
 
 その他のモード（フロントだけ触る / native 起動 / CLI 利用）と、環境変数の置き場所・よくある落とし穴は [開発者向けスタートガイド](https://digitaldemocracy2030.github.io/kouchou-ai/development/developer-quickstart) にまとめています。
 

--- a/README.md
+++ b/README.md
@@ -4,214 +4,69 @@
 
 デジタル民主主義 2030 プロジェクトにおいて、ブロードリスニングを実現するためのソフトウェア「広聴 AI」のリポジトリです。
 
-このプロジェクトは、[AI Objectives Institute](https://www.aiobjectivesinstitute.org/) が開発した [Talk to the City](https://github.com/AIObjectives/talk-to-the-city-reports)を参考に、日本の自治体や政治家の実務に合わせた機能改善を進めています。
+このプロジェクトは、[AI Objectives Institute](https://www.aiobjectivesinstitute.org/) が開発した [Talk to the City](https://github.com/AIObjectives/talk-to-the-city-reports) を参考に、日本の自治体や政治家の実務に合わせた機能改善を進めています。
 
 - 機能例
-  - 開発者以外でも扱いやすいような機能 (CSV Upload)
+  - 開発者以外でも扱いやすいような機能（CSV Upload）
   - 濃いクラスタ抽出機能
   - パブリックコメント用分析機能（予定）
   - 多数派攻撃に対する防御機能（予定）
 
-## 前提条件
+## ドキュメントサイト
 
-- 一般ユーザー向け：
-- 安定版リリースをダウンロード（[Windows](https://digitaldemocracy2030.github.io/kouchou-ai/getting-started/windows-setup)/[Mac](https://digitaldemocracy2030.github.io/kouchou-ai/getting-started/mac-setup)/[Linux](https://digitaldemocracy2030.github.io/kouchou-ai/getting-started/linux-setup)の各ガイドを参照）
-  - Docker（各ガイドに従ってインストール）
-  - OpenAI API キー
-- 開発者向け：
-  - docker
-  - git
-  - OpenAI API キー
-## セットアップ・起動
+詳細な手順・設計情報はドキュメントサイトを正本としています。
 
-### 前提
+➡ **<https://digitaldemocracy2030.github.io/kouchou-ai/>**
 
-- 広聴 AI は Web アプリとして構築されており、アプリケーションを立ち上げ、ブラウザを操作することでレポートの出力と閲覧ができます
-- 以下の手順は、ローカル環境で docker compose を使用してセットアップする際の手順となります
-- リモート環境でホスティングする場合は、個別のサービス（public-viewer, admin, api）について、適切に環境変数を設定した上でそれぞれホスティングしてください
-  - サービスごとに設定する環境変数は.env.example に記載しています
+## はじめに
 
-### おすすめクラスタ数設定
+### 一般ユーザーの方（アプリを「使う」だけ）
 
-レポート作成時の意見グループ数（クラスタ数）の目安は以下の通りです：
+お使いの OS のセットアップガイドを参照してください。
 
-- コメント数の立方根（∛n）を基準として設定することをお勧めします
-- 例：
-  - 1000 件のコメント: 10→100（一層目 → 二層目）
-  - 8000 件のコメント: 20→400
-  - 125 件のコメント: 5→25
-  - 400 件のコメント: 7→50
-- デフォルト設定は上記に基づいて設定されますが、コメント数に応じて調整することで最適な分析結果が得られます
+- [Windows セットアップガイド](https://digitaldemocracy2030.github.io/kouchou-ai/getting-started/windows-setup)
+- [Mac セットアップガイド](https://digitaldemocracy2030.github.io/kouchou-ai/getting-started/mac-setup)
+- [Linux セットアップガイド](https://digitaldemocracy2030.github.io/kouchou-ai/getting-started/linux-setup)
 
-### 手順
+### 開発者の方（コードを触る）
 
-- 開発者でない方は以下のユーザーガイドを参照してください：
+利用モード別（Docker Compose / フロントだけ / native / CLI）の入口は **[開発者向けスタートガイド](https://digitaldemocracy2030.github.io/kouchou-ai/development/developer-quickstart)** に集約しました。
 
-  - [Windows 環境でのユーザーガイド](https://digitaldemocracy2030.github.io/kouchou-ai/getting-started/windows-setup)
-  - [Mac 環境でのユーザーガイド](https://digitaldemocracy2030.github.io/kouchou-ai/getting-started/mac-setup)
-  - [Linux 環境でのユーザーガイド](https://digitaldemocracy2030.github.io/kouchou-ai/getting-started/linux-setup)
+最短：Docker Compose で全体を起動
 
-- 開発者向け：
-  - リポジトリをクローン
-  - `cp .env.example .env` をコンソールで実行
-    - コピー後に各環境変数を設定。各環境変数の意味は.env.example に記載。
-  - `docker compose up` をコンソールで実行
-    - ブラウザで http://localhost:3000 にアクセスすることでレポート一覧画面にアクセス可能
-    - ブラウザで http://localhost:4000 にアクセスすることで管理画面にアクセス可能
-    - 環境変数（.env）を編集した場合は、`docker compose down` を実行した後、 `docker compose up --build` を実行してアプリケーションを起動してください
-      - 一部の環境変数は Docker イメージのビルド時に埋め込まれているため、環境変数を変更した場合はビルドの再実行が必要となります
-    - すべてのモジュールを起動すると遅い場合は `docker compose up --no-deps public-viewer api` など適宜絞って起動できます
-
-### ローカル LLM の使用
-
-GPU を搭載したマシンでローカル LLM を使用したい場合は、以下の手順に従ってください：
-
-1. `.env`ファイルに`WITH_GPU=true`を設定します
-2. 以下のコマンドを実行して Ollama を含めたサービスを起動します：
-   ```sh
-   docker compose --profile ollama up -d
-   ```
-3. Ollama サービスが起動し、ポート 11434 で利用可能になります
-4. デフォルトでは `hf.co/elyza/Llama-3-ELYZA-JP-8B-GGUF` モデルが自動的にダウンロードされます
-5. ダウンロードが完了したモデルはレポート生成時に選択して使用できます
-
-**前提条件**:
-
-- **Linux**・**Windows**：
-
-  - NVIDIA の GPU が搭載されていること
-  - 適切な NVIDIA ドライバーがインストールされていること
-  - NVIDIA Container Toolkit に相当するものがインストールされていること
-    - Linux では nvidia-docker2 / NVIDIA Container Toolkit
-    - Windows では Docker Desktop の GPU サポート設定
-  - デフォルトのモデルデータのダウンロードとインストールに約 5GB 以上の空きディスク容量が必要
-
-- **macOS**：
-  - Apple Silicon (M1/M2/M3)やほとんどの Intel Mac では、NVIDIA GPU の利用は基本的に対応していません
-
-**注意**:
-
-- ローカル LLM の使用には十分な GPU メモリが必要です（8GB 以上推奨）
-- 初回起動時にはモデルのダウンロードに時間がかかる場合があります
-
-### Google Analytics の設定
-
-- Google Analytics 4（GA4）を使用して、ユーザーのアクセス解析を行うことができます
-- 設定手順:
-  1. Google Analytics アカウントを作成し、データストリームを設定して測定 ID を取得します（G-XXXXXXXXXX の形式）
-  2. `.env` ファイルに以下の環境変数を設定します:
-     - `NEXT_PUBLIC_GA_MEASUREMENT_ID`: クライアントアプリ（ポート 3000）用の測定 ID
-     - `NEXT_PUBLIC_ADMIN_GA_MEASUREMENT_ID`: 管理画面アプリ（ポート 4000）用の測定 ID
-  3. 本番環境（`ENVIRONMENT=production` または `NODE_ENV=production`）でのみ Google Analytics が有効になります
-     - 開発環境では自動的に無効化されるため、開発中のアクセスはカウントされません
-
-アプリ起動後の、アプリの操作方法については[広聴 AI の使い方](https://digitaldemocracy2030.github.io/kouchou-ai/user-guide/how-to-use)を参照
-
-### メタデータファイルのセットアップ
-
-レポート作成者に関する情報（ロゴ画像やリンクなど）をカスタマイズするには、以下の手順で設定してください。
-
-1. デフォルト環境について
-
-  - デフォルト環境（`apps/api/public/meta/default`）では、画像やリンクは表示されません
-   - これはテスト環境用の設定であり、本番環境では使用しないでください
-
-2. カスタマイズ方法
-
-  - `apps/api/public/meta/custom` ディレクトリに以下のファイルを配置することで、レポート作成者情報をカスタマイズできます：
-     - `metadata.json`: レポート作成者の基本情報
-     - `reporter.png`: レポート作成者のロゴ画像
-     - `icon.png`: レポートのアイコン画像
-     - `ogp.png`: レポートの OGP 画像
-
-3. 表示の条件
-   - 画像の表示：`reporter.png`が`custom`ディレクトリに存在する場合のみ表示されます
-   - リンクの表示：`metadata.json`の各リンク（webLink, privacyLink, termsLink）に値が設定されている場合のみ表示されます
-   - 値が空の場合や、ファイルが存在しない場合は、該当する要素は表示されません
-
-### Azure 環境へのセットアップ
-
-Azure 環境にセットアップする方法は[Azure 環境へのセットアップ方法](https://digitaldemocracy2030.github.io/kouchou-ai/deployment/azure)を参照
-
-### 静的ファイル出力
-
-レポートを閲覧する画面は、静的ファイルとしても出力できます。  
-出力したファイルを Web サーバーに配置することで、アプリを起動せずにレポートを閲覧することが可能です。
-
-静的ファイルを生成する場合は、以下のコマンドを実行してください。
-
-```sh
-make client-build-static
+```bash
+git clone https://github.com/digitaldemocracy2030/kouchou-ai.git
+cd kouchou-ai
+cp .env.example .env       # OPENAI_API_KEY 等を設定
+docker compose up
 ```
 
-`out/` ディレクトリに静的ファイルが出力されますので、Web サーバーに配置してください。
+- public-viewer: <http://localhost:3000>
+- admin: <http://localhost:4000>
+- api: <http://localhost:8000/docs>
 
-静的エクスポートしたレポートをGithub Pagesにホスティングする手順は[GitHub Pagesの静的ファイルホスティング手順](https://digitaldemocracy2030.github.io/kouchou-ai/deployment/github-pages)を参照。
+!!! note "`.env` を編集したら再ビルドが必要なことがある"
+    一部の環境変数はビルド時に埋め込まれるため、変更後は `docker compose down && docker compose up --build` が必要です。詳細は [開発者向けスタートガイド](https://digitaldemocracy2030.github.io/kouchou-ai/development/developer-quickstart) を参照。
 
-静的ホスティング環境で CSP を付与する場合は、[静的ホスティング向け CSP 設定ガイド](https://digitaldemocracy2030.github.io/kouchou-ai/deployment/static-hosting-csp)も参照してください。`img-src` に `blob:` が無いと Plotly の PNG ダウンロードがブラウザにブロックされます。
+その他のモード（フロントだけ触る / native 起動 / CLI 利用）と、環境変数の置き場所・よくある落とし穴は [開発者向けスタートガイド](https://digitaldemocracy2030.github.io/kouchou-ai/development/developer-quickstart) にまとめています。
 
 ## アーキテクチャ概要
 
-本システムは以下のサービスで構成されています。
+| サービス | ポート | 役割 |
+|---------|-------|------|
+| public-viewer | 3000 | レポート閲覧用フロントエンド（Next.js） |
+| admin | 4000 | レポート作成・管理用フロントエンド（Next.js） |
+| api | 8000 | バックエンド API、レポート生成パイプライン（FastAPI） |
+| ollama（オプション） | 11434 | ローカル LLM 推論 |
 
-### api
+詳細：[ドキュメントサイト](https://digitaldemocracy2030.github.io/kouchou-ai/)
 
-- ポート: 8000
-- 役割: バックエンド API サービス
-- 主要機能:
-  - レポートデータの取得・管理
-  - レポート生成パイプラインの実行
-  - 管理用 API の提供
-- 技術スタック:
-  - Python (FastAPI)
-  - Docker
+## デプロイ / 静的出力 / カスタマイズ
 
-### public-viewer
-
-- ポート: 3000
-- 役割: レポート表示用フロントエンド
-- 主要機能:
-  - レポートの可視化
-  - インタラクティブなデータ分析
-  - ユーザーフレンドリーなインターフェース
-- 技術スタック:
-  - Next.js
-  - TypeScript
-  - Docker
-
-### admin
-
-- ポート: 4000
-- 役割: 管理用フロントエンド
-- 主要機能:
-  - レポートの作成・編集
-  - パイプライン設定の管理
-  - システム設定の管理
-- 技術スタック:
-  - Next.js
-  - TypeScript
-  - Docker
-
-### utils/dummy-server
-
-- 役割: 開発用ダミー API
-- 用途: 開発環境での API モックとして使用
-
-## public-viewer の開発環境の構築手順
-
-フロントエンドのアプリケーション(public-viewer と admin) を開発用のダミーサーバ (dummy-server) をバックエンドとして起動する手順です。
-
-### 1. public-viewer, admin, dummy-server の環境構築
-
-```sh
-make client-setup
-```
-
-### 2. 開発サーバーを起動
-
-```sh
-make client-dev -j 3
-```
+- [Azure 環境へのセットアップ](https://digitaldemocracy2030.github.io/kouchou-ai/deployment/azure)
+- [GitHub Pages で静的ホスティング](https://digitaldemocracy2030.github.io/kouchou-ai/deployment/github-pages)
+- [静的ホスティング向け CSP 設定](https://digitaldemocracy2030.github.io/kouchou-ai/deployment/static-hosting-csp)
+- レポート作成者情報（ロゴ・リンク）のカスタマイズ → [ドキュメントサイト](https://digitaldemocracy2030.github.io/kouchou-ai/)
 
 ## 免責事項
 
@@ -219,22 +74,19 @@ make client-dev -j 3
 
 ## 注意事項
 
-本アプリは開発の初期段階であり、今後開発を進めていく過程で前バージョンと互換性のない変更が行われる可能性があります。
-アプリをアップデートする際には、重要なデータ（レポート）がある場合はアプリ・データのバックアップを保存した上でアップデートすることを推奨します。
+本アプリは開発の初期段階であり、今後開発を進めていく過程で前バージョンと互換性のない変更が行われる可能性があります。アプリをアップデートする際には、重要なデータ（レポート）がある場合はアプリ・データのバックアップを保存した上でアップデートすることを推奨します。
 
-## 開発者向けのガイドライン
+## 開発者向けガイドライン
 
-広聴 AI は OSS として開発されており、開発者の方からのコントリビュートを募集しています。
-詳しくは、[コントリビューションガイド](https://digitaldemocracy2030.github.io/kouchou-ai/development/contributing)を参照ください。
-また、本プロジェクトでは AI エンジニア「[Devin](https://cognition.ai)」との協働開発を行っています。
-現時点での Devin とのコラボレーションについては、模索中ですが [Devin とのコラボレーション](https://digitaldemocracy2030.github.io/kouchou-ai/development/devin-collaboration)を参照してください。
+広聴 AI は OSS として開発されており、開発者の方からのコントリビュートを募集しています。詳しくは [コントリビューションガイド](https://digitaldemocracy2030.github.io/kouchou-ai/development/contributing) を参照ください。
+
+AI エンジニア（Claude Code / Codex / Devin）との協働方針は [Claude Code / Codex スキル](https://digitaldemocracy2030.github.io/kouchou-ai/development/ai-assistants) と [Devin とのコラボレーション](https://digitaldemocracy2030.github.io/kouchou-ai/development/devin-collaboration) を参照してください。
 
 ## 機能要望・バグ報告について
 
-- github アカウントをお持ちの方は、[Issue](https://github.com/digitaldemocracy2030/kouchou-ai/issues) にバグ・改善要望を投稿してください
-- github アカウントをお持ちでない方は、以下の google form よりバグ・改善要望を投稿してください
-  - [バグ報告・改善要望フォーム](https://docs.google.com/forms/d/e/1FAIpQLSf43rpi8N1hGQmECDOBOmiV3c-Buwf4gWSj2sYc2KbZL9NOBA/viewform?usp=dialog)
+- github アカウントをお持ちの方は [Issue](https://github.com/digitaldemocracy2030/kouchou-ai/issues) にバグ・改善要望を投稿してください
+- github アカウントをお持ちでない方は [バグ報告・改善要望フォーム](https://docs.google.com/forms/d/e/1FAIpQLSf43rpi8N1hGQmECDOBOmiV3c-Buwf4gWSj2sYc2KbZL9NOBA/viewform?usp=dialog) より投稿してください
 
 ## クレジット
 
-このプロジェクトは、[AI Objectives Institute](https://www.aiobjectivesinstitute.org/) が開発した [Talk to the City](https://github.com/AIObjectives/talk-to-the-city-reports)を参考に開発されており、ライセンスに基づいてソースコードを一部活用し、機能追加や改善を実施しています。ここに原作者の貢献に感謝の意を表します。
+このプロジェクトは、[AI Objectives Institute](https://www.aiobjectivesinstitute.org/) が開発した [Talk to the City](https://github.com/AIObjectives/talk-to-the-city-reports) を参考に開発されており、ライセンスに基づいてソースコードを一部活用し、機能追加や改善を実施しています。ここに原作者の貢献に感謝の意を表します。

--- a/docs/development/developer-quickstart.md
+++ b/docs/development/developer-quickstart.md
@@ -50,7 +50,7 @@ docker compose up
 docker compose --profile ollama up -d
 ```
 
-詳細は [README](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/README.md) の「ローカル LLM の使用」節を参照。
+利用するモデルは事前に `ollama pull <model>` で取得しておくと、admin UI のモデル一覧から選択できます。サポートされるモデルは [Ollama 公式モデルライブラリ](https://ollama.com/library) を参照してください。
 
 ### よくある落とし穴（Mode 1）
 

--- a/docs/development/developer-quickstart.md
+++ b/docs/development/developer-quickstart.md
@@ -1,0 +1,218 @@
+# 開発者向けスタートガイド
+
+広聴 AI の開発者向け canonical な入口ページです。**「自分はどの起動モードを使うべきか」をこのページの最初で判断**してから、対応するモードの節へ進んでください。
+
+!!! info "一般ユーザーの方へ"
+    アプリを「使う」だけが目的の方は、OS 別セットアップ（[Windows](../getting-started/windows-setup.md) / [Mac](../getting-started/mac-setup.md) / [Linux](../getting-started/linux-setup.md)）をご覧ください。本ページはローカルで広聴 AI の **コードを触る** 人向けです。
+
+## どの起動モードを選ぶか
+
+| やりたいこと | 推奨モード | 起動コストの目安 |
+|---|---|---|
+| まず動かして全体像を掴みたい / バックエンドも含めて E2E で確認したい | [Mode 1: Docker Compose](#mode-1-docker-compose) | 初回ビルド数分、以降は速い |
+| public-viewer / admin の **UI だけ** を触りたい（API のロジックは触らない） | [Mode 2: dummy-server + frontend dev](#mode-2-dummy-server-frontend-dev) | pnpm + Node のみ、Docker 不要 |
+| `apps/api` または `apps/admin` を **個別にデバッガで動かしたい** / ホットリロードしたい | [Mode 3: native 起動](#mode-3-native) | Rye + pnpm のローカル install |
+| CSV → クラスタリング結果を CLI で回したい / `packages/analysis-core` を組み込みたい | [Mode 4: CLI / analysis-core](#mode-4-cli-analysis-core) | pip install のみ、Docker / Node 不要 |
+
+迷ったら **Mode 1** から始めるのが安全です。Mode 1 で全体像を掴んでから、触りたいレイヤに応じて Mode 2〜4 へ降りていく流れを想定しています。
+
+---
+
+## Mode 1: Docker Compose（全体を一発で起動） { #mode-1-docker-compose }
+
+### 必要なもの
+
+- Docker Desktop または Docker Engine + Compose v2
+- OpenAI / Gemini / OpenRouter / Azure OpenAI / ローカル LLM のいずれかの API キー
+
+### 手順
+
+```bash
+git clone https://github.com/digitaldemocracy2030/kouchou-ai.git
+cd kouchou-ai
+cp .env.example .env
+# .env を編集して OPENAI_API_KEY 等を設定
+docker compose up
+```
+
+### 確認 URL
+
+| サービス | URL |
+|---|---|
+| public-viewer（レポート閲覧） | <http://localhost:3000> |
+| admin（レポート作成・管理） | <http://localhost:4000> |
+| api（FastAPI / Swagger UI） | <http://localhost:8000/docs> |
+
+### ローカル LLM（Ollama）を併用する場合
+
+```bash
+# .env に WITH_GPU=true を追加してから
+docker compose --profile ollama up -d
+```
+
+詳細は [README](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/README.md) の「ローカル LLM の使用」節を参照。
+
+### よくある落とし穴（Mode 1）
+
+- **`.env` を編集したのに反映されない**: 一部の環境変数は Docker イメージのビルド時に埋め込まれます。`docker compose down && docker compose up --build` で再ビルドしてください。
+- **全部起動すると遅い**: `docker compose up --no-deps public-viewer api` のように対象サービスだけ起動できます。
+
+---
+
+## Mode 2: dummy-server + frontend dev（UI のみ） { #mode-2-dummy-server-frontend-dev }
+
+public-viewer / admin の UI を触りたいが、Python バックエンドは動かしたくない（または API のロジックは別途モックしたい）場合のモードです。`utils/dummy-server` が固定レスポンスを返す軽量サーバとして API を代替します。
+
+### 必要なもの
+
+- Node.js + **pnpm 9.15.4**（corepack 経由が推奨）。npm は非対応 ⇒ [なぜ pnpm か](why-pnpm.md)
+
+### 手順
+
+```bash
+# 初回のみ：pnpm install と各 app の .env コピー
+make client-setup
+
+# public-viewer + admin + dummy-server を並行起動
+make client-dev -j 3
+```
+
+### 確認 URL
+
+| サービス | URL |
+|---|---|
+| public-viewer | <http://localhost:3000> |
+| admin | <http://localhost:4000> |
+| dummy-server（API モック） | <http://localhost:8000> |
+
+### よくある落とし穴（Mode 2）
+
+- **`pnpm` が無い**: corepack で導入してください。`corepack enable && corepack prepare pnpm@9.15.4 --activate`
+- **`.env` が無いと怒られる**: `make client-setup` は `apps/public-viewer/.env-sample` / `apps/admin/.env-sample` / `utils/dummy-server/.env-sample` を `.env` にコピーします。手動で起動する場合は同じコピーを忘れずに。
+
+---
+
+## Mode 3: native 起動（apps/api / apps/admin を個別に） { #mode-3-native }
+
+Python / Next.js のデバッガを使って `apps/api` や `apps/admin` を直接動かしたい場合のモードです。Docker は使いません。
+
+### 必要なもの
+
+- Python 3.12 + **Rye**（バックエンド）
+- Node.js + pnpm 9.15.4（フロント）
+- OpenAI 等の API キー
+
+### 3-1. api を native で起動
+
+```bash
+# 1. ルートの .env（コンテナ向け）とは別に、apps/api 用の .env を用意
+cp apps/api/.env.example apps/api/.env
+```
+
+`apps/api/.env` に最低限以下を入れます。
+
+```env
+ADMIN_API_KEY=admin
+PUBLIC_API_KEY=public
+OPENAI_API_KEY=sk-your-api-key-here
+LOG_FILE=apps/api/error.log
+```
+
+```bash
+cd apps/api
+rye sync
+rye run python -m ensurepip --upgrade
+rye run python -m pip install -e ../../packages/analysis-core
+make run
+# -> http://localhost:8000/docs (Swagger UI)
+```
+
+!!! warning "analysis-core の editable install は必須"
+    `packages/analysis-core` の editable install を忘れると、起動時に `No module named analysis_core` で落ちます。上記コマンドの 3 行目を必ず実行してください。
+
+### 3-2. admin を native で起動
+
+```bash
+cp apps/admin/.env.example apps/admin/.env
+```
+
+`apps/admin/.env`：
+
+```env
+NEXT_PUBLIC_API_BASEPATH=http://localhost:8000
+NEXT_PUBLIC_ADMIN_API_KEY=admin
+NEXT_PUBLIC_CLIENT_BASEPATH=http://localhost:3000
+```
+
+```bash
+cd apps/admin
+pnpm dev
+# -> http://localhost:4000
+```
+
+### 確認 URL
+
+| サービス | URL |
+|---|---|
+| api | <http://localhost:8000/docs> |
+| admin | <http://localhost:4000> |
+| public-viewer（必要なら別途 `pnpm --filter @kouchou-ai/public-viewer dev`） | <http://localhost:3000> |
+
+### よくある落とし穴（Mode 3）
+
+- **`.env` の置き場所が複数ある**: ルートの `.env`（Docker Compose 用）/ `apps/api/.env`（native api 用）/ `apps/admin/.env`（native admin 用）は **別物** です。native モードで起動するときはルート `.env` は使われません。
+- **admin のレポートリンクが `undefined`**: `apps/admin/.env` の `NEXT_PUBLIC_CLIENT_BASEPATH` が未設定です。上記のように `http://localhost:3000` を設定して `pnpm dev` を再起動してください。
+- **api のエラーログ**: `LOG_FILE` 設定済みなら `apps/api/error.log` に出ます。
+
+---
+
+## Mode 4: CLI / analysis-core { #mode-4-cli-analysis-core }
+
+`packages/analysis-core` を Python ライブラリ / CLI として使い、CSV → クラスタリングのパイプラインを Docker / Node なしで回すモードです。
+
+### 必要なもの
+
+- Python 3.12 以上
+- OpenAI / Azure OpenAI / Gemini いずれかの API キー
+
+### 手順
+
+```bash
+python3.12 -m venv .venv
+source .venv/bin/activate
+pip install 'kouchou-ai-analysis-core[embeddings,clustering]'
+
+kouchou-analyze --version
+kouchou-analyze --config config.json --dry-run
+kouchou-analyze --config config.json
+```
+
+完全なフローは [CLI クイックスタート](../user-guide/cli-quickstart.md) を参照してください（config.json の書式、出力ファイルの読み方、Azure OpenAI / Gemini 切替、トラブルシューティング含む）。
+
+### よくある落とし穴（Mode 4）
+
+- **`No module named analysis_core`**: base install だけだと embedding / clustering 系の依存が入りません。`pip install 'kouchou-ai-analysis-core[embeddings,clustering]'` で extras 付きで入れてください。
+- **`Unknown provider: None`**: `config.json` に `"provider": "openai"` 等を明示してください。
+- **`Job already running`**: 前回実行のロックです。`rm -rf outputs/<config_name>` で消してから再実行。
+
+---
+
+## 環境変数の置き場所まとめ
+
+| ファイル | 使われるモード | 主な用途 |
+|---|---|---|
+| `.env`（ルート） | Mode 1（Docker Compose） | `docker compose` 起動時のサービス共通設定 |
+| `apps/api/.env` | Mode 3（native api） | `rye run` で起動する api の設定 |
+| `apps/admin/.env` | Mode 2 / Mode 3 | `pnpm dev` で起動する admin の設定 |
+| `apps/public-viewer/.env` | Mode 2 / Mode 3 | `pnpm dev` で起動する public-viewer の設定 |
+| `utils/dummy-server/.env` | Mode 2 | dummy-server の API キー設定 |
+| `.env`（CLI 実行ディレクトリ） | Mode 4 | `kouchou-analyze` 実行時の API キー |
+
+ルート `.env` を編集しても native / CLI モードには反映されないので、モード切替時は対象 `.env` をそれぞれ更新してください。
+
+## 次のステップ
+
+- API キー周りの選択肢（Azure OpenAI / Gemini / Ollama 等） ⇒ [CLI クイックスタート](../user-guide/cli-quickstart.md)
+- アーキテクチャをもっと知る ⇒ [ドキュメントサイトのトップ](../index.md)
+- コントリビュート手順 ⇒ [コントリビューションガイド](contributing.md)
+- AI コーディングエージェント（Claude Code / Codex）と協働する ⇒ [Claude Code / Codex スキル](ai-assistants.md)

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,6 +1,9 @@
 # クイックスタート
 
-このガイドでは、広聴AIを最短で使い始めるための手順を説明します。
+このガイドでは、広聴AIを最短で使い始めるための手順を説明します（Docker Compose で全体を起動するモード）。
+
+!!! info "コードを触る開発者の方へ"
+    フロントエンドだけ触りたい / `apps/api` を native で起動したい / `packages/analysis-core` を CLI で使いたい場合は、[開発者向けスタートガイド](../development/developer-quickstart.md) に利用モード別の入口がまとまっています。
 
 ## 前提条件
 
@@ -14,7 +17,7 @@
     - [Mac セットアップ](mac-setup.md)
     - [Linux セットアップ](linux-setup.md)
 
-## 開発者向けクイックスタート
+## クイックスタート（Docker Compose）
 
 ### 1. リポジトリをクローン
 
@@ -49,48 +52,9 @@
 | 管理画面 | http://localhost:4000 | レポートの作成・管理 |
 | API | http://localhost:8000 | バックエンド API |
 
-## ローカル開発（Dockerを使わずに起動）
+## Docker を使わずに起動したい場合
 
-Dockerを使わずに `apps/api` と `apps/admin` を個別に起動する場合は、以下を実行します。
-
-### 1. API 側の環境変数
-
-    cp apps/api/.env.example apps/api/.env
-
-`apps/api/.env` に最低限以下を設定します：
-
-    ADMIN_API_KEY=admin
-    PUBLIC_API_KEY=public
-    OPENAI_API_KEY=sk-your-api-key-here
-    LOG_FILE=apps/api/error.log
-
-### 2. API 依存のセットアップと起動
-
-    cd apps/api
-    rye sync
-    rye run python -m ensurepip --upgrade
-    rye run python -m pip install -e ../../packages/analysis-core
-    make run
-
-!!! note "analysis-core について"
-    analysis-core が未インストールだと `No module named analysis_core` で失敗します。上記の editable install を必ず実行してください。
-
-### 3. 管理画面（admin）の環境変数
-
-    cp apps/admin/.env.example apps/admin/.env
-
-`apps/admin/.env` を以下のように設定します：
-
-    NEXT_PUBLIC_API_BASEPATH=http://localhost:8000
-    NEXT_PUBLIC_ADMIN_API_KEY=admin
-
-### 4. 管理画面の起動
-
-    cd apps/admin
-    pnpm dev
-
-!!! tip "APIのエラー確認"
-    `LOG_FILE` を設定している場合は `apps/api/error.log` にエラーが出力されます。
+`apps/api` / `apps/admin` を native で起動するモード、フロントエンドだけ dummy-server 経由で触るモード、CLI から `kouchou-analyze` を回すモードは、[開発者向けスタートガイド](../development/developer-quickstart.md) にまとまっています。
 
 ## 基本的な使い方
 
@@ -138,15 +102,6 @@ Docker Desktop が起動しているか確認してください。
 ### API キーのエラー
 
 `.env` ファイルの `OPENAI_API_KEY` が正しく設定されているか確認してください。
-
-### 管理画面のレポートリンクが `undefined` になる
-
-管理画面のレポートリンクが `http://localhost:4000/undefined/...` になる場合は、
-`apps/admin/.env` に `NEXT_PUBLIC_CLIENT_BASEPATH` が未設定です。
-
-    NEXT_PUBLIC_CLIENT_BASEPATH=http://localhost:3000
-
-設定後に `pnpm dev` を再起動してください。
 
 ### ポートが使用中
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,22 +41,20 @@
 
 ### 開発者向け
 
+ローカルでコードを触る場合は **[開発者向けスタートガイド](development/developer-quickstart.md)** が canonical な入口です。利用モード（Docker Compose / フロントだけ / native 起動 / CLI）ごとに必要な環境変数・起動コマンド・確認 URL・落とし穴を 1 ページに集約しています。
+
+最短：Docker Compose で全体を起動
+
 ```bash
-# リポジトリをクローン
 git clone https://github.com/digitaldemocracy2030/kouchou-ai.git
 cd kouchou-ai
-
-# 環境設定
-cp .env.example .env
-# .env ファイルを編集して API キーなどを設定
-
-# 起動
+cp .env.example .env       # OPENAI_API_KEY 等を設定
 docker compose up
 ```
 
-- レポート一覧: http://localhost:3000
-- 管理画面: http://localhost:4000
-- API: http://localhost:8000
+- レポート一覧: <http://localhost:3000>
+- 管理画面: <http://localhost:4000>
+- API: <http://localhost:8000/docs>
 
 ## アーキテクチャ
 
@@ -86,9 +84,11 @@ docker compose up
 
 ## ドキュメント構成
 
-- **[はじめに](getting-started/quickstart.md)**: セットアップと基本的な使い方
+- **[はじめに](getting-started/quickstart.md)**: 一般ユーザー向け Docker クイックスタートと OS 別セットアップ
+- **[開発者向けスタートガイド](development/developer-quickstart.md)**: コードを触る開発者のための利用モード別 canonical 入口
 - **[ユーザーガイド](user-guide/how-to-use.md)**: 詳細な操作方法
-- **[開発者向け](development/contributing.md)**: コントリビューション方法、プラグイン開発
+- **[CLI クイックスタート](user-guide/cli-quickstart.md)**: `kouchou-analyze` / `packages/analysis-core` での実行手順
+- **[コントリビューション](development/contributing.md)**: 開発参加方法、プラグイン開発
 - **[デプロイ](deployment/azure.md)**: Azure、GitHub Pages、静的ホスティング時の CSP 設定
 - **[静的ホスティング向け CSP 設定](deployment/static-hosting-csp.md)**: Azure Static Web Apps / Cloudflare Pages / Nginx での CSP 例
 - **[技術解説資料](https://www.docswell.com/s/tokoroten/ZL1M88-2025-06-14-014546)**: プロジェクトの技術的背景と設計思想（外部リンク）

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,6 +78,7 @@ nav:
       - インポート方法: user-guide/import-quickstart.md
       - FAQ: user-guide/faq.md
   - 開発者向け:
+      - 開発者向けスタートガイド: development/developer-quickstart.md
       - コントリビューション: development/contributing.md
       - Claude Code/Codex スキル: development/ai-assistants.md
       - npmではなくpnpmを使う理由: development/why-pnpm.md


### PR DESCRIPTION
## Summary

- `docs/development/developer-quickstart.md` を新規追加し、開発者向けの canonical 入口に。Docker Compose / dummy-server + frontend dev / native (apps/api・apps/admin) / CLI (analysis-core) の 4 モードへ「最初の 1 ページ」で分岐できるようにした。
- 各モードで必要な環境変数・起動コマンド・確認 URL・よくある落とし穴を 1 ページに集約。`.env` の置き場所がモードごとに異なる点、Docker 環境変数のビルド時埋め込み、`analysis-core` の editable install といった見落としやすい注意点を明示。
- `README.md` を概要 + docs サイト導線に絞り、長い setup 説明・ローカル LLM / GA / メタデータ / 静的出力の詳細はドキュメントサイトへ集約。
- `docs/index.md` / `docs/getting-started/quickstart.md` / `mkdocs.yml` を新ページに合わせて整理（重複削除、nav 追加）。

closes #876

## Test plan

- [ ] `mkdocs build --strict` がローカルでクリーン pass することを確認済み（CI でも回す）
- [ ] レンダリング後の `developer-quickstart` ページで 4 モードの anchor (#mode-1-docker-compose 等) が機能する
- [ ] `docs/getting-started/quickstart.md` → 開発者向けスタートガイドへの導線リンクが click 可能
- [ ] `README.md` の最短手順 (`docker compose up`) で localhost:3000 / 4000 / 8000 が起動する（既存挙動の維持確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Major README rewrite: concise project overview, launch shortcuts, links to docs, and simplified warnings/credit text.
  * Added developer quickstart with four startup modes (Docker Compose, UI-only mock, native apps, and CLI/data mode).
  * Reworked getting-started to favor Docker Compose quickstart.
  * Updated docs index and site navigation to include the new developer-start guide.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/digitaldemocracy2030/kouchou-ai/pull/883?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->