### PR TITLE
[codex] Fix Plotly scattergl CSP

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ make client-build-static
 
 静的エクスポートしたレポートをGithub Pagesにホスティングする手順は[GitHub Pagesの静的ファイルホスティング手順](https://digitaldemocracy2030.github.io/kouchou-ai/deployment/github-pages)を参照。
 
-静的ホスティング環境で CSP を付与する場合は、[静的ホスティング向け CSP 設定ガイド](https://digitaldemocracy2030.github.io/kouchou-ai/deployment/static-hosting-csp)も参照してください。`img-src` に `blob:` が無いと Plotly の PNG ダウンロードがブラウザにブロックされます。
+静的ホスティング環境で CSP を付与する場合は、[静的ホスティング向け CSP 設定ガイド](https://digitaldemocracy2030.github.io/kouchou-ai/deployment/static-hosting-csp)も参照してください。Plotly の `scattergl` には `script-src 'unsafe-eval'` が必要で、`img-src` に `blob:` が無いと PNG ダウンロードがブラウザにブロックされます。
 
 ## アーキテクチャ概要
 

--- a/apps/admin/app/utils/__tests__/csp.test.ts
+++ b/apps/admin/app/utils/__tests__/csp.test.ts
@@ -25,6 +25,13 @@ describe("CSP helpers", () => {
     expect(csp).toContain("connect-src 'self' http://18.233.19.158:8000 http://18.233.19.158:4000");
     expect(csp).toContain("style-src 'self' 'unsafe-inline' https://fonts.googleapis.com");
     expect(csp).toContain("font-src 'self' data: https://fonts.gstatic.com");
+    expect(csp).not.toContain("'unsafe-eval'");
+  });
+
+  it("allows unsafe-eval when explicitly enabled for Plotly scattergl", () => {
+    const csp = buildCspHeaderValue({ allowUnsafeEval: true });
+
+    expect(csp).toContain("script-src 'self' 'unsafe-inline' 'unsafe-eval'");
   });
 
   it("adds Google Analytics origins only when enabled", () => {

--- a/apps/public-viewer/next.config.ts
+++ b/apps/public-viewer/next.config.ts
@@ -11,6 +11,8 @@ const contentSecurityPolicy = buildCspHeaderValue({
   publicApiBasePath: process.env.NEXT_PUBLIC_API_BASEPATH,
   siteUrl: process.env.NEXT_PUBLIC_SITE_URL,
   enableGoogleAnalytics,
+  // Plotly scattergl uses regl, which requires runtime eval during WebGL initialization.
+  allowUnsafeEval: true,
   isDevelopment: process.env.NODE_ENV !== "production",
 });
 

--- a/apps/shared/csp.ts
+++ b/apps/shared/csp.ts
@@ -30,6 +30,7 @@ type BuildCspOptions = {
   publicApiBasePath?: string;
   siteUrl?: string;
   enableGoogleAnalytics?: boolean;
+  allowUnsafeEval?: boolean;
   isDevelopment?: boolean;
 };
 
@@ -40,6 +41,7 @@ export const buildCspHeaderValue = ({
   publicApiBasePath,
   siteUrl,
   enableGoogleAnalytics = false,
+  allowUnsafeEval = false,
   isDevelopment = false,
 }: BuildCspOptions): string => {
   const remoteOrigins = extractAllowedOrigins([apiBasePath, publicApiBasePath, siteUrl]);
@@ -49,7 +51,7 @@ export const buildCspHeaderValue = ({
   const imgSrc = ["'self'", "data:", "blob:", ...remoteOrigins];
   const connectSrc = ["'self'", ...remoteOrigins];
 
-  if (isDevelopment) {
+  if (isDevelopment || allowUnsafeEval) {
     scriptSrc.push("'unsafe-eval'");
   }
 

--- a/docs/deployment/static-hosting-csp.md
+++ b/docs/deployment/static-hosting-csp.md
@@ -22,21 +22,24 @@ const nextConfig: NextConfig = {
 
 このモードでは、Next.js アプリ側で動的にレスポンスヘッダーを配る前提が弱くなるため、**CSP は配信先の CDN / リバースプロキシ / 静的ホスティング設定で付与する**のが基本です。
 
-特に Plotly の PNG ダウンロードでは、ブラウザが `blob:` URL を使って画像を書き出します。CSP の `img-src` に `blob:` が入っていないと、ダウンロード処理がブラウザにブロックされます。
+Plotly の散布図は `scattergl` を使っており、内部の regl が WebGL 描画コマンド生成で runtime eval を使います。そのため CSP の `script-src` に `'unsafe-eval'` が入っていないと、WebGL 対応ブラウザでも Plotly の初期化が失敗し、`WebGL is not supported...` が表示されることがあります。
+
+また、Plotly の PNG ダウンロードでは、ブラウザが `blob:` URL を使って画像を書き出します。CSP の `img-src` に `blob:` が入っていないと、ダウンロード処理がブラウザにブロックされます。
 
 ## 最低限必要な考え方
 
-静的エクスポート配信でまず確認すべきなのは次の 3 点です。
+静的エクスポート配信でまず確認すべきなのは次の 4 点です。
 
-1. `img-src` に `blob:` を含める
-2. `img-src` に `data:` を含める
-3. 静的サイトから外部 API や解析タグへ通信する場合は、必要な origin を `connect-src` や `script-src` に明示する
+1. `script-src` に `'unsafe-eval'` を含める
+2. `img-src` に `blob:` を含める
+3. `img-src` に `data:` を含める
+4. 静的サイトから外部 API や解析タグへ通信する場合は、必要な origin を `connect-src` や `script-src` に明示する
 
 最小構成の例:
 
 ```text
 default-src 'self';
-script-src 'self' 'unsafe-inline';
+script-src 'self' 'unsafe-inline' 'unsafe-eval';
 style-src 'self' 'unsafe-inline';
 img-src 'self' data: blob:;
 font-src 'self' data:;
@@ -58,7 +61,7 @@ frame-ancestors 'none';
 ```text
 connect-src 'self' https://api.example.com https://www.google-analytics.com;
 img-src 'self' data: blob: https://images.example.com;
-script-src 'self' 'unsafe-inline' https://www.googletagmanager.com;
+script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com;
 ```
 
 ## Azure Static Web Apps
@@ -70,7 +73,7 @@ Azure Static Web Apps では、`staticwebapp.config.json` の `globalHeaders` �
 ```json
 {
   "globalHeaders": {
-    "content-security-policy": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https://api.example.com; frame-ancestors 'none';"
+    "content-security-policy": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https://api.example.com; frame-ancestors 'none';"
   }
 }
 ```
@@ -80,7 +83,7 @@ Azure Application Insights を使う場合は、必要に応じて `connect-src`
 例:
 
 ```text
-script-src 'self' 'unsafe-inline' https://js.monitor.azure.com;
+script-src 'self' 'unsafe-inline' 'unsafe-eval' https://js.monitor.azure.com;
 connect-src 'self' https://api.example.com https://js.monitor.azure.com https://*.applicationinsights.azure.com https://*.azurestaticapps.net;
 ```
 
@@ -92,7 +95,7 @@ Cloudflare Pages では、静的アセット配信に対して `_headers` ファ
 
 ```text
 /*
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https://api.example.com; frame-ancestors 'none';
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https://api.example.com; frame-ancestors 'none';
 ```
 
 `public/` に `_headers` を置いておくと、ビルド後の出力ディレクトリへ一緒にコピーされる構成では運用しやすいです。ただし、この repo では API origin や analytics origin が環境ごとに違うので、**固定値の `_headers` をそのままコミットするより、デプロイ前に環境に合わせて生成・配置する運用**を推奨します。
@@ -111,7 +114,7 @@ server {
     root /var/www/kouchou-ai-public-viewer;
     index index.html;
 
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https://api.example.com; frame-ancestors 'none';" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https://api.example.com; frame-ancestors 'none';" always;
 
     location / {
         try_files $uri $uri/ /index.html;
@@ -131,6 +134,7 @@ CSP を変更した後は、少なくとも次を確認してください。
 
 1. レポート画面が通常表示できる
 2. Scatter / Treemap / 階層リストが崩れない
-3. PNG ダウンロードがブラウザ console の CSP エラーなしで動く
-4. 外部 API を使う構成なら、network error ではなく正常応答になる
-5. 外部画像や監視タグを使う構成なら、それらが CSP で落ちていない
+3. Scatter の `scattergl` が `WebGL is not supported...` 表示なしで描画される
+4. PNG ダウンロードがブラウザ console の CSP エラーなしで動く
+5. 外部 API を使う構成なら、network error ではなく正常応答になる
+6. 外部画像や監視タグを使う構成なら、それらが CSP で落ちていない


### PR DESCRIPTION
close #886 

## 概要

本修正では、production 環境で Plotly の `scattergl` が初期化できるように、public viewer の CSP を修正しました。

## 根本原因

ブラウザは WebGL に対応しており、Plotly のデータも有効でしたが、production の CSP では `script-src 'self' 'unsafe-inline'` のみが許可されていました。

Plotly の `scattergl` は内部で regl を使用しており、regl は WebGL の描画コマンドを生成する際に runtime eval を必要とします。`'unsafe-eval'` がない場合、Plotly は `.no-webgl` オーバーレイを表示したままにし、WebGL 対応ブラウザでも `WebGL is not supported...` と表示します。

## 変更内容

* 共有 CSP ビルダーに明示的な `allowUnsafeEval` オプションを追加しました。
* Plotly の `scattergl` が使用される `public-viewer` で、そのオプションを有効化しました。
* その他の呼び出し元については、明示的に opt-in しない限り、デフォルトの CSP 挙動を変更しないようにしました。
* opt-in 挙動に対する CSP ヘルパーテストを追加しました。
* 静的ホスティング向けの CSP ドキュメントと README の注記を更新し、Plotly `scattergl` 用に `script-src 'unsafe-eval'` を含めるようにしました。

## 検証

* `./node_modules/.bin/biome check apps/shared/csp.ts apps/public-viewer/next.config.ts apps/admin/app/utils/__tests__/csp.test.ts`
* `./node_modules/.bin/jest app/utils/__tests__/csp.test.ts --runInBand`
* `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Plotly's scattergl visualization with proper Content Security Policy configuration.
  * Enabled PNG download functionality with updated CSP blob requirements.

* **Documentation**
  * Updated deployment guides with CSP requirements for scattergl and PNG downloads.
  * Added configuration examples for Azure Static Web Apps, Cloudflare Pages, and Nginx.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->