### PR TITLE
public-viewer の build と startup を分離する

### DIFF
--- a/.github/workflows/client-build.yml
+++ b/.github/workflows/client-build.yml
@@ -5,11 +5,17 @@ on:
     branches: [main]
     paths:
       - 'apps/public-viewer/**'
+      - 'apps/shared/**'
+      - 'packages/report-schema/**'
+      - 'utils/dummy-server/**'
       - '!apps/public-viewer/**/*.md'
   pull_request:
     branches: [main]
     paths:
       - 'apps/public-viewer/**'
+      - 'apps/shared/**'
+      - 'packages/report-schema/**'
+      - 'utils/dummy-server/**'
       - '!apps/public-viewer/**/*.md'
   workflow_dispatch:
 
@@ -35,8 +41,78 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Run build
+      - name: Run API-less dynamic build
         run: pnpm --filter @kouchou-ai/public-viewer build
+
+      - name: Start static export fixture API
+        run: |
+          node <<'NODE' &
+          const http = require("node:http");
+          const fs = require("node:fs");
+          const path = require("node:path");
+
+          const root = process.cwd();
+          const report = fs.readFileSync(path.join(root, "utils/dummy-server/app/reports/example/hierarchical_result.json"), "utf8");
+          const meta = fs.readFileSync(path.join(root, "utils/dummy-server/public/meta/metadata.json"), "utf8");
+          const reports = JSON.stringify([
+            {
+              slug: "example",
+              status: "ready",
+              title: "[テスト]人類が人工知能を開発・展開する上で、最優先すべき課題は何でしょうか？",
+              description: "static export fixture",
+              isPubcom: true,
+              visibility: "public",
+            },
+          ]);
+
+          http
+            .createServer((request, response) => {
+              response.setHeader("Access-Control-Allow-Origin", "*");
+              response.setHeader("Content-Type", "application/json");
+
+              if (request.url === "/meta/metadata.json") {
+                response.end(meta);
+                return;
+              }
+
+              if (request.url === "/reports") {
+                response.end(reports);
+                return;
+              }
+
+              if (request.url === "/reports/example") {
+                response.end(report);
+                return;
+              }
+
+              response.statusCode = 404;
+              response.end(JSON.stringify({ error: "not found" }));
+            })
+            .listen(8002, "127.0.0.1");
+          NODE
+
+          for _ in {1..20}; do
+            if curl -fsS http://127.0.0.1:8002/meta/metadata.json >/dev/null; then
+              exit 0
+            fi
+            sleep 1
+          done
+
+          echo "static export fixture API did not start" >&2
+          exit 1
+
+      - name: Run static export build
+        run: pnpm --filter @kouchou-ai/public-viewer build:static
         env:
-          NEXT_PUBLIC_API_BASEPATH: 'http://localhost:8000'
+          API_BASEPATH: 'http://127.0.0.1:8002'
+          NEXT_PUBLIC_API_BASEPATH: 'http://127.0.0.1:8002'
           NEXT_PUBLIC_PUBLIC_API_KEY: 'xxxxxxxxxx'
+
+      - name: Run Docker build
+        run: |
+          docker build --platform linux/amd64 \
+            -f ./apps/public-viewer/Dockerfile \
+            --build-arg NEXT_PUBLIC_API_BASEPATH=http://localhost:8000 \
+            --build-arg NEXT_PUBLIC_PUBLIC_API_KEY=xxxxxxxxxx \
+            --build-arg API_BASEPATH=http://api:8000 \
+            -t kouchou-ai-public-viewer-ci .

--- a/apps/public-viewer/Dockerfile
+++ b/apps/public-viewer/Dockerfile
@@ -10,6 +10,7 @@ ENV NEXT_PUBLIC_API_BASEPATH=${NEXT_PUBLIC_API_BASEPATH}
 ENV NEXT_PUBLIC_PUBLIC_API_KEY=${NEXT_PUBLIC_PUBLIC_API_KEY}
 ENV NEXT_PUBLIC_SITE_URL=${NEXT_PUBLIC_SITE_URL}
 ENV API_BASEPATH=${API_BASEPATH}
+ENV NEXT_TELEMETRY_DISABLED=1
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
 COPY packages/report-schema/package.json packages/report-schema/
@@ -21,6 +22,7 @@ COPY apps/shared apps/shared
 COPY apps/public-viewer apps/public-viewer
 
 RUN node_modules/.bin/tsc --project packages/report-schema/tsconfig.json
+RUN pnpm --filter @kouchou-ai/public-viewer build
 
 FROM node:22-alpine AS runner
 WORKDIR /repo

--- a/apps/public-viewer/app/[slug]/page.tsx
+++ b/apps/public-viewer/app/[slug]/page.tsx
@@ -24,6 +24,10 @@ type PageProps = {
 export const revalidate = 300;
 
 export async function generateStaticParams() {
+  if (!isStaticExportBuild()) {
+    return [];
+  }
+
   let reports: Report[];
 
   try {
@@ -49,6 +53,12 @@ export async function generateStaticParams() {
 }
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  if (!isStaticExportBuild()) {
+    return {
+      title: "広聴AI",
+    };
+  }
+
   try {
     const slug = (await params).slug;
     const metaResponse = await fetch(`${getApiBaseUrl()}/meta/metadata.json`, {

--- a/apps/public-viewer/app/faq/page.tsx
+++ b/apps/public-viewer/app/faq/page.tsx
@@ -1,13 +1,19 @@
+import { ApiConnectionError } from "@/components/ApiConnectionError";
 import { Footer } from "@/components/Footer";
 import { Header } from "@/components/Header";
-import { ApiConnectionError } from "@/components/ApiConnectionError";
 import type { Meta } from "@/type";
 import { Box } from "@chakra-ui/react";
+import { connection } from "next/server";
 import { getApiBaseUrl } from "../utils/api";
+import { isStaticExportBuild } from "../utils/static-build";
 import { Contact } from "./Contact";
 import { Faq } from "./Faq";
 
 export default async function Page() {
+  if (!isStaticExportBuild()) {
+    await connection();
+  }
+
   try {
     const metaResponse = await fetch(`${getApiBaseUrl()}/meta/metadata.json`, {
       next: { tags: ["meta"] },

--- a/apps/public-viewer/app/page.tsx
+++ b/apps/public-viewer/app/page.tsx
@@ -1,16 +1,24 @@
+import { ApiConnectionError } from "@/components/ApiConnectionError";
 import { Footer } from "@/components/Footer";
 import { Header } from "@/components/Header";
 import { Reporter } from "@/components/reporter/Reporter";
-import { ApiConnectionError } from "@/components/ApiConnectionError";
 import type { Meta, Report } from "@/type";
 import { Box, Card, HStack, Heading, Image, Text, VStack } from "@chakra-ui/react";
 import type { Metadata } from "next";
 import Link from "next/link";
+import { connection } from "next/server";
 import { getApiBaseUrl } from "./utils/api";
+import { isStaticExportBuild } from "./utils/static-build";
 
 export const revalidate = 300;
 
 export async function generateMetadata(): Promise<Metadata> {
+  if (!isStaticExportBuild()) {
+    return {
+      title: "広聴AI",
+    };
+  }
+
   try {
     const metaResponse = await fetch(`${getApiBaseUrl()}/meta/metadata.json`);
     const meta: Meta = await metaResponse.json();
@@ -42,6 +50,10 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function Page() {
+  if (!isStaticExportBuild()) {
+    await connection();
+  }
+
   try {
     const metaResponse = await fetch(`${getApiBaseUrl()}/meta/metadata.json`);
     const reportsResponse = await fetch(`${getApiBaseUrl()}/reports`, {

--- a/apps/public-viewer/app/page.tsx
+++ b/apps/public-viewer/app/page.tsx
@@ -14,9 +14,7 @@ export const revalidate = 300;
 
 export async function generateMetadata(): Promise<Metadata> {
   if (!isStaticExportBuild()) {
-    return {
-      title: "広聴AI",
-    };
+    await connection();
   }
 
   try {

--- a/apps/public-viewer/app/utils/api.ts
+++ b/apps/public-viewer/app/utils/api.ts
@@ -1,3 +1,6 @@
+// サーバー実行時の環境変数を読むため、Next.js の build-time 直値展開を避ける。
+const getServerEnv = (key: "API_BASEPATH" | "NEXT_PUBLIC_API_BASEPATH") => process.env[key] || "";
+
 /**
  * 実行環境に応じた適切なAPIのベースURLを取得する
  *
@@ -13,12 +16,13 @@ export const getApiBaseUrl = (): string => {
   }
 
   // サーバーサイドでAPI_BASEPATHが設定されている場合
-  if (process.env.API_BASEPATH) {
-    return process.env.API_BASEPATH;
+  const serverApiBasePath = getServerEnv("API_BASEPATH");
+  if (serverApiBasePath) {
+    return serverApiBasePath;
   }
 
   // それ以外の場合はNEXT_PUBLIC_API_BASEPATHを使用
-  return process.env.NEXT_PUBLIC_API_BASEPATH || "";
+  return getServerEnv("NEXT_PUBLIC_API_BASEPATH");
 };
 
 /**

--- a/apps/public-viewer/entrypoint.sh
+++ b/apps/public-viewer/entrypoint.sh
@@ -1,9 +1,3 @@
 #!/bin/sh
 set -e
-# 起動時に全て削除した上でbuildしなおす
-if [ -d ".next" ]; then
-  rm -rf .next
-fi  
-# build時にAPIサーバーを参照するため、APIサーバーの起動を待ってからbuildを行う
-pnpm run build
 exec pnpm run start


### PR DESCRIPTION
## 概要
- dynamic hosting の `next build` が API を読まないようにし、API fetch を request-time に寄せる
- static export は fixture API ありの build として CI で維持する
- Docker image build 時に `.next` を作り、container 起動時の `pnpm run build` を撤去する

## 確認
- `pnpm --filter @kouchou-ai/public-viewer test -- --runInBand`
- `env -u API_BASEPATH -u NEXT_PUBLIC_API_BASEPATH -u NEXT_PUBLIC_PUBLIC_API_KEY pnpm --filter @kouchou-ai/public-viewer build`
- fixture API あり `pnpm --filter @kouchou-ai/public-viewer build:static`
- runtime smoke: `/`, `/faq/`, `/example/` が 200、API 接続エラー文字列なし
- PR #888 CI `client build`: API-less dynamic build、static export build、Docker build が success

## メモ
- `[slug]` に `connection()` を入れると `/example` が `DYNAMIC_SERVER_USAGE` で落ちたため、non-export は `generateStaticParams() => []` と runtime env 読みで対応

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded CI triggers and added a local fixture-based build/test flow for static exports.
  * Optimized container build (telemetry disabled, explicit package build) and simplified startup to skip in-container builds.

* **Performance**
  * Conditional metadata and connection behavior to skip remote calls during non-static-export builds.
  * Safer environment-variable handling to avoid build-time inlining.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->