### PR TITLE
[codex] Code scanning alerts の指摘を修正

### DIFF
--- a/apps/admin/app/_components/ReportCard/ActionMenu/csvDownloadCommon.ts
+++ b/apps/admin/app/_components/ReportCard/ActionMenu/csvDownloadCommon.ts
@@ -22,9 +22,10 @@ type CsvDownloadResult =
 
 export async function csvDownloadCommon(slug: string, options: CsvDownloadOptions = {}): Promise<CsvDownloadResult> {
   const { includeBOM = false, filenameSuffix = "", contentType = "text/csv" } = options;
+  const encodedSlug = encodeURIComponent(slug);
 
   try {
-    const response = await fetch(`${getApiBaseUrl()}/admin/comments/${slug}/csv`, {
+    const response = await fetch(`${getApiBaseUrl()}/admin/comments/${encodedSlug}/csv`, {
       headers: {
         "x-api-key": process.env.NEXT_PUBLIC_ADMIN_API_KEY || "",
         "Content-Type": "application/json",

--- a/apps/admin/app/_components/ReportCard/ActionMenu/jsonDownload.ts
+++ b/apps/admin/app/_components/ReportCard/ActionMenu/jsonDownload.ts
@@ -15,8 +15,9 @@ type JsonDownloadResult =
     };
 
 export async function jsonDownload(slug: string): Promise<JsonDownloadResult> {
+  const encodedSlug = encodeURIComponent(slug);
   try {
-    const response = await fetch(`${getApiBaseUrl()}/admin/reports/${slug}/json`, {
+    const response = await fetch(`${getApiBaseUrl()}/admin/reports/${encodedSlug}/json`, {
       headers: {
         "x-api-key": process.env.NEXT_PUBLIC_ADMIN_API_KEY || "",
         "Content-Type": "application/json",

--- a/apps/admin/app/_components/ReportCard/ClusterEditDialog/actions.ts
+++ b/apps/admin/app/_components/ReportCard/ClusterEditDialog/actions.ts
@@ -14,8 +14,9 @@ type FetchClustersResult =
     };
 
 export async function fetchClusters(reportSlug: string): Promise<FetchClustersResult> {
+  const encodedReportSlug = encodeURIComponent(reportSlug);
   try {
-    const response = await fetch(`${getApiBaseUrl()}/admin/reports/${reportSlug}/cluster-labels`, {
+    const response = await fetch(`${getApiBaseUrl()}/admin/reports/${encodedReportSlug}/cluster-labels`, {
       headers: {
         "x-api-key": process.env.NEXT_PUBLIC_ADMIN_API_KEY || "",
       },
@@ -38,12 +39,13 @@ type UpdateClusterResult = {
 };
 
 export async function updateCluster(reportSlug: string, formData: FormData): Promise<UpdateClusterResult> {
+  const encodedReportSlug = encodeURIComponent(reportSlug);
   const id = formData.get("id") as string;
   const label = formData.get("label") as string;
   const description = formData.get("description") as string;
 
   try {
-    const response = await fetch(`${getApiBaseUrl()}/admin/reports/${reportSlug}/cluster-label`, {
+    const response = await fetch(`${getApiBaseUrl()}/admin/reports/${encodedReportSlug}/cluster-label`, {
       method: "PATCH",
       headers: {
         "x-api-key": process.env.NEXT_PUBLIC_ADMIN_API_KEY || "",

--- a/apps/admin/app/_components/ReportCard/DeleteDialog/action.ts
+++ b/apps/admin/app/_components/ReportCard/DeleteDialog/action.ts
@@ -5,8 +5,9 @@ import { getApiBaseUrl } from "../../../utils/api";
 type DeleteResult = { success: true } | { success: false; error: string };
 
 export async function reportDelete(slug: string): Promise<DeleteResult> {
+  const encodedSlug = encodeURIComponent(slug);
   try {
-    const response = await fetch(`${getApiBaseUrl()}/admin/reports/${slug}`, {
+    const response = await fetch(`${getApiBaseUrl()}/admin/reports/${encodedSlug}`, {
       method: "DELETE",
       headers: {
         "x-api-key": process.env.NEXT_PUBLIC_ADMIN_API_KEY || "",

--- a/apps/admin/app/_components/ReportCard/DuplicateReportDialog/actions.ts
+++ b/apps/admin/app/_components/ReportCard/DuplicateReportDialog/actions.ts
@@ -27,6 +27,7 @@ export async function duplicateReport(sourceSlug: string, params: DuplicateParam
   if (!adminApiKey) {
     throw new Error("ADMIN_API_KEY is not set");
   }
+  const encodedSourceSlug = encodeURIComponent(sourceSlug);
 
   const body: Record<string, unknown> = {
     reuse: { enabled: params.reuseEnabled },
@@ -41,7 +42,7 @@ export async function duplicateReport(sourceSlug: string, params: DuplicateParam
   }
 
   try {
-    const response = await fetch(`${getApiBaseUrl()}/admin/reports/${sourceSlug}/duplicate`, {
+    const response = await fetch(`${getApiBaseUrl()}/admin/reports/${encodedSourceSlug}/duplicate`, {
       method: "POST",
       headers: {
         "x-api-key": adminApiKey,

--- a/apps/admin/app/_components/ReportCard/ProgressSteps/useReportProgressPolling.ts
+++ b/apps/admin/app/_components/ReportCard/ProgressSteps/useReportProgressPolling.ts
@@ -28,6 +28,7 @@ export function useReportProgressPoll(slug: string) {
   useEffect(() => {
     if (!isPolling) return;
 
+    const encodedSlug = encodeURIComponent(slug);
     let cancelled = false;
     let retryCount = 0;
     const maxRetries = 10;
@@ -36,15 +37,18 @@ export function useReportProgressPoll(slug: string) {
       if (cancelled) return;
 
       try {
-        const response = await fetch(`${process.env.NEXT_PUBLIC_API_BASEPATH}/admin/reports/${slug}/status/step-json`, {
-          headers: {
-            "x-api-key": process.env.NEXT_PUBLIC_ADMIN_API_KEY || "",
-            "Content-Type": "application/json",
-            // キャッシュを防止するためのヘッダーを追加
-            "Cache-Control": "no-cache, no-store, must-revalidate",
-            Pragma: "no-cache",
+        const response = await fetch(
+          `${process.env.NEXT_PUBLIC_API_BASEPATH}/admin/reports/${encodedSlug}/status/step-json`,
+          {
+            headers: {
+              "x-api-key": process.env.NEXT_PUBLIC_ADMIN_API_KEY || "",
+              "Content-Type": "application/json",
+              // キャッシュを防止するためのヘッダーを追加
+              "Cache-Control": "no-cache, no-store, must-revalidate",
+              Pragma: "no-cache",
+            },
           },
-        });
+        );
 
         if (response.ok) {
           const data = (await response.json()) as StepJsonResponse;

--- a/apps/admin/app/_components/ReportCard/ReportEditDialog/actions.ts
+++ b/apps/admin/app/_components/ReportCard/ReportEditDialog/actions.ts
@@ -3,11 +3,12 @@
 import { getApiBaseUrl } from "@/app/utils/api";
 
 export async function updateReportConfig(reportSlug: string, formData: FormData) {
+  const encodedReportSlug = encodeURIComponent(reportSlug);
   const question = formData.get("question") as string;
   const intro = formData.get("intro") as string;
 
   try {
-    const response = await fetch(`${getApiBaseUrl()}/admin/reports/${reportSlug}/config`, {
+    const response = await fetch(`${getApiBaseUrl()}/admin/reports/${encodedReportSlug}/config`, {
       method: "PATCH",
       headers: {
         "x-api-key": process.env.NEXT_PUBLIC_ADMIN_API_KEY || "",

--- a/apps/admin/app/_components/ReportCard/Visibility/actions.ts
+++ b/apps/admin/app/_components/ReportCard/Visibility/actions.ts
@@ -14,8 +14,9 @@ type Result =
     };
 
 export async function updateReportVisibility(slug: string, visibility: ReportVisibility): Promise<Result> {
+  const encodedSlug = encodeURIComponent(slug);
   try {
-    const response = await fetch(`${getApiBaseUrl()}/admin/reports/${slug}/visibility`, {
+    const response = await fetch(`${getApiBaseUrl()}/admin/reports/${encodedSlug}/visibility`, {
       method: "PATCH",
       headers: {
         "x-api-key": process.env.NEXT_PUBLIC_ADMIN_API_KEY || "",

--- a/apps/admin/app/_components/ReportCard/VisualizationConfigDialog/actions.ts
+++ b/apps/admin/app/_components/ReportCard/VisualizationConfigDialog/actions.ts
@@ -14,8 +14,9 @@ type FetchVisualizationConfigResult =
     };
 
 export async function fetchVisualizationConfig(reportSlug: string): Promise<FetchVisualizationConfigResult> {
+  const encodedReportSlug = encodeURIComponent(reportSlug);
   try {
-    const response = await fetch(`${getApiBaseUrl()}/admin/reports/${reportSlug}/visualization-config`, {
+    const response = await fetch(`${getApiBaseUrl()}/admin/reports/${encodedReportSlug}/visualization-config`, {
       headers: {
         "x-api-key": process.env.NEXT_PUBLIC_ADMIN_API_KEY || "",
       },
@@ -42,8 +43,9 @@ export async function updateVisualizationConfig(
   reportSlug: string,
   config: ReportDisplayConfig,
 ): Promise<UpdateVisualizationConfigResult> {
+  const encodedReportSlug = encodeURIComponent(reportSlug);
   try {
-    const response = await fetch(`${getApiBaseUrl()}/admin/reports/${reportSlug}/visualization-config`, {
+    const response = await fetch(`${getApiBaseUrl()}/admin/reports/${encodedReportSlug}/visualization-config`, {
       method: "PATCH",
       headers: {
         "x-api-key": process.env.NEXT_PUBLIC_ADMIN_API_KEY || "",

--- a/apps/admin/app/api/admin/reports/[slug]/config/route.ts
+++ b/apps/admin/app/api/admin/reports/[slug]/config/route.ts
@@ -16,8 +16,9 @@ export async function GET(_: Request, context: { params: Promise<{ slug: string 
   }
 
   const { slug } = await context.params;
+  const encodedSlug = encodeURIComponent(slug);
   try {
-    const response = await fetch(`${baseUrl}/admin/reports/${slug}/config`, {
+    const response = await fetch(`${baseUrl}/admin/reports/${encodedSlug}/config`, {
       headers: {
         "x-api-key": adminApiKey,
       },
@@ -26,7 +27,7 @@ export async function GET(_: Request, context: { params: Promise<{ slug: string 
     const data = await response.json().catch(() => ({}));
     return NextResponse.json(data, { status: response.status });
   } catch (error) {
-    const message = error instanceof Error ? error.message : "Failed to fetch report config";
-    return NextResponse.json({ detail: message }, { status: 500 });
+    console.error("Failed to fetch report config", error);
+    return NextResponse.json({ detail: "Failed to fetch report config" }, { status: 500 });
   }
 }

--- a/apps/admin/app/create/api/plugins.ts
+++ b/apps/admin/app/create/api/plugins.ts
@@ -29,7 +29,8 @@ export async function validatePluginSource(
   pluginId: string,
   source: string,
 ): Promise<{ isValid: boolean; error: string | null }> {
-  const response = await fetch(`${getApiBaseUrl()}/admin/plugins/${pluginId}/validate-source`, {
+  const encodedPluginId = encodeURIComponent(pluginId);
+  const response = await fetch(`${getApiBaseUrl()}/admin/plugins/${encodedPluginId}/validate-source`, {
     method: "POST",
     headers: {
       "x-api-key": process.env.NEXT_PUBLIC_ADMIN_API_KEY || "",
@@ -49,7 +50,8 @@ export async function validatePluginSource(
  * プラグインからデータをプレビュー
  */
 export async function previewPluginData(pluginId: string, source: string, limit = 10): Promise<PluginPreviewResult> {
-  const response = await fetch(`${getApiBaseUrl()}/admin/plugins/${pluginId}/preview`, {
+  const encodedPluginId = encodeURIComponent(pluginId);
+  const response = await fetch(`${getApiBaseUrl()}/admin/plugins/${encodedPluginId}/preview`, {
     method: "POST",
     headers: {
       "x-api-key": process.env.NEXT_PUBLIC_ADMIN_API_KEY || "",
@@ -75,7 +77,8 @@ export async function importPluginData(
   maxResults = 1000,
   includeReplies = false,
 ): Promise<PluginImportResult> {
-  const response = await fetch(`${getApiBaseUrl()}/admin/plugins/${pluginId}/import`, {
+  const encodedPluginId = encodeURIComponent(pluginId);
+  const response = await fetch(`${getApiBaseUrl()}/admin/plugins/${encodedPluginId}/import`, {
     method: "POST",
     headers: {
       "x-api-key": process.env.NEXT_PUBLIC_ADMIN_API_KEY || "",

--- a/apps/admin/app/create/api/spreadsheet.ts
+++ b/apps/admin/app/create/api/spreadsheet.ts
@@ -33,8 +33,9 @@ export async function importSpreadsheet(url: string, fileName: string): Promise<
  * スプレッドシートのデータを取得する
  */
 export async function getSpreadsheetData(id: string): Promise<{ comments: SpreadsheetComment[] }> {
+  const encodedId = encodeURIComponent(id);
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_API_BASEPATH}/admin/spreadsheet/data/${id}`, {
+    const response = await fetch(`${process.env.NEXT_PUBLIC_API_BASEPATH}/admin/spreadsheet/data/${encodedId}`, {
       headers: {
         "x-api-key": process.env.NEXT_PUBLIC_ADMIN_API_KEY || "",
       },
@@ -54,8 +55,9 @@ export async function getSpreadsheetData(id: string): Promise<{ comments: Spread
  * スプレッドシートのデータを削除する
  */
 export async function deleteSpreadsheetData(id: string): Promise<void> {
+  const encodedId = encodeURIComponent(id);
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_API_BASEPATH}/admin/inputs/${id}`, {
+    const response = await fetch(`${process.env.NEXT_PUBLIC_API_BASEPATH}/admin/inputs/${encodedId}`, {
       method: "DELETE",
       headers: {
         "x-api-key": process.env.NEXT_PUBLIC_ADMIN_API_KEY || "",

--- a/apps/admin/app/create/components/EnvironmentCheckDialog/verifyApiKey.ts
+++ b/apps/admin/app/create/components/EnvironmentCheckDialog/verifyApiKey.ts
@@ -14,6 +14,7 @@ type VerificationResult = {
 
 export const verifyApiKey = async (provider: string, userApiKey?: string) => {
   try {
+    const encodedProvider = encodeURIComponent(provider);
     const headers: Record<string, string> = {
       "x-api-key": process.env.NEXT_PUBLIC_ADMIN_API_KEY || "",
       "Content-Type": "application/json",
@@ -23,7 +24,7 @@ export const verifyApiKey = async (provider: string, userApiKey?: string) => {
       headers["x-user-api-key"] = userApiKey;
     }
 
-    const response = await fetch(`${getApiBaseUrl()}/admin/environment/verify?provider=${provider}`, {
+    const response = await fetch(`${getApiBaseUrl()}/admin/environment/verify?provider=${encodedProvider}`, {
       method: "GET",
       headers,
     });
@@ -44,7 +45,8 @@ export const verifyApiKey = async (provider: string, userApiKey?: string) => {
 
 export const verifyChatGptApiKeyWithProvider = async (provider = "openai") => {
   try {
-    const response = await fetch(`${getApiBaseUrl()}/admin/environment/verify-chatgpt?provider=${provider}`, {
+    const encodedProvider = encodeURIComponent(provider);
+    const response = await fetch(`${getApiBaseUrl()}/admin/environment/verify-chatgpt?provider=${encodedProvider}`, {
       method: "GET",
       headers: {
         "x-api-key": process.env.NEXT_PUBLIC_ADMIN_API_KEY || "",

--- a/apps/api/src/routers/admin_report.py
+++ b/apps/api/src/routers/admin_report.py
@@ -181,6 +181,15 @@ def _read_error_log_excerpt(log_path: Path) -> str | None:
     return content[-MAX_ERROR_LOG_CHARS:]
 
 
+def _api_key_verification_error_response(message: str, error_type: str) -> dict:
+    return {
+        "success": False,
+        "message": message,
+        "error_detail": message,
+        "error_type": error_type,
+    }
+
+
 @router.get("/admin/reports/{slug}/status/step-json", dependencies=[Depends(verify_admin_api_key)])
 async def get_current_step(slug: str) -> dict:
     validate_slug(slug)
@@ -522,48 +531,42 @@ async def verify_api_key(
         }
 
     except openai.AuthenticationError as e:
-        return {
-            "success": False,
-            "message": "認証エラー: APIキーが無効または期限切れです",
-            "error_detail": str(e),
-            "error_type": "authentication_error",
-        }
+        slogger.warning(f"Authentication error while verifying API key: {e}")
+        return _api_key_verification_error_response(
+            "認証エラー: APIキーが無効または期限切れです",
+            "authentication_error",
+        )
     except openai.RateLimitError as e:
         error_str = str(e).lower()
         if "insufficient_quota" in error_str or "quota exceeded" in error_str:
-            return {
-                "success": False,
-                "message": "残高不足エラー: APIキーのデポジット残高が不足しています。残高を追加してください。",
-                "error_detail": str(e),
-                "error_type": "insufficient_quota",
-            }
-        return {
-            "success": False,
-            "message": "レート制限エラー: APIリクエストの制限を超えました。しばらく待ってから再試行してください。",
-            "error_detail": str(e),
-            "error_type": "rate_limit_error",
-        }
+            slogger.warning(f"Insufficient quota while verifying API key: {e}")
+            return _api_key_verification_error_response(
+                "残高不足エラー: APIキーのデポジット残高が不足しています。残高を追加してください。",
+                "insufficient_quota",
+            )
+        slogger.warning(f"Rate limit while verifying API key: {e}")
+        return _api_key_verification_error_response(
+            "レート制限エラー: APIリクエストの制限を超えました。しばらく待ってから再試行してください。",
+            "rate_limit_error",
+        )
     except Exception as e:
         if google_exceptions is not None and isinstance(e, google_exceptions.Unauthenticated):
-            return {
-                "success": False,
-                "message": "認証エラー: APIキーが無効または期限切れです",
-                "error_detail": str(e),
-                "error_type": "authentication_error",
-            }
+            slogger.warning(f"Google authentication error while verifying API key: {e}")
+            return _api_key_verification_error_response(
+                "認証エラー: APIキーが無効または期限切れです",
+                "authentication_error",
+            )
         if google_exceptions is not None and isinstance(e, google_exceptions.ResourceExhausted):
-            return {
-                "success": False,
-                "message": "レート制限エラー: APIリクエストの制限を超えました。しばらく待ってから再試行してください。",
-                "error_detail": str(e),
-                "error_type": "rate_limit_error",
-            }
-        return {
-            "success": False,
-            "message": f"エラーが発生しました: {str(e)}",
-            "error_detail": str(e),
-            "error_type": "unknown_error",
-        }
+            slogger.warning(f"Google rate limit while verifying API key: {e}")
+            return _api_key_verification_error_response(
+                "レート制限エラー: APIリクエストの制限を超えました。しばらく待ってから再試行してください。",
+                "rate_limit_error",
+            )
+        slogger.error(f"Unknown error while verifying API key: {e}", exc_info=True)
+        return _api_key_verification_error_response(
+            "エラーが発生しました: APIの設定や接続を確認してください。",
+            "unknown_error",
+        )
 
 
 @router.get("/admin/llm-pricing")

--- a/apps/api/tests/routers/test_admin_report.py
+++ b/apps/api/tests/routers/test_admin_report.py
@@ -168,6 +168,19 @@ class TestVerifyApiKey:
             _, kwargs = mock_request.call_args
             assert kwargs["user_api_key"] == "user-test-key"
 
+    def test_verify_api_key_does_not_expose_exception_detail(self, client):
+        with patch("analysis_core.services.llm.request_to_chat_ai") as mock_request:
+            mock_request.side_effect = RuntimeError("secret stack detail")
+
+            response = client.get("/admin/environment/verify?provider=openai", headers={"x-api-key": "test-api-key"})
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["success"] is False
+            assert data["error_type"] == "unknown_error"
+            assert "secret stack detail" not in data["message"]
+            assert "secret stack detail" not in data["error_detail"]
+
 
 class TestDownloadReportJson:
     def test_download_report_json_success(self, client, tmp_path):

--- a/apps/static-site-builder/package.json
+++ b/apps/static-site-builder/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "archiver": "^7.0.1",
-    "express": "^5.1.0"
+    "express": "^5.1.0",
+    "express-rate-limit": "^8.5.2"
   },
   "devDependencies": {
     "@types/archiver": "^6.0.3",

--- a/apps/static-site-builder/src/index.ts
+++ b/apps/static-site-builder/src/index.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import archiver from "archiver";
 import express from "express";
+import rateLimit from "express-rate-limit";
 
 const execAsync = promisify(exec);
 const __filename = fileURLToPath(import.meta.url);
@@ -14,21 +15,34 @@ const clientDir = join(__dirname, "../../public-viewer");
 const outDir = join(clientDir, "out");
 
 const ZIP_FILE_NAME = "kouchou-ai.zip";
+const BUILD_RATE_LIMIT_WINDOW_MS = 60 * 1000;
+const BUILD_RATE_LIMIT_MAX_REQUESTS = 5;
 
 const app = express();
+const buildRateLimiter = rateLimit({
+  windowMs: BUILD_RATE_LIMIT_WINDOW_MS,
+  limit: BUILD_RATE_LIMIT_MAX_REQUESTS,
+  standardHeaders: "draft-8",
+  legacyHeaders: false,
+  message: {
+    status: "error",
+    message: "Too many build requests. Please try again later.",
+  },
+});
 
 app.use(express.json());
 
-app.post("/build", async (req, res) => {
+app.post("/build", buildRateLimiter, async (req, res) => {
   try {
     console.log("Build request received");
+    const buildSlugs = typeof req.body.slugs === "string" ? req.body.slugs : "";
     const { stdout, stderr } = await execAsync("pnpm run build:static", {
       cwd: clientDir,
       env: {
         ...process.env,
         PATH: process.env.PATH ?? "",
         NODE_ENV: "production",
-        BUILD_SLUGS: req.body.slugs || ""
+        BUILD_SLUGS: buildSlugs,
       },
     });
 
@@ -49,7 +63,7 @@ app.post("/build", async (req, res) => {
     console.error("Build or Zip error:", err);
     res.status(500).json({
       status: "error",
-      message: err instanceof Error ? err.message : String(err),
+      message: "Build failed",
     });
   }
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -211,6 +211,9 @@ importers:
       express:
         specifier: ^5.1.0
         version: 5.2.1
+      express-rate-limit:
+        specifier: ^8.5.2
+        version: 8.5.2(express@5.2.1)
     devDependencies:
       '@types/archiver':
         specifier: ^6.0.3
@@ -2375,6 +2378,12 @@ packages:
     resolution: {integrity: sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  express-rate-limit@8.5.2:
+    resolution: {integrity: sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
   express@5.2.1:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
@@ -2727,6 +2736,10 @@ packages:
   ini@4.1.3:
     resolution: {integrity: sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+    engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -6956,6 +6969,11 @@ snapshots:
       jest-message-util: 29.7.0
       jest-util: 29.7.0
 
+  express-rate-limit@8.5.2(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.2.0
+
   express@5.2.1:
     dependencies:
       accepts: 2.0.0
@@ -7430,6 +7448,8 @@ snapshots:
   inherits@2.0.4: {}
 
   ini@4.1.3: {}
+
+  ip-address@10.2.0: {}
 
   ipaddr.js@1.9.1: {}
 


### PR DESCRIPTION
## Summary
- admin の API fetch で URL path/query に入る入力値をエンコード
- static-site-builder の build endpoint に rate limit を追加し、build 失敗時の外部返却メッセージを固定化
- API key verify endpoint の例外詳細をレスポンスへ返さないよう変更し、回帰テストを追加

## Validation
- pnpm exec biome check --write <touched TypeScript files>
- pnpm --filter @kouchou-ai/static-site-builder build
- pnpm --filter @kouchou-ai/admin test -- --runInBand <related tests>
- ruff check apps/api/src/routers/admin_report.py apps/api/tests/routers/test_admin_report.py
- ENV_FILE=.env.test PYTHONPATH=src:../../packages/analysis-core/src uv run --with pytest --with pytest-asyncio pytest tests/routers/test_admin_report.py::TestVerifyApiKey

## Notes
- pnpm --filter @kouchou-ai/admin lint は今回触っていない既存の formatting/import/dependency 指摘で失敗します。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of special characters in report names, cluster labels, and identifiers across admin operations to prevent malformed URLs

* **Improvements**
  * Standardized API error responses to hide internal implementation details from users
  * Added rate limiting to the build endpoint to prevent abuse and improve stability

* **Tests**
  * Added verification test to ensure error responses properly conceal internal details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->