### PR TITLE
[codex] CodeQL Action を v4 に更新

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,12 +40,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
## 概要

CodeQL Action v3 が 2026 年 12 月に deprecated 予定であるため、`.github/workflows/codeql.yml` 内の CodeQL Action 参照を v4 に更新しました。

## 変更内容

- `github/codeql-action/init@v3` を `@v4` に更新
- `github/codeql-action/autobuild@v3` を `@v4` に更新
- `github/codeql-action/analyze@v3` を `@v4` に更新

workflow の trigger、permissions、対象言語、job 構成は変更していません。

## 確認

- `.github` 配下に `github/codeql-action/*@v3` が残っていないことを確認
- `git diff --check HEAD~1..HEAD`
- Ruby 標準 YAML parser で `.github/workflows/codeql.yml` の構文確認