### PR TITLE
[codex] API Docker の analysis-core 依存検証を追加

### DIFF
--- a/.github/workflows/api-docker-dependency-smoke.yml
+++ b/.github/workflows/api-docker-dependency-smoke.yml
@@ -1,0 +1,67 @@
+name: API Docker Dependency Smoke
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "apps/api/Dockerfile"
+      - "apps/api/pyproject.toml"
+      - "apps/api/requirements*.lock"
+      - "packages/analysis-core/pyproject.toml"
+      - "packages/analysis-core/requirements*.lock"
+      - ".github/workflows/api-docker-dependency-smoke.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "apps/api/Dockerfile"
+      - "apps/api/pyproject.toml"
+      - "apps/api/requirements*.lock"
+      - "packages/analysis-core/pyproject.toml"
+      - "packages/analysis-core/requirements*.lock"
+      - ".github/workflows/api-docker-dependency-smoke.yml"
+  workflow_dispatch:
+
+jobs:
+  dependency-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build API Docker image
+        run: |
+          docker build --platform linux/amd64 \
+            -f ./apps/api/Dockerfile \
+            --build-arg ENVIRONMENT=production \
+            --build-arg WITH_GPU=false \
+            -t kouchou-api:dependency-smoke \
+            .
+
+      - name: Verify analysis-core runtime dependencies
+        run: |
+          docker run --rm kouchou-api:dependency-smoke python - <<'PY'
+          import importlib
+
+          required_modules = {
+              "analysis_core": "analysis-core package",
+              "analysis_core.steps.hierarchical_clustering": "hierarchical clustering step",
+              "google.genai": "analysis-core gemini extra",
+              "numba": "analysis-core clustering extra",
+              "scipy": "analysis-core clustering extra",
+              "sklearn": "analysis-core clustering extra",
+              "sentence_transformers": "analysis-core embeddings extra",
+              "torch": "analysis-core embeddings extra",
+              "umap": "analysis-core clustering extra",
+          }
+
+          missing = []
+          for module_name, reason in required_modules.items():
+              try:
+                  importlib.import_module(module_name)
+              except Exception as exc:
+                  missing.append(f"{module_name} ({reason}): {exc!r}")
+
+          if missing:
+              raise SystemExit("Missing API Docker runtime dependencies:\n" + "\n".join(missing))
+          PY

--- a/.github/workflows/server-pytest.yml
+++ b/.github/workflows/server-pytest.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
     paths:
       - 'apps/api/**/*.py'
+      - 'apps/api/Dockerfile'
       - 'apps/api/pyproject.toml'
       - 'apps/api/requirements*.lock'
       - 'apps/api/tests/**/*.py'
@@ -17,6 +18,7 @@ on:
     branches: [ main ]
     paths:
       - 'apps/api/**/*.py'
+      - 'apps/api/Dockerfile'
       - 'apps/api/pyproject.toml'
       - 'apps/api/requirements*.lock'
       - 'apps/api/tests/**/*.py'

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -25,7 +25,7 @@ COPY packages/analysis-core /packages/analysis-core
 # torch is resolved as a transitive dependency of analysis-core.
 # For CPU mode, use the PyTorch CPU-only index as --extra-index-url so it takes
 # priority over the primary PyPI index (uv searches extra indexes first).
-RUN set -- /packages/analysis-core && \
+RUN set -- "/packages/analysis-core[full]" && \
     if [ "$ENVIRONMENT" = "development" ]; then \
         set -- "$@" -r requirements-dev.lock; \
     else \

--- a/apps/api/tests/test_dockerfile_dependencies.py
+++ b/apps/api/tests/test_dockerfile_dependencies.py
@@ -1,0 +1,47 @@
+import re
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+ANALYSIS_CORE_INSTALL_ARG = re.compile(
+    r"set\s+--\s+(?P<quote>[\"']?)(?P<path>/packages/analysis-core)(?P<extras>\[[^\]\"'\s]+])?(?P=quote)"
+)
+SELF_REFERENCING_EXTRA = re.compile(r"kouchou-ai-analysis-core\[(?P<extras>[A-Za-z0-9_,.-]+)]")
+
+
+def _analysis_core_optional_dependencies() -> dict[str, list[str]]:
+    with (REPO_ROOT / "packages/analysis-core/pyproject.toml").open("rb") as pyproject:
+        return tomllib.load(pyproject)["project"]["optional-dependencies"]
+
+
+def _extra_names(requirement: str) -> set[str]:
+    match = SELF_REFERENCING_EXTRA.match(requirement)
+    assert match is not None, f"Unexpected full extra dependency: {requirement}"
+    return {extra.strip() for extra in match.group("extras").split(",")}
+
+
+def test_analysis_core_full_extra_includes_pipeline_optional_dependencies():
+    optional_dependencies = _analysis_core_optional_dependencies()
+
+    full_extra_references = [
+        dependency for dependency in optional_dependencies["full"] if dependency.startswith("kouchou-ai-analysis-core[")
+    ]
+    assert full_extra_references, "analysis-core full extra must reference its optional dependency groups"
+
+    included_extras = set()
+    for dependency in full_extra_references:
+        included_extras.update(_extra_names(dependency))
+    assert {"gemini", "embeddings", "clustering"} <= included_extras
+
+
+def test_api_dockerfile_installs_analysis_core_with_full_extra():
+    dockerfile = (REPO_ROOT / "apps/api/Dockerfile").read_text()
+
+    match = ANALYSIS_CORE_INSTALL_ARG.search(dockerfile)
+    assert match is not None, "API Dockerfile must install the local analysis-core package"
+
+    extras = match.group("extras")
+    assert extras is not None, "API Dockerfile must install analysis-core with required extras"
+    assert "full" in {extra.strip() for extra in extras.strip("[]").split(",")}
+    assert match.group("quote"), "The analysis-core extra spec must be quoted to avoid shell glob expansion"


### PR DESCRIPTION
## 概要

- API Dockerfile の `analysis-core` install を `/packages/analysis-core[full]` に固定しました。
- `apps/api/tests/test_dockerfile_dependencies.py` を追加し、`analysis-core` の `full` extra が pipeline に必要な optional groups を含むことと、API Dockerfile が quote 付きで `full` extra を install することを検証します。
- `server-pytest.yml` の path filter に `apps/api/Dockerfile` を追加し、Dockerfile 変更時にも contract test が走るようにしました。
- `API Docker Dependency Smoke` workflow を追加し、Dockerfile / dependency manifest 変更時だけ API image を build して、container 内で clustering / embeddings / gemini 関連 import を smoke します。

## 背景

PR #895 で、`analysis-core` の clustering 依存が optional extras 化された後も API Dockerfile が extras なしで local package を install していたことが分かりました。既存 CI は dev lock / all-features 前提で依存が揃うため、この Docker image 固有の差分を検知できていませんでした。

この PR は #895 と同じ Dockerfile の 1 行修正を含みつつ、同じ退行を CI で落とす検証を追加します。

## 確認

- `ADMIN_API_KEY=dummy PUBLIC_API_KEY=dummy OPENAI_API_KEY=dummy uv run --with pytest --with fastapi --with pydantic-settings --with python-dotenv --with httpx python -m pytest tests/test_dockerfile_dependencies.py -q`
- `uv run --with ruff ruff check tests/test_dockerfile_dependencies.py`
- `uv run --with ruff ruff format --check tests/test_dockerfile_dependencies.py`
- workflow YAML parse と `run:` block の `bash -n` 構文チェック

実 Docker build / container import smoke は、この PR の `API Docker Dependency Smoke` workflow で確認します。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated validation for API Docker image dependencies
  * Extended server test triggers to include API Dockerfile changes
  * Updated API Docker build configuration to include additional optional dependencies

* **Tests**
  * Added validation tests for API Docker dependency installation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->