### PR TITLE
[codex] 混在型の入力CSV属性を文字列として扱う

### DIFF
--- a/apps/api/src/services/report_launcher.py
+++ b/apps/api/src/services/report_launcher.py
@@ -124,7 +124,11 @@ def save_input_file(report_input: ReportInput) -> Path:
 
     input_path = settings.INPUT_DIR / f"{report_input.input}.csv"
     input_path.parent.mkdir(parents=True, exist_ok=True)
-    df = pl.DataFrame(comments)
+    schema = {"comment-id": pl.Utf8, "comment-body": pl.Utf8, "source": pl.Utf8, "url": pl.Utf8}
+    for comment_data in comments:
+        for key in comment_data:
+            schema.setdefault(key, pl.Utf8)
+    df = pl.DataFrame(comments, schema=schema)
     df.write_csv(input_path)
     return input_path
 

--- a/apps/api/tests/services/test_report_launcher.py
+++ b/apps/api/tests/services/test_report_launcher.py
@@ -1,7 +1,7 @@
 import subprocess
 import threading
 
-from src.schemas.admin_report import Prompt, ReportInput
+from src.schemas.admin_report import Comment, Prompt, ReportInput
 
 
 class DummyThread:
@@ -46,6 +46,26 @@ def patch_subprocess_launch(monkeypatch):
     monkeypatch.setattr(subprocess, "Popen", DummyPopen)
     monkeypatch.setattr(threading, "Thread", DummyThread)
     return called
+
+
+def test_save_input_file_writes_mixed_type_attributes_as_csv(tmp_path, monkeypatch):
+    from src.services import report_launcher
+
+    monkeypatch.setattr(report_launcher.settings, "INPUT_DIR", tmp_path)
+    report_input = make_report_input(
+        input="demo",
+        comments=[
+            Comment(id="c1", comment="first", attribute_group=1),
+            Comment(id="c2", comment="second", attribute_group="label-a"),
+        ],
+    )
+
+    input_path = report_launcher.save_input_file(report_input)
+
+    lines = input_path.read_text(encoding="utf-8").splitlines()
+    assert lines[0] == "comment-id,comment-body,source,url,attribute_group"
+    assert lines[1].endswith(",1")
+    assert lines[2].endswith(",label-a")
 
 
 def test_user_api_key_propagation_to_env(monkeypatch):

--- a/packages/analysis-core/src/analysis_core/core/__init__.py
+++ b/packages/analysis-core/src/analysis_core/core/__init__.py
@@ -23,6 +23,7 @@ from analysis_core.core.utils import (
     estimate_tokens,
     format_token_count,
     messages,
+    read_input_csv,
     typed_message,
 )
 
@@ -46,4 +47,5 @@ __all__ = [
     "format_token_count",
     "estimate_tokens",
     "chunk_text",
+    "read_input_csv",
 ]

--- a/packages/analysis-core/src/analysis_core/core/orchestration.py
+++ b/packages/analysis-core/src/analysis_core/core/orchestration.py
@@ -14,8 +14,9 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, Callable
 
-import polars as pl
 from dotenv import load_dotenv
+
+from analysis_core.core.utils import read_input_csv
 
 # Default specs - can be overridden
 _specs: list[dict[str, Any]] = []
@@ -293,7 +294,7 @@ def validate_input_file(config: dict[str, Any], input_base_dir: Path, plan: list
         raise RuntimeError(f"Input CSV not found: {input_path}")
 
     try:
-        comments = pl.read_csv(input_path, n_rows=0)
+        comments = read_input_csv(input_path, n_rows=0)
     except Exception as exc:
         raise RuntimeError(f"Failed to read input CSV header: {input_path}") from exc
 

--- a/packages/analysis-core/src/analysis_core/core/utils.py
+++ b/packages/analysis-core/src/analysis_core/core/utils.py
@@ -4,6 +4,22 @@ Utility functions for the analysis pipeline.
 Migrated from apps/api/broadlistening/pipeline/utils.py
 """
 
+from pathlib import Path
+from typing import Any
+
+import polars as pl
+
+
+def read_input_csv(path: str | Path, **kwargs: Any) -> pl.DataFrame:
+    """Read user-provided input CSV columns as strings.
+
+    Input metadata columns are categorical labels, not numeric measures. Keeping
+    them as strings avoids Polars inferring a numeric dtype from early rows and
+    then failing when later rows contain non-numeric labels.
+    """
+    kwargs.setdefault("infer_schema_length", 0)
+    return pl.read_csv(path, **kwargs)
+
 
 def typed_message(t: str, m: str) -> dict[str, str]:
     """

--- a/packages/analysis-core/src/analysis_core/steps/extraction.py
+++ b/packages/analysis-core/src/analysis_core/steps/extraction.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, Field
 from tqdm import tqdm
 
 from analysis_core.core import update_progress
+from analysis_core.core.utils import read_input_csv
 from analysis_core.services.llm import request_to_chat_ai
 from analysis_core.services.parse_json_list import parse_extraction_response
 
@@ -69,10 +70,10 @@ def extraction(config):
 
     # カラム名だけを読み込み、必要なカラムが含まれているか確認する
     input_path = f"{input_base_dir}/{config['input']}.csv"
-    comments = pl.read_csv(input_path, n_rows=0)
+    comments = read_input_csv(input_path, n_rows=0)
     _validate_property_columns(property_columns, comments)
     # エラーが出なかった場合、すべての行を読み込む
-    comments = pl.read_csv(input_path, columns=["comment-id", "comment-body"] + config["extraction"]["properties"])
+    comments = read_input_csv(input_path, columns=["comment-id", "comment-body"] + config["extraction"]["properties"])
 
     # 空文字列・空白のみのコメントを除外する (#583)
     comments = _filter_empty_comments(comments)

--- a/packages/analysis-core/src/analysis_core/steps/hierarchical_aggregation.py
+++ b/packages/analysis-core/src/analysis_core/steps/hierarchical_aggregation.py
@@ -7,6 +7,8 @@ from typing import Any, TypedDict
 import numpy as np
 import polars as pl
 
+from analysis_core.core.utils import read_input_csv
+
 
 def json_serialize_numpy(obj: Any) -> Any:
     """
@@ -83,7 +85,7 @@ def hierarchical_aggregation(config) -> bool:
         arguments = pl.read_csv(f"{output_base_dir}/{config['output_dir']}/args.csv")
         arg_num = len(arguments)
         relation_df = pl.read_csv(f"{output_base_dir}/{config['output_dir']}/relations.csv")
-        comments = pl.read_csv(f"{input_base_dir}/{config['input']}.csv")
+        comments = read_input_csv(f"{input_base_dir}/{config['input']}.csv")
         clusters = pl.read_csv(f"{output_base_dir}/{config['output_dir']}/hierarchical_clusters.csv")
         labels = pl.read_csv(f"{output_base_dir}/{config['output_dir']}/hierarchical_merge_labels.csv")
 
@@ -128,7 +130,7 @@ def create_custom_intro(config):
 
     dataset = config["output_dir"]
     args_path = f"{output_base_dir}/{dataset}/args.csv"
-    comments = pl.read_csv(f"{input_base_dir}/{config['input']}.csv")
+    comments = read_input_csv(f"{input_base_dir}/{config['input']}.csv")
     result_path = f"{output_base_dir}/{dataset}/hierarchical_result.json"
 
     input_count = len(comments)
@@ -193,7 +195,7 @@ def add_original_comments(labels, arguments, relation_df, clusters, config):
     merged = merged.join(relation_df, on="arg-id", how="left")
 
     # 元コメント取得
-    comments = pl.read_csv(f"{input_base_dir}/{config['input']}.csv")
+    comments = read_input_csv(f"{input_base_dir}/{config['input']}.csv")
     comments = comments.with_columns(pl.col("comment-id").cast(pl.Utf8))
     merged = merged.with_columns(pl.col("comment-id").cast(pl.Utf8))
 

--- a/packages/analysis-core/tests/test_orchestration.py
+++ b/packages/analysis-core/tests/test_orchestration.py
@@ -553,6 +553,22 @@ class TestValidateInputFile:
         with pytest.raises(RuntimeError, match="extraction.properties"):
             validate_input_file({"input": "demo", "extraction": {"properties": ["source"]}}, tmp_path)
 
+    def test_validate_input_file_accepts_mixed_type_property_column(self, tmp_path):
+        """Validation should treat input property columns as categorical strings."""
+        from analysis_core.core.orchestration import validate_input_file
+
+        input_path = tmp_path / "demo.csv"
+        input_path.write_text(
+            "comment-id,comment-body,attribute_group\n"
+            "1,first,1\n"
+            "2,second,label-a\n",
+            encoding="utf-8",
+        )
+
+        path = validate_input_file({"input": "demo", "extraction": {"properties": ["attribute_group"]}}, tmp_path)
+
+        assert path == input_path
+
     def test_validate_input_file_skips_when_plan_does_not_need_input(self, tmp_path):
         """Visualization-only runs should not require the input CSV."""
         from analysis_core.core.orchestration import validate_input_file


### PR DESCRIPTION
## 概要
- analysis-core で入力CSVを検証・読み込みする際、ユーザー入力由来の列を文字列として扱うようにしました。
- API が生成する入力CSVについて、動的な属性列を含めて文字列スキーマで保存するようにしました。
- 数値のような値と文字列ラベルが混在する属性列の回帰テストを追加しました。

## 原因
属性列の先頭付近だけを見ると Polars が数値型として推定することがあり、その後に文字列カテゴリが現れるとCSV読み込みに失敗していました。この失敗が、分析開始前の入力CSVヘッダー読み込みエラーとして表示されていました。

## 影響
今後、カテゴリ属性列に数値風の値と文字列ラベルが混在するCSVでも、入力検証・抽出・集約処理を継続できるようになります。

## 検証
- `docker compose exec -T api pytest tests/services/test_report_launcher.py tests/services/test_report_duplicate.py tests/routers/test_get_current_step.py -q`
- `docker compose run --rm -T -v "${PWD}/packages/analysis-core:/packages/analysis-core" api sh -lc 'uv pip install --system -e "/packages/analysis-core[clustering]" && pytest /packages/analysis-core/tests -q --ignore=/packages/analysis-core/tests/e2e'`
- `docker compose run --rm -T -v "${PWD}/packages/analysis-core:/packages/analysis-core" api sh -lc 'uv pip install --system -e "/packages/analysis-core[dev]" && ruff check /packages/analysis-core/src/analysis_core/core/orchestration.py'`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of mixed-type data in CSV input files, ensuring consistent column type preservation for categorical and metadata fields.

* **Tests**
  * Added test coverage for validating proper CSV serialization with mixed-type columns and attribute values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->